### PR TITLE
Use default JDK from Travis to workaround Travis outage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ services:
 
 addons:
   chrome: stable
-  apt:
-    packages:
-      - oracle-java8-installer
 
 cache:
   directories:


### PR DESCRIPTION
Signed-off-by: Andrew Crouch <jcrouc15@ford.com>

## Overview
Travis CI currently has an outage which prevents installing a JDK through apt-get. This PR removes the apt-get and uses the default JDK installed by travis (current 1.8.0_151-b12)