### PR TITLE
Stops tasks from blinking when modified

### DIFF
--- a/ui/src/app/modules/teams/pages/team/team.page.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.ts
@@ -182,7 +182,7 @@ export class TeamPageComponent implements OnInit {
     if (thoughtIndex === -1) {
       this.thoughtsArray.push(thought);
     } else {
-      this.thoughtsArray[thoughtIndex] = thought;
+      Object.assign(this.thoughtsArray[thoughtIndex], thought);
     }
   }
 
@@ -197,7 +197,7 @@ export class TeamPageComponent implements OnInit {
     if (actionItemIndex === -1) {
       this.actionItems.push(actionItem);
     } else {
-      this.actionItems[actionItemIndex] = actionItem;
+      Object.assign(this.actionItems[actionItemIndex], actionItem);
     }
   }
 


### PR DESCRIPTION
## Overview
-Tasks used to blink when changing any of their attributes, this was
because we were inserting a new object upon updates.
-This change keeps the same old object, but copies the fields