### PR TITLE
Fixes action item and thoughts not limiting messages to 255 characters.

### DIFF
--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
@@ -33,6 +33,7 @@
       (input)="actionItem.task = content_value.textContent"
       (keydown.enter)="forceBlur()"
       (blur)="toggleEditMode()"
+      (keydown)="onKeyDown($event)"
     >{{actionItem.task}}
     </div>
   </ng-template>

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.spec.ts
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.spec.ts
@@ -164,4 +164,55 @@ describe('ThoughtComponent', () => {
       expect(component.editableTextArea.nativeElement.blur).toHaveBeenCalled();
     });
   });
+
+  describe('onKeyDown', () => {
+
+    it('should prevent the key event from being processed if the task has reached the max length', () => {
+      const fakeKeyEvent = jasmine.createSpyObj({
+        preventDefault: null
+      });
+
+      component.maxMessageLength = 2;
+      component.actionItem.task = 'XX';
+      component.onKeyDown(fakeKeyEvent);
+      expect(fakeKeyEvent.preventDefault).toHaveBeenCalled();
+    });
+
+    it('should allow the key event if the max message length has not been reached', () => {
+      const fakeKeyEvent = jasmine.createSpyObj({
+        preventDefault: null
+      });
+
+      component.maxMessageLength = 3;
+      component.actionItem.task = 'XX';
+      component.onKeyDown(fakeKeyEvent);
+      expect(fakeKeyEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('should allow the backspace key event even if the max length has been reached', () => {
+      const fakeBackspaceEvent = jasmine.createSpyObj({
+        preventDefault: null
+      });
+
+      fakeBackspaceEvent.keyCode = 8;
+
+      component.maxMessageLength = 2;
+      component.actionItem.task = 'XX';
+      component.onKeyDown(fakeBackspaceEvent);
+      expect(fakeBackspaceEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('should allow the delete key event even if the max length has been reached', () => {
+      const fakeDeleteKeyEvent = jasmine.createSpyObj({
+        preventDefault: null,
+      });
+
+      fakeDeleteKeyEvent.keyCode = 46;
+
+      component.maxMessageLength = 2;
+      component.actionItem.task = 'XX';
+      component.onKeyDown(fakeDeleteKeyEvent);
+      expect(fakeDeleteKeyEvent.preventDefault).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.ts
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.ts
@@ -18,6 +18,9 @@
 import {Component, ElementRef, EventEmitter, Input, Output, ViewChild} from '@angular/core';
 import {ActionItem, emptyActionItem} from '../../teams/domain/action-item';
 
+const BACKSPACE_KEY = 8;
+const DELETE_KEY = 46;
+
 @Component({
   selector: 'rq-action-item-task',
   templateUrl: './action-item-task.component.html',
@@ -40,6 +43,7 @@ export class ActionItemTaskComponent {
   @ViewChild('content_value') editableTextArea: ElementRef;
 
   taskEditModeEnabled = false;
+  maxMessageLength = 255;
 
   constructor() {
   }
@@ -92,6 +96,17 @@ export class ActionItemTaskComponent {
 
   private selectAllText(): void {
     document.execCommand('selectAll', false, null);
+  }
+
+  public onKeyDown(keyEvent: KeyboardEvent) {
+    if ((this.actionItem.task.length >= this.maxMessageLength)
+      && !this.keyEventIsAnAction(keyEvent)) {
+      keyEvent.preventDefault();
+    }
+  }
+
+  private keyEventIsAnAction(keyEvent: KeyboardEvent): boolean {
+    return keyEvent.keyCode === BACKSPACE_KEY || keyEvent.keyCode === DELETE_KEY;
   }
 }
 

--- a/ui/src/app/modules/controls/task/task.component.html
+++ b/ui/src/app/modules/controls/task/task.component.html
@@ -33,6 +33,7 @@
       (input)="task.message = content_value.textContent"
       (keydown.enter)="forceBlur()"
       (blur)="toggleEditMode()"
+      (keydown)="onKeyDown($event)"
     >{{task.message}}
     </div>
   </ng-template>

--- a/ui/src/app/modules/controls/task/task.component.spec.ts
+++ b/ui/src/app/modules/controls/task/task.component.spec.ts
@@ -187,4 +187,55 @@ describe('ThoughtComponent', () => {
       expect(component.editableTextArea.nativeElement.blur).toHaveBeenCalled();
     });
   });
+
+  describe('onKeyDown', () => {
+
+    it('should prevent the key event from being processed if the task has reached the max length', () => {
+      const fakeKeyEvent = jasmine.createSpyObj({
+        preventDefault: null
+      });
+
+      component.maxMessageLength = 2;
+      component.task.message = 'XX';
+      component.onKeyDown(fakeKeyEvent);
+      expect(fakeKeyEvent.preventDefault).toHaveBeenCalled();
+    });
+
+    it('should allow the key event if the max message length has not been reached', () => {
+      const fakeKeyEvent = jasmine.createSpyObj({
+        preventDefault: null
+      });
+
+      component.maxMessageLength = 3;
+      component.task.message = 'XX';
+      component.onKeyDown(fakeKeyEvent);
+      expect(fakeKeyEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('should allow the backspace key event even if the max length has been reached', () => {
+      const fakeBackspaceEvent = jasmine.createSpyObj({
+        preventDefault: null
+      });
+
+      fakeBackspaceEvent.keyCode = 8;
+
+      component.maxMessageLength = 2;
+      component.task.message = 'XX';
+      component.onKeyDown(fakeBackspaceEvent);
+      expect(fakeBackspaceEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('should allow the delete key event even if the max length has been reached', () => {
+      const fakeDeleteKeyEvent = jasmine.createSpyObj({
+        preventDefault: null,
+      });
+
+      fakeDeleteKeyEvent.keyCode = 46;
+
+      component.maxMessageLength = 2;
+      component.task.message = 'XX';
+      component.onKeyDown(fakeDeleteKeyEvent);
+      expect(fakeDeleteKeyEvent.preventDefault).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/ui/src/app/modules/controls/task/task.component.ts
+++ b/ui/src/app/modules/controls/task/task.component.ts
@@ -18,6 +18,10 @@
 import {Component, ElementRef, EventEmitter, Input, Output, ViewChild} from '@angular/core';
 import {emptyThought, Thought} from '../../teams/domain/thought';
 
+
+const BACKSPACE_KEY = 8;
+const DELETE_KEY = 46;
+
 @Component({
   selector: 'rq-task',
   templateUrl: './task.component.html',
@@ -45,11 +49,11 @@ export class TaskComponent {
   @ViewChild('content_value') editableTextArea: ElementRef;
 
   starCountMax = 99;
+  maxMessageLength = 255;
   taskEditModeEnabled = false;
 
   constructor() {
   }
-
 
   public toggleEditMode(): void {
     if (this.taskEditModeEnabled) {
@@ -100,6 +104,17 @@ export class TaskComponent {
     setTimeout(() => {
       this.editableTextArea.nativeElement.blur();
     }, 0);
+  }
+
+  public onKeyDown(keyEvent: KeyboardEvent) {
+    if ((this.task.message.length >= this.maxMessageLength)
+    && !this.keyEventIsAnAction(keyEvent)) {
+      keyEvent.preventDefault();
+    }
+  }
+
+  private keyEventIsAnAction(keyEvent: KeyboardEvent): boolean {
+    return keyEvent.keyCode === BACKSPACE_KEY || keyEvent.keyCode === DELETE_KEY;
   }
 }
 


### PR DESCRIPTION
## Overview
Fixes the issue where the user could put in a thought and action item message greater than the 255 backend limit.

## Testing
1. Add in this 255 character string and add one character to it. You should not be able to. ```xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx```

2. You should still be able to clear out the string by using the backspace and delete key.
