### PR TITLE
This will hopefully fix the overscroll on IOS

### DIFF
--- a/ui/src/app/modules/teams/components/header/header.component.scss
+++ b/ui/src/app/modules/teams/components/header/header.component.scss
@@ -31,7 +31,7 @@
     left: 0;
     padding-bottom: 0;
     padding-top: 6px;
-    position: fixed;
+    position: absolute;
     right: 0;
     top: 0;
   }


### PR DESCRIPTION
## Overview
On IOS and maybe other mobile browsers, the user can overscroll above the top header, causing a window to clip over the header. This should hopefully this it after reading a blog.