### PR TITLE
word wrap on thoughts and action items no longer cuts words in half 

### DIFF
--- a/ui/src/app/modules/teams/components/actions-column/actions-column.component.scss
+++ b/ui/src/app/modules/teams/components/actions-column/actions-column.component.scss
@@ -49,6 +49,7 @@
       flex-grow: 1;
       order: 2;
       padding: 6px 18px;
+      word-break: break-word;
     }
 
     &.completed {

--- a/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.scss
+++ b/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.scss
@@ -61,6 +61,7 @@
       flex-grow: 1;
       order: 2;
       padding: 6px 18px;
+      word-break: break-word;
     }
 
     &.edit {


### PR DESCRIPTION
:scissors:

## Overview
Fixes word wrap splitting words in half on thoughts and action items.

### Demo
<img width="323" alt="screen shot 2018-07-05 at 2 25 49 pm" src="https://user-images.githubusercontent.com/40771550/42340950-71017602-805f-11e8-8a66-91630da48e10.png">



### Notes
Tested on Safari and Chome in OSX.