### PR TITLE
Fixed thought dialog being unusable on mobile

### DIFF
--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 @import 'color-vars';
 
 :host {
@@ -33,22 +32,37 @@
   width: 100%;
   z-index: 100;
 
+  @media only screen and (max-width: 610px) {
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+
   rq-task {
     $border-width: 8px;
     $base-drop-shadow: 0 19px 38px opacity($black, .3);
 
     $action-shadow: 0 0 0 $border-width $action-yellow, $base-drop-shadow;
 
+
     $confused-shadow: 0 0 0 $border-width $confused-blue, $base-drop-shadow;
     $happy-shadow: 0 0 0 $border-width $happy-green, $base-drop-shadow;
     $sad-shadow: 0 0 0 $border-width $unhappy-red, $base-drop-shadow;
 
     border-radius: 6px;
+    box-sizing: border-box;
     font-size: 1rem;
     height: auto;
-    transform: scale(1.3);
 
+    transform: scale(1.3);
     width: 450px;
+
+    @media only screen and (max-width: 610px) {
+      height: 280px;
+      margin: $border-width;
+      max-height: 280px;
+      transform: none;
+      width: calc(100% - 16px);
+    }
 
     &.happy {
       box-shadow: $happy-shadow;
@@ -66,7 +80,6 @@
       }
     }
 
-
     &.sad {
       box-shadow: $sad-shadow;
 
@@ -74,7 +87,6 @@
         box-shadow: $sad-shadow;
       }
     }
-
 
     &.action {
       box-shadow: $action-shadow;


### PR DESCRIPTION
## Overview
The thought dialog was unusable on mobile screens because it would be permanently cut off.
This fixes that issue by using media queries to scale the thought dialog to fit.

### Demo
![dialog](https://user-images.githubusercontent.com/6293337/43672478-981b441e-977c-11e8-8938-1c53f546afbf.png)
