### PR TITLE
Secure Feedback endpoint with no auth header. Fixes GH-61

### DIFF
--- a/api/src/apiTest/java/com/ford/labs/retroquest/api/FeedbackApiTest.java
+++ b/api/src/apiTest/java/com/ford/labs/retroquest/api/FeedbackApiTest.java
@@ -55,16 +55,18 @@ public class FeedbackApiTest extends AbstractTransactionalJUnit4SpringContextTes
     }
 
     @Test
-    public void cannotGetFeedbackWithoutAuth() throws Exception {
-        Feedback feedback = new Feedback();
-        feedbackRepository.save(feedback);
-
-        int size = feedbackRepository.findAll().size();
-
+    public void cannotGetFeedbackWithBadAuth() throws Exception {
         String token = Base64.getEncoder().encodeToString("notadmin:pass".getBytes());
 
         mockMvc.perform(get("/api/feedback/all").contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Basic " + token))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void cannotGetFeedbackWithNoAuth() throws Exception {
+
+        mockMvc.perform(get("/api/feedback/all").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/security/WebSecurityConfig.java
+++ b/api/src/main/java/com/ford/labs/retroquest/security/WebSecurityConfig.java
@@ -63,6 +63,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
         if (requireHttps) {
             httpSecurity.requiresChannel().antMatchers("/*").requiresSecure();
         }
+
+        httpSecurity.authorizeRequests().antMatchers("/api/feedback/all")
+                .hasRole("ADMIN").and().httpBasic();
+
         httpSecurity
         .authorizeRequests()
         .antMatchers("/**")
@@ -71,8 +75,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter{
         .authenticated()
         .and().addFilterAfter(jwtAuthenticationFilter, BasicAuthenticationFilter.class);
 
-        httpSecurity.authorizeRequests().antMatchers("/api/feedback/all")
-                .hasRole("ADMIN").and().httpBasic();
 
         httpSecurity.csrf().disable();
     }


### PR DESCRIPTION
This fixes GH-61. The spring security setup was treating requests with a auth header with bad  credentials differently than no auth header provided. I added a test for the latter case and fixed the code.
