### PR TITLE
Add assigned to column to action items

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItem.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItem.java
@@ -71,7 +71,7 @@ public class ActionItem {
 
     @JsonIgnore
     public List<String> getCSVFields() {
-        return Arrays.asList("action item", task, "", getCompletedString());
+        return Arrays.asList("action item", task, "", getCompletedString(), assignee);
     }
 
     public void toggleCompleted() {

--- a/api/src/main/java/com/ford/labs/retroquest/team/CsvFile.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/CsvFile.java
@@ -49,7 +49,7 @@ public class CsvFile {
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out));
 
         CSVPrinter csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT
-                .withHeader("Column", "Message", "Likes", "Completed"));
+                .withHeader("Column", "Message", "Likes", "Completed", "Assigned To"));
         for (Thought thought: thoughts) {
             csvPrinter.printRecord(thought.getCSVFields());
         }

--- a/api/src/test/java/com/ford/labs/retroquest/actionitem/ActionItemTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/actionitem/ActionItemTest.java
@@ -41,8 +41,9 @@ public class ActionItemTest {
     public void shouldBuildActionCSVField() {
         ActionItem actionItem = new ActionItem();
         actionItem.setTask("task");
+        actionItem.setAssignee("user");
         List<String> actual = actionItem.getCSVFields();
-        assertThat(actual, contains("action item", "task", "", "no"));
+        assertThat(actual, contains("action item", "task", "", "no", "user"));
     }
 
     @Test

--- a/api/src/test/java/com/ford/labs/retroquest/team/CsvFileTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/team/CsvFileTest.java
@@ -42,7 +42,8 @@ public class CsvFileTest {
                 .message("a thought, with a comma").hearts(2).discussed(true).build();
         Thought thirdThought = Thought.builder().topic("unhappy").message("sad").hearts(0).discussed(false).build();
 
-        ActionItem actionItem = ActionItem.builder().task("tasks and \"stuff, yo\"").completed(false).build();
+        ActionItem actionItem = ActionItem.builder().task("tasks and \"stuff, yo\"").completed(false)
+                .assignee("test user").build();
         String actual = new CsvFile("teamName", Arrays.asList(firstThought, secondThoght, thirdThought),
                 Collections.singletonList(actionItem) ).getCSVString();
 

--- a/api/src/test/resources/sampleOutput.csv
+++ b/api/src/test/resources/sampleOutput.csv
@@ -1,5 +1,5 @@
-Column,Message,Likes,Completed
+Column,Message,Likes,Completed,Assigned To
 confused,"stuff ""goes here""",5,no
 happy,"a thought, with a comma",2,yes
 unhappy,sad,0,no
-action item,"tasks and ""stuff, yo""",,no
+action item,"tasks and ""stuff, yo""",,no,test user


### PR DESCRIPTION
## Overview
Adds 'Assigned To' as a column in CSV. 

Connects #3 

### Demo
![screen shot 2018-07-03 at 10 27 56 pm](https://user-images.githubusercontent.com/7977480/42253600-6e365654-7f10-11e8-9a64-c8a33ba44a55.png)

## Testing Instructions
- Add relative info to Happy/Confused/Sad
- Add info to Action Items
- Assign 'Assigned To' users in Action Items
- Download as CSV and verify information appears in columns