### PR TITLE
Brute Force Prevention: Treat null failed login attempts as 0

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/team/CaptchaService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/CaptchaService.java
@@ -23,7 +23,8 @@ public class CaptchaService {
 
         Optional<Team> team = teamRepository.findTeamByName(teamName);
         if(team.isPresent()) {
-            return team.get().getFailedAttempts() > captchaProperties.getFailedLoginThreshold();
+            Integer failedAttempts = team.get().getFailedAttempts() != null ? team.get().getFailedAttempts() : 0;
+            return failedAttempts > captchaProperties.getFailedLoginThreshold();
         }
         throw new BoardDoesNotExistException();
     }

--- a/api/src/main/java/com/ford/labs/retroquest/team/Team.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/Team.java
@@ -43,7 +43,8 @@ public class Team implements Persistable<String> {
 
     @JsonIgnore
     private LocalDate dateCreated;
-    private int failedAttempts;
+
+    private Integer failedAttempts;
 
     Team(String uri, String name, String password) {
         this.uri = uri;

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
@@ -101,7 +101,8 @@ public class TeamService {
         Team savedTeam = getTeamByName(loginRequest.getName());
 
         if (loginRequest.getPassword() == null || !passwordEncoder.matches(loginRequest.getPassword(), savedTeam.getPassword())) {
-            updateFailedAttempts(savedTeam, savedTeam.getFailedAttempts() + 1);
+            Integer failedAttempts = savedTeam.getFailedAttempts() != null ? savedTeam.getFailedAttempts() : 0;
+            updateFailedAttempts(savedTeam, failedAttempts + 1);
             throw new PasswordInvalidException();
         }
 

--- a/api/src/test/java/com/ford/labs/retroquest/team/CaptchaServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/team/CaptchaServiceTest.java
@@ -59,4 +59,16 @@ public class CaptchaServiceTest {
 
         assertFalse(captchaService.isCaptchaEnabledForTeam("some team"));
     }
+
+    @Test
+    public void handlesNullFailedAttempts() {
+        Team team = new Team();
+        captchaProperties.setEnabled(true);
+        captchaProperties.setFailedLoginThreshold(1);
+        when(teamRepository.findTeamByName("some team")).thenReturn(Optional.of(team));
+
+        CaptchaService captchaService = new CaptchaService(teamRepository, captchaProperties);
+
+        assertFalse(captchaService.isCaptchaEnabledForTeam("some team"));
+    }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/team/TeamServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/team/TeamServiceTest.java
@@ -127,7 +127,7 @@ public class TeamServiceTest {
     }
 
     @Test
-    public void shouldIncrementFailedAttemptsCountWhenPasswordsDoNotMatch() {
+    public void incrementFailedAttemptsCountWhenPasswordsDoNotMatch() {
         String teamName = "beach-bums";
         String teamPassword = "encryptedPassword";
 
@@ -148,7 +148,7 @@ public class TeamServiceTest {
     }
 
     @Test
-    public void shouldResetFailedAttemptsCountWhenPasswordsMatch() {
+    public void resetsFailedAttemptsCountWhenPasswordsMatch() {
         String teamName = "beach-bums";
         String teamPassword = "encryptedPassword";
 
@@ -162,7 +162,7 @@ public class TeamServiceTest {
 
         teamService.login(loginRequest);
 
-        assertEquals(0, team.getFailedAttempts());
+        assertEquals(Integer.valueOf(0), team.getFailedAttempts());
     }
 
     @Test


### PR DESCRIPTION
## Overview
This is a bug fix which allows a pre-existing boards with `null` failed login attempts to correctly log in. 

This fix will treat `null` as `0` for failedAttempts on the team table.

Connects #66 #26 
### Demo
![image](https://user-images.githubusercontent.com/5607510/43524762-0bb225fc-956e-11e8-9fc3-204f1e6e500e.png)

## Testing Instructions
1. Start the api, db, and ui
2. Create a board
3. Edit the entry in the teams table in the db and reset failed attempts to null
4. Attempt to login with the modified team (you should be able to)