### PR TITLE
Resolved title case on thought entry

### DIFF
--- a/ui/src/app/modules/controls/text-field/text-field.component.scss
+++ b/ui/src/app/modules/controls/text-field/text-field.component.scss
@@ -39,7 +39,7 @@
     margin: inherit;
     outline: 0;
     padding: 0 12px;
-    text-transform: capitalize;
+    text-transform: initial;
     width: inherit;
 
     &::placeholder {

--- a/ui/src/app/modules/teams/components/actions-header/actions-header.component.html
+++ b/ui/src/app/modules/teams/components/actions-header/actions-header.component.html
@@ -19,7 +19,7 @@
   <rq-column-header [title]="'Action Items'" [type]="'action'"></rq-column-header>
   <rq-text-field
     [type]="'action'"
-    [placeholder]="'enter action item'"
+    [placeholder]="'Enter Action Item'"
     (newMessageAdded)="addActionItem($event)"
   ></rq-text-field>
 

--- a/ui/src/app/modules/teams/components/thoughts-header/thoughts-header.component.html
+++ b/ui/src/app/modules/teams/components/thoughts-header/thoughts-header.component.html
@@ -26,7 +26,7 @@
 
   <rq-text-field
     [type]="column.topic"
-    [placeholder]="'enter a thought'"
+    [placeholder]="'Enter A Thought'"
     (newMessageAdded)="addThought($event)"
   ></rq-text-field>
 


### PR DESCRIPTION
## Overview
This Pulle Request resolves the following issue: Title Case on thoughts #68.


### Demo
1) No Data Entry
<img width="1465" alt="screen shot 2018-07-25 at 11 56 14 am" src="https://user-images.githubusercontent.com/8965915/43212405-defd94ae-9001-11e8-9040-164f5e4dce4a.png">

2) Various Thought Entry and Displaying No Longer Title Case
<img width="1467" alt="screen shot 2018-07-25 at 1 05 06 pm" src="https://user-images.githubusercontent.com/8965915/43215880-5e5c603c-900b-11e8-8729-0e0418cae45d.png">


## Testing Instructions
Open RetroQuest and add a thought entry or Action Item.  When entering the action item the case of the text should be persevered as it was entered by the user.