### PR TITLE
Add failed login threshold to prevent excessive captcha triggers

### DIFF
--- a/api/src/apiTest/resources/application.properties
+++ b/api/src/apiTest/resources/application.properties
@@ -30,6 +30,7 @@ com.retroquest.adminPassword=Admin
 com.retroquest.captcha.url=http://captcha.url
 com.retroquest.captcha.secret=secret
 com.retroquest.captcha.enabled=true
+com.retroquest.captcha.failedLoginThreshold=0
 
 # H2
 spring.h2.console.enabled=true

--- a/api/src/main/java/com/ford/labs/retroquest/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/ford/labs/retroquest/exception/GlobalExceptionHandler.java
@@ -22,9 +22,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @ControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "Incorrect board or password. Please try again.")
     @ExceptionHandler(CaptchaInvalidException.class)
     public void invalidCaptchaExceptionHandler() {

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackRepository.java
@@ -23,8 +23,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface FeedbackRepository extends JpaRepository<Feedback, Long>{
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
-    public List<Feedback> findAllByStarsIsGreaterThanEqual(int minimumValue);
+    List<Feedback> findAllByStarsIsGreaterThanEqual(int minimumValue);
 
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/CaptchaResponse.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/CaptchaResponse.java
@@ -1,0 +1,10 @@
+package com.ford.labs.retroquest.team;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CaptchaResponse {
+    private boolean captchaEnabled;
+}

--- a/api/src/main/java/com/ford/labs/retroquest/team/CaptchaService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/CaptchaService.java
@@ -1,0 +1,34 @@
+package com.ford.labs.retroquest.team;
+
+import com.ford.labs.retroquest.exception.BoardDoesNotExistException;
+import com.ford.labs.retroquest.team.validation.CaptchaProperties;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class CaptchaService {
+    private TeamRepository teamRepository;
+    private CaptchaProperties captchaProperties;
+
+    public CaptchaService(TeamRepository teamRepository, CaptchaProperties captchaProperties) {
+        this.teamRepository = teamRepository;
+        this.captchaProperties = captchaProperties;
+    }
+
+    public boolean isCaptchaEnabledForTeam(String teamName) {
+        if(!isCaptchaEnabled()) {
+            return false;
+        }
+
+        Optional<Team> team = teamRepository.findTeamByName(teamName);
+        if(team.isPresent()) {
+            return team.get().getFailedAttempts() > captchaProperties.getFailedLoginThreshold();
+        }
+        throw new BoardDoesNotExistException();
+    }
+
+    public boolean isCaptchaEnabled() {
+        return captchaProperties.isEnabled();
+    }
+}

--- a/api/src/main/java/com/ford/labs/retroquest/team/CreateTeamRequest.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/CreateTeamRequest.java
@@ -17,7 +17,6 @@
 
 package com.ford.labs.retroquest.team;
 
-import com.ford.labs.retroquest.team.validation.CaptchaConstraint;
 import com.ford.labs.retroquest.team.validation.PasswordConstraint;
 import com.ford.labs.retroquest.team.validation.TeamNameConstraint;
 import lombok.AllArgsConstructor;
@@ -27,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class CreateTeamRequest {
+public class CreateTeamRequest implements TeamRequest {
 
     @TeamNameConstraint
     private String name;
@@ -35,6 +34,5 @@ public class CreateTeamRequest {
     @PasswordConstraint
     private String password;
 
-    @CaptchaConstraint
     private String captchaResponse;
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/LoginRequest.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/LoginRequest.java
@@ -17,7 +17,6 @@
 
 package com.ford.labs.retroquest.team;
 
-import com.ford.labs.retroquest.team.validation.CaptchaConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -25,11 +24,9 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class LoginRequest {
+public class LoginRequest implements TeamRequest {
 
     private String name;
     private String password;
-
-    @CaptchaConstraint
     private String captchaResponse;
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/Team.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/Team.java
@@ -19,6 +19,7 @@ package com.ford.labs.retroquest.team;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Persistable;
 
 import javax.persistence.Entity;
@@ -28,11 +29,13 @@ import java.time.LocalDate;
 
 @Data
 @Entity
-public class Team implements Persistable<String>{
+@NoArgsConstructor
+public class Team implements Persistable<String> {
 
     @Id
     @JsonIgnore
     private String uri;
+
     private String name;
 
     @JsonIgnore
@@ -40,6 +43,14 @@ public class Team implements Persistable<String>{
 
     @JsonIgnore
     private LocalDate dateCreated;
+    private int failedAttempts;
+
+    Team(String uri, String name, String password) {
+        this.uri = uri;
+        this.name = name;
+        this.password = password;
+        this.failedAttempts = 0;
+    }
 
     @Override
     public String getId() {

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
@@ -20,7 +20,10 @@ package com.ford.labs.retroquest.team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface TeamRepository extends JpaRepository<Team, String> {
-    Team findTeamByName(String name);
+    Optional<Team> findTeamByName(String name);
+    Optional<Team> findTeamByUri(String uri);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamRequest.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamRequest.java
@@ -1,0 +1,15 @@
+package com.ford.labs.retroquest.team;
+
+
+import com.ford.labs.retroquest.team.validation.CaptchaConstraint;
+
+@CaptchaConstraint
+public interface TeamRequest {
+    String getName();
+    String getPassword();
+    String getCaptchaResponse();
+
+    void setName(String name);
+    void setPassword(String password);
+    void setCaptchaResponse(String captchaResponse);
+}

--- a/api/src/main/java/com/ford/labs/retroquest/team/validation/CaptchaConstraint.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/validation/CaptchaConstraint.java
@@ -25,10 +25,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Constraint(validatedBy = CaptchaValidator.class)
-@Target( { ElementType.METHOD, ElementType.FIELD })
+@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CaptchaConstraint {
     String message() default "Invalid Captcha Response";
+
     Class<?>[] groups() default {};
+
     Class<? extends Payload>[] payload() default {};
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/validation/CaptchaProperties.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/validation/CaptchaProperties.java
@@ -11,4 +11,5 @@ public class CaptchaProperties {
     private String secret;
     private String url;
     private boolean enabled = true;
+    private int failedLoginThreshold;
 }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -34,3 +34,4 @@ com.retroquest.adminPassword=${random.value}
 com.retroquest.captcha.url=https://www.google.com/recaptcha/api/siteverify
 com.retroquest.captcha.secret=${random.value}
 com.retroquest.captcha.enabled=false
+com.retroquest.captcha.failedLoginThreshold=5

--- a/api/src/main/resources/db/h2/V001__create_action_item_table.sql
+++ b/api/src/main/resources/db/h2/V001__create_action_item_table.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS `team` (
   `date_created` varbinary,
   `name` varchar(255) DEFAULT NULL,
   `password` varchar(255) DEFAULT NULL,
+  `failed_attempts` int,
   PRIMARY KEY (`uri`)
 );
 

--- a/api/src/main/resources/db/migration/V007__add_failed_login_attempts_column.sql
+++ b/api/src/main/resources/db/migration/V007__add_failed_login_attempts_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `team`
+ADD `failed_attempts` INT

--- a/api/src/test/java/com/ford/labs/retroquest/team/CaptchaServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/team/CaptchaServiceTest.java
@@ -1,0 +1,62 @@
+package com.ford.labs.retroquest.team;
+
+import com.ford.labs.retroquest.team.validation.CaptchaProperties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaptchaServiceTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    private CaptchaProperties captchaProperties = new CaptchaProperties();
+
+    @Test
+    public void returnsTrueWhenFailedLoginAttemptsIsAboveThreshold() {
+        Team team = new Team();
+        team.setFailedAttempts(5);
+
+        captchaProperties.setEnabled(true);
+        captchaProperties.setFailedLoginThreshold(4);
+        CaptchaService captchaService = new CaptchaService(teamRepository, captchaProperties);
+
+        when(teamRepository.findTeamByName("some team")).thenReturn(Optional.of(team));
+
+        assertTrue(captchaService.isCaptchaEnabledForTeam("some team"));
+    }
+
+    @Test
+    public void returnsFalseWhenFailedLoginAttemptsIsBelowThreshold() {
+        Team team = new Team();
+        team.setFailedAttempts(5);
+
+        captchaProperties.setEnabled(true);
+        captchaProperties.setFailedLoginThreshold(10);
+        CaptchaService captchaService = new CaptchaService(teamRepository, captchaProperties);
+
+        when(teamRepository.findTeamByName("some team")).thenReturn(Optional.of(team));
+
+        assertFalse(captchaService.isCaptchaEnabledForTeam("some team"));
+    }
+
+    @Test
+    public void returnsFalseWhenCaptchaIsDisabled() {
+        Team team = new Team();
+        team.setFailedAttempts(5);
+
+        captchaProperties.setEnabled(false);
+        CaptchaService captchaService = new CaptchaService(teamRepository, captchaProperties);
+
+        assertFalse(captchaService.isCaptchaEnabledForTeam("some team"));
+    }
+}

--- a/api/src/test/java/com/ford/labs/retroquest/team/TeamControllerTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/team/TeamControllerTest.java
@@ -43,9 +43,6 @@ public class TeamControllerTest {
     @Mock
     private JwtBuilder jwtBuilder;
 
-    @Mock
-    private TeamRepository teamRepository;
-
     @InjectMocks
     private TeamController controller;
 
@@ -73,7 +70,7 @@ public class TeamControllerTest {
 
         when(teamService.login(loginRequest)).thenReturn(savedTeam);
         when(jwtBuilder.buildJwt("a-team")).thenReturn(expectedJwt);
-        when(teamRepository.findTeamByName("A Team")).thenReturn(savedTeam);
+        when(teamService.getTeamByName("A Team")).thenReturn(savedTeam);
 
         ResponseEntity<String> actualResponse = controller.login(loginRequest);
 
@@ -90,7 +87,7 @@ public class TeamControllerTest {
 
         when(teamService.createNewTeam(createTeamRequest)).thenReturn(savedTeam);
         when(jwtBuilder.buildJwt("a-team")).thenReturn(expectedJwt);
-        when(teamRepository.findTeamByName("A Team")).thenReturn(savedTeam);
+        when(teamService.getTeamByName("A Team")).thenReturn(savedTeam);
 
         ResponseEntity<String> actualResponse = controller.createTeam(createTeamRequest);
 

--- a/ui/e2e/src/create/create.e2e-spec.ts
+++ b/ui/e2e/src/create/create.e2e-spec.ts
@@ -1,5 +1,6 @@
-import { CreatePage } from './create.po';
-import { browser } from 'protractor';
+import {CreatePage} from './create.po';
+import {browser} from 'protractor';
+import {ZoneJsBugWorkaround as workaround} from '../util/zone-js-bug-workaround';
 
 describe('Create Page', () => {
   let page: CreatePage;
@@ -49,6 +50,7 @@ describe('Create Page', () => {
         page.teamPasswordInput().sendKeys('passwrd').then(() => {
           page.teamPasswordConfirm().sendKeys('passwrd').then(() => {
             page.createRetroButton().click().then(() => {
+              workaround.wait();
               expect(page.errorMessage().getText()).toBe('Password must be 8 characters or longer.');
             });
           });

--- a/ui/e2e/src/create/create.po.ts
+++ b/ui/e2e/src/create/create.po.ts
@@ -1,4 +1,5 @@
-import { browser, by, element, ElementFinder } from 'protractor';
+import {browser, by, element, ElementFinder} from 'protractor';
+import {ZoneJsBugWorkaround as workaround} from '../util/zone-js-bug-workaround';
 
 export class CreatePage {
   createRandomBoard(boardName: string = '', password: string = 'Passw0rd'): Promise<string> {
@@ -13,6 +14,7 @@ export class CreatePage {
           this.teamPasswordConfirm().sendKeys(password).then(() => {
             browser.sleep(1); // make sure timestamps are at least 1 mili apart
             this.createRetroButton().click().then(() => {
+              workaround.wait();
               browser.driver.getCurrentUrl().then((url: string) => {
                 const boardId = boardName.replace(' ', '-');
                 if (url.endsWith(`/team/${boardId}`)) {

--- a/ui/e2e/src/login/login.e2e-spec.ts
+++ b/ui/e2e/src/login/login.e2e-spec.ts
@@ -1,5 +1,6 @@
-import { LoginPage } from './login.po';
-import { browser } from 'protractor';
+import {LoginPage} from './login.po';
+import {browser} from 'protractor';
+import {ZoneJsBugWorkaround as workaround} from '../util/zone-js-bug-workaround';
 
 describe('Login Page', () => {
   let page: LoginPage;
@@ -42,16 +43,18 @@ describe('Login Page', () => {
       page.teamNameInput().sendKeys('team name').then(() => {
         page.teamPasswordInput().sendKeys(invalidPassword).then(() => {
           page.signInButton().click().then(() => {
+            workaround.wait();
             expect(page.errorMessage().getText()).toBe('Incorrect board or password. Please try again.');
           });
         });
       });
     });
 
-    it('should display error message if board name is does not exist', () => {
+    it('should display error message if board name does not exist', () => {
       page.teamNameInput().sendKeys('team name that does not exist').then(() => {
         page.teamPasswordInput().sendKeys(validPassword).then(() => {
           page.signInButton().click().then(() => {
+            workaround.wait();
             expect(page.errorMessage().getText()).toBe('Incorrect board name. Please try again.');
           });
         });
@@ -65,6 +68,7 @@ describe('Login Page', () => {
         page.teamNameInput().sendKeys(boardName).then(() => {
           page.teamPasswordInput().sendKeys(validPassword).then(() => {
             page.signInButton().click().then(() => {
+              workaround.wait();
               expect(browser.driver.getCurrentUrl()).toContain(`/team/${boardName}`);
             });
           });

--- a/ui/e2e/src/team/team.e2e-spec.ts
+++ b/ui/e2e/src/team/team.e2e-spec.ts
@@ -11,11 +11,13 @@ describe('Team Page', () => {
     page.loginToRandomBoard().then((randomTeamData) => {
       teamData = randomTeamData;
       page.navigateTo(teamData.id).then(() => {
-        // waiting for anuglar is broken when using websockets
+        // waiting for angular is broken when using websockets
         // we are toggling waitForAngularEnabled as a workaround
         browser.waitForAngularEnabled(false);
         done();
       });
+    }).catch((error) => {
+      console.error('failed to log into board: ', error);
     });
   });
 

--- a/ui/e2e/src/util/zone-js-bug-workaround.ts
+++ b/ui/e2e/src/util/zone-js-bug-workaround.ts
@@ -1,0 +1,14 @@
+/*
+* This is a workaround for bug https://github.com/angular/angular/issues/20921.
+* A fix has been merged into zone.js as of June 18, 2018 however a new version
+* of zone.js has not been released. Once released, update zone.js, remove
+* references to this file and delete it.
+* */
+
+import {browser} from 'protractor';
+
+export class ZoneJsBugWorkaround {
+  static wait() {
+    browser.driver.sleep(750);
+  }
+}

--- a/ui/src/app/modules/boards/pages/create/create.page.html
+++ b/ui/src/app/modules/boards/pages/create/create.page.html
@@ -63,7 +63,7 @@
                    [(ngModel)]="confirmPassword"/>
           </div>
           <span id="errorMessage" class="rq-error-message">{{errorMessage}}</span>
-          <button id="createRetroButton" class="rq-button" (click)="useCaptchaForProd()">
+          <button id="createRetroButton" class="rq-button" (click)="requestCaptchaStateAndCreateTeam()">
             Create Board
           </button>
         </div>

--- a/ui/src/app/modules/boards/pages/login/login.page.html
+++ b/ui/src/app/modules/boards/pages/login/login.page.html
@@ -50,7 +50,7 @@
                    [(ngModel)]="password"/>
           </div>
           <span id="errorMessage" class="rq-error-message">{{errorMessage}}</span>
-          <button id="signInButton" class="rq-button" (click)="useCaptchaForProd()">
+          <button id="signInButton" class="rq-button" (click)="requestCaptchaStateAndLogIn()">
             Sign In
           </button>
         </div>

--- a/ui/src/app/modules/boards/pages/login/login.page.ts
+++ b/ui/src/app/modules/boards/pages/login/login.page.ts
@@ -15,14 +15,17 @@
  * limitations under the License.
  */
 
-import { Component } from '@angular/core';
-import { Router } from '@angular/router';
+import {Component, ViewChild} from '@angular/core';
+import {Router} from '@angular/router';
 
-import { AuthService } from '../../../auth/auth.service';
-import { TeamService } from '../../../teams/services/team.service';
-import { RecaptchaComponent } from 'ng-recaptcha';
-import { ViewChild } from '@angular/core';
-import {isDevMode} from '@angular/core';
+import {AuthService} from '../../../auth/auth.service';
+import {TeamService} from '../../../teams/services/team.service';
+import {RecaptchaComponent} from 'ng-recaptcha';
+import {concatMap, map} from 'rxjs/operators';
+import {EMPTY} from 'rxjs';
+import {Observable} from 'rxjs/internal/Observable';
+import {HttpResponse} from '@angular/common/http';
+import {of} from 'rxjs/internal/observable/of';
 
 @Component({
   selector: 'rq-login',
@@ -31,7 +34,7 @@ import {isDevMode} from '@angular/core';
 })
 export class LoginComponent {
 
-  constructor (private teamService: TeamService, private router: Router) {
+  constructor(private teamService: TeamService, private router: Router) {
   }
 
   @ViewChild(RecaptchaComponent) recaptchaComponent: RecaptchaComponent;
@@ -40,26 +43,38 @@ export class LoginComponent {
   password: string;
   errorMessage: string;
 
-  useCaptchaForProd() {
-    if (isDevMode()) {
-      this.login();
+  requestCaptchaStateAndLogIn(): void {
+    if (!this.validateInput()) {
       return;
     }
-    this.recaptchaComponent.execute();
+
+    this.teamService.isCaptchaEnabledForTeam(this.teamName).pipe(
+      map(response => JSON.parse(response.body).captchaEnabled),
+      concatMap(captchaEnabled => this.loginOrExecuteReCaptcha(captchaEnabled))
+    ).subscribe(
+      response => this.handleResponse(response),
+      error => this.handleError(error)
+    );
   }
 
-  login (captchaResponse: string = null): void {
-    this.recaptchaComponent.reset();
-    if (this.validateInput()) {
-      this.teamService.login(this.teamName, this.password, captchaResponse)
-        .subscribe(
-          response => this.handleResponse(response),
-          error => this.handleError(error)
-        );
+  login(captchaResponse: string): void {
+    this.teamService.login(this.teamName, this.password, captchaResponse)
+      .subscribe(
+        response => this.handleResponse(response),
+        error => this.handleError(error)
+      );
+  }
+
+  private loginOrExecuteReCaptcha(captchaEnabled): Observable<HttpResponse<Object>> {
+    if (captchaEnabled) {
+      this.recaptchaComponent.reset();
+      this.recaptchaComponent.execute();
+      return EMPTY;
     }
+    return this.teamService.login(this.teamName, this.password, null);
   }
 
-  private validateInput (): boolean {
+  private validateInput(): boolean {
     if (!this.teamName || this.teamName === '') {
       this.errorMessage = 'Please enter a team name';
       return false;
@@ -74,15 +89,16 @@ export class LoginComponent {
     return true;
   }
 
-  private handleResponse (response): void {
+  private handleResponse(response): void {
     AuthService.setToken(response.body);
     const teamId = response.headers.get('location');
-    this.router.navigateByUrl( `/team/${teamId}`);
+    this.router.navigateByUrl(`/team/${teamId}`);
   }
 
-  private handleError (error) {
+  private handleError(error) {
     error.error = JSON.parse(error.error);
     this.errorMessage = error.error.message ? error.error.message : `${error.status} ${error.error}`;
-    console.error('A login error occurred:', this.errorMessage);
+    console.error('A login error occurred: ', this.errorMessage);
+    return of(this.errorMessage);
   }
 }

--- a/ui/src/app/modules/teams/services/team.service.spec.ts
+++ b/ui/src/app/modules/teams/services/team.service.spec.ts
@@ -86,4 +86,15 @@ describe('TeamService', () => {
       expect(returnObj instanceof Observable).toBeTruthy();
     });
   });
+
+  describe('isCaptchaEnabledForTeam', () => {
+    it('should request captcha state from the team api', () => {
+      const teamName = 'team-name';
+
+      const returnObj = service.isCaptchaEnabledForTeam(teamName);
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(`/api/team/${teamName}/captcha`, {observe: 'response', responseType: 'text' });
+      expect(returnObj instanceof Observable).toBe(true);
+    });
+  });
 });

--- a/ui/src/app/modules/teams/services/team.service.ts
+++ b/ui/src/app/modules/teams/services/team.service.ts
@@ -39,21 +39,35 @@ export class TeamService {
     return this.http.post(
       '/api/team/login',
       {name, password, captchaResponse},
-      {observe: 'response', responseType: 'text'}
+      {observe: 'response' , responseType: 'text'}
     );
   }
 
-  fetchTeamName(teamId): Observable<string> {
+  fetchTeamName(teamId: string): Observable<string> {
     return this.http.get(
       `/api/team/${teamId}/name`,
       {responseType: 'text'}
     );
   }
 
-  validateTeamId(teamId): Observable<HttpResponse<Object>> {
+  validateTeamId(teamId: string): Observable<HttpResponse<Object>> {
     return this.http.get(
       `/api/team/${teamId}/validate`,
       {observe: 'response'}
+    );
+  }
+
+  isCaptchaEnabledForTeam(teamName: string): Observable<HttpResponse<string>> {
+    return this.http.get(
+      `/api/team/${teamName}/captcha`,
+      {observe: 'response', responseType: 'text'}
+    );
+  }
+
+  isCaptchaEnabled(): Observable<HttpResponse<string>> {
+    return this.http.get(
+      `/api/captcha`,
+      {observe: 'response', responseType: 'text'}
     );
   }
 }


### PR DESCRIPTION
## Overview
Recaptcha is triggered on every request in Safari. We are only requiring
captcha to be valid when a user has exceeded the failed login threshold

Connects #26 #66 

### Notes
Recaptcha can be disabled via a spring property `com.retroquest.captcha.enabled=false`
The failed login threshold can also be configured via a spring property `com.retroquest.captcha.failedLoginThreshold=5`

There is a bug in zone.js which prevents angular from waiting until all http requests have completed. See https://github.com/angular/angular/issues/20921. I worked around this by adding a browser wait in the E2E tests. Once the fix for the aforementioned bug is merged into angular, then we should upgrade and remove the workaround. See `ui/e2e/src/util/zone-js-bug-workaround.ts`

## Testing Instructions
### Captcha Enabled Test Cases
1. Enable captcha via the spring property
1. Run the UI and API
1. Create a board and watch the network traffic, you will see requests to Google Recaptcha. You may also be prompted to solve the recaptcha if you act like a robot.
1. Go to the login screen and enter the incorrect password for the same board 5+ times
1. After the 5th try, watch the network traffic and you should see requests to Google Recaptcha. You may also be prompted to solve the recaptcha if you act like a robot.
1. Use the correct password to log in successfully
1. Go to the log in page and try to log in with the same user, you should not see requests to Google Repcatcha.

### Captcha Disabled Test Case
1. Disable captcha via the spring property
1. Run the UP and API
1. Create a board and watch the network traffic, you will not see requests to Google Recaptcha
1. Go to the login screen and enter the incorrect password for the same board 5+ times
1. After the 5th try, watch the network traffic and you should not see requests to Google Recaptcha