### PR TITLE
Remove task and action item hover events on mobile

### DIFF
--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -45,6 +45,12 @@
     box-shadow: 0 0 0 $host-border-width $action-yellow;
   }
 
+  @media only screen and (max-width: 610px) {
+    &:hover {
+      box-shadow: none;
+    }
+  }
+
   &.edit-mode {
     &:hover {
       box-shadow: 0 0 0 4px $grape;

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -33,7 +33,6 @@
 
   width: 100px;
 
-
   &.push-order-to-bottom {
     box-shadow: none;
     order: 99;
@@ -65,6 +64,19 @@
     &:hover {
       box-shadow: 0 0 0 $host-border-width $action-yellow;
     }
+  }
+
+  @media only screen and (max-width: 610px) {
+
+    &.action,
+    &.sad,
+    &.confused,
+    &.happy {
+      &:hover {
+        box-shadow: none;
+      }
+    }
+
   }
 
   &.edit-mode {


### PR DESCRIPTION
## Overview
-Hover events are all wack on mobile. They look like the user is
selected an item even thought they aren't. We just need to remove them
and this does that.