### PR TITLE
Create gradle task for starting backend with h2. Refer to ##31

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ What you need to install before building our project.  This guide will assume yo
 Running the application locally can be done with either an H2 in-memory database or with a docker container of MySQL.
 
 ### In-Memory
-The simplest way to get the application spun up is by using the in-memory database:
+The simplest way to get the application spun up is by using the in-memory database via Gradle:
+```
+./gradlew withH2
+```
+or
 ```
 SPRING_PROFILES_ACTIVE=h2 ./gradlew bootRun
 ```

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -69,6 +69,14 @@ dockerApiTest.finalizedBy apiTest
 task runAllTests(dependsOn: [test, apiTest]) {
 }
 
+task withH2(type: org.springframework.boot.gradle.run.BootRunTask, dependsOn: 'build') {
+    doFirst() {
+        main = project.mainClassName
+        classpath = sourceSets.main.runtimeClasspath
+        systemProperty 'spring.profiles.active', 'h2'
+    }
+}
+
 jar {
     archiveName = "${archivesBaseName}-${version}.jar"
 }


### PR DESCRIPTION
## Overview
It's not straightforward when reading the instructions for starting the backend with the in-memory database. I think that moving it into a Gradle task simplifies things.

Connects #31 

## Testing Instructions
Test by starting the backend with `./gradlew withH2`
