### PR TITLE
Sends heartbeat periodically to keep socket alive

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/websocket/WebSocketHeartbeatController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/websocket/WebSocketHeartbeatController.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.websocket;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class WebSocketHeartbeatController {
+
+    @MessageMapping("/heartbeat/ping")
+    @SendTo("/topic/heartbeat/pong")
+    public String sendBackHeartbeat() {
+        return "";
+    }
+}

--- a/ui/src/app/modules/teams/services/websocket.service.ts
+++ b/ui/src/app/modules/teams/services/websocket.service.ts
@@ -40,7 +40,7 @@ export class WebsocketService {
   }
 
   public getWebsocketState(): number {
-    if ( !this.websocket) {
+    if (!this.websocket) {
       return WebSocket.CLOSED;
     }
     return this.websocket.readyState;
@@ -83,6 +83,22 @@ export class WebsocketService {
             headers: headers
           });
         });
+    });
+  }
+
+  public sendHeartbeat() {
+    this.checkForOpenSocket();
+    this.stompClient.send(`/app/heartbeat/ping`, '');
+  }
+
+  public heartbeatTopic(): Observable<any> {
+    this.checkForOpenSocket();
+
+    return new Observable<any>(observer => {
+      const sub = this.stompClient.subscribe(`/topic/heartbeat/pong`);
+      sub.messages.subscribe(m => {
+        observer.next(m);
+      });
     });
   }
 


### PR DESCRIPTION
## Overview
-This should keep the websocket from disconnecting all the time
-The frontend send a heartbeat signal to the backend every minute.

[#30]

## Testing Instructions
This is really hard to test because the websocket can be controller by the browser and the system firewall. I don't see any way to test it besides just push it up and watch.