### PR TITLE
Metrics update

### DIFF
--- a/api/src/apiTest/java/com/ford/labs/retroquest/api/MetricsApiTest.java
+++ b/api/src/apiTest/java/com/ford/labs/retroquest/api/MetricsApiTest.java
@@ -144,13 +144,13 @@ public class MetricsApiTest extends ControllerTest {
     public void whenGettingTheTotalNumberofReviews_providingOnlyAStartDate_getsAllFromThatDateUntilNow() throws Exception {
 
         Feedback feedback1 = new Feedback();
-        feedback1.setDateCreated(LocalDateTime.of(1995, 5, 8, 1, 1));
+        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
         Feedback feedback2 = new Feedback();
-        feedback2.setDateCreated(LocalDateTime.of(1996, 2, 13, 1, 1));
+        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
 
         feedbackRepository.save(asList(feedback1, feedback2));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/count?start=1996-01-01")
+        mockMvc.perform(get("/api/admin/metrics/feedback/count?start=2018-02-02")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", getBasicAuthToken()))
                 .andExpect(status().isOk())
@@ -161,13 +161,13 @@ public class MetricsApiTest extends ControllerTest {
     public void whenGettingTheTotalNumberofReviews_providingOnlyAnEndDate_getsAllFromNowToThatDate() throws Exception {
 
         Feedback feedback1 = new Feedback();
-        feedback1.setDateCreated(LocalDateTime.of(1995, 5, 8, 1, 1));
+        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
         Feedback feedback2 = new Feedback();
-        feedback2.setDateCreated(LocalDateTime.of(1996, 2, 13, 1, 1));
+        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
 
         feedbackRepository.save(asList(feedback1, feedback2));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/count?end=1996-01-01")
+        mockMvc.perform(get("/api/admin/metrics/feedback/count?end=2018-02-02")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", getBasicAuthToken()))
                 .andExpect(status().isOk())
@@ -219,15 +219,15 @@ public class MetricsApiTest extends ControllerTest {
     public void whenGettingTheAverageRating_providingOnlyAStartDate_getsAllFromThatDateUntilNow() throws Exception {
 
         Feedback feedback1 = new Feedback();
-        feedback1.setDateCreated(LocalDateTime.of(1995, 5, 8, 1, 1));
+        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
         feedback1.setStars(1);
         Feedback feedback2 = new Feedback();
-        feedback2.setDateCreated(LocalDateTime.of(1996, 2, 13, 1, 1));
+        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
         feedback2.setStars(3);
 
         feedbackRepository.save(asList(feedback1, feedback2));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/average?start=1996-01-01")
+        mockMvc.perform(get("/api/admin/metrics/feedback/average?start=2018-02-02")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", getBasicAuthToken()))
                 .andExpect(status().isOk())
@@ -239,14 +239,14 @@ public class MetricsApiTest extends ControllerTest {
 
         Feedback feedback1 = new Feedback();
         feedback1.setStars(3);
-        feedback1.setDateCreated(LocalDateTime.of(1995, 5, 8, 1, 1));
+        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
         Feedback feedback2 = new Feedback();
         feedback2.setStars(1);
-        feedback2.setDateCreated(LocalDateTime.of(1996, 2, 13, 1, 1));
+        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
 
         feedbackRepository.save(asList(feedback1, feedback2));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/average?end=1996-01-01")
+        mockMvc.perform(get("/api/admin/metrics/feedback/average?end=2018-02-02")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", getBasicAuthToken()))
                 .andExpect(status().isOk())
@@ -258,13 +258,13 @@ public class MetricsApiTest extends ControllerTest {
 
         Team team1 = new Team();
         team1.setUri("team" + LocalDate.now().toEpochDay());
-        team1.setDateCreated(LocalDate.of(1996, 2, 13));
+        team1.setDateCreated(LocalDate.of(2018, 2, 2));
         Team team2 = new Team();
         team2.setUri("team" + (LocalDate.now().toEpochDay() + 1));
-        team2.setDateCreated(LocalDate.of(1995, 5, 8));
+        team2.setDateCreated(LocalDate.of(2018, 4, 4));
         teamRepository.save(asList(team1, team2));
 
-        mockMvc.perform(get("/api/admin/metrics/team/count?start=1996-01-01")
+        mockMvc.perform(get("/api/admin/metrics/team/count?start=2018-03-03")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", getBasicAuthToken()))
                 .andExpect(status().isOk())

--- a/api/src/apiTest/java/com/ford/labs/retroquest/api/MetricsApiTest.java
+++ b/api/src/apiTest/java/com/ford/labs/retroquest/api/MetricsApiTest.java
@@ -180,11 +180,71 @@ public class MetricsApiTest extends ControllerTest {
 
         feedbackRepository.save(asList(feedback1, feedback2, feedback3));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/count?start=2018-05-01&end=2018-12-31")
+        mockMvc.perform(get("/api/admin/metrics/feedback/count?start=2018-05-01&end=2018-12-01")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", getBasicAuthToken()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(2)));
+                .andExpect(jsonPath("$", Matchers.is(1)));
+    }
+
+    @Test
+    public void whenGettingTheAverageRating_providingAStartAndEndDate_getsTheBetweenDates() throws Exception {
+
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(2018, 4, 1, 1, 1));
+        feedback1.setStars(1);
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(2018, 10, 31, 1, 1));
+        feedback2.setStars(1);
+        Feedback feedback3 = new Feedback();
+        feedback3.setDateCreated(LocalDateTime.of(2018, 12, 25, 1, 1));
+        feedback3.setStars(1);
+
+        feedbackRepository.save(asList(feedback1, feedback2, feedback3));
+
+        mockMvc.perform(get("/api/admin/metrics/feedback/average?start=2018-05-01&end2018-12-31")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", getBasicAuthToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.is(1.0)));
+    }
+
+    @Test
+    public void whenGettingTheAverageRating_providingOnlyAStartDate_getsAllFromThatDateUntilNow() throws Exception {
+
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(1995, 5, 8, 1, 1));
+        feedback1.setStars(1);
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(1996, 2, 13, 1, 1));
+        feedback2.setStars(1);
+
+        feedbackRepository.save(asList(feedback1, feedback2));
+
+        mockMvc.perform(get("/api/admin/metrics/feedback/average?start=1996-01-01")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", getBasicAuthToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.is(1.0)));
+    }
+
+    @Test
+    public void whenGettingTheAverageRating_providingOnlyAnEndDate_getsAllFromNowToThatDate() throws Exception {
+
+        Feedback feedback1 = new Feedback();
+        feedback1.setStars(1);
+        feedback1.setDateCreated(LocalDateTime.of(1995, 5, 8, 1, 1));
+        Feedback feedback2 = new Feedback();
+        feedback2.setStars(1);
+        feedback2.setDateCreated(LocalDateTime.of(1996, 2, 13, 1, 1));
+
+        feedbackRepository.save(asList(feedback1, feedback2));
+
+        mockMvc.perform(get("/api/admin/metrics/feedback/average?end=1996-01-01")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", getBasicAuthToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.is(1.0)));
     }
 
     private String getToken(String adminUsername, String adminPassword) {

--- a/api/src/apiTest/java/com/ford/labs/retroquest/api/MetricsApiTest.java
+++ b/api/src/apiTest/java/com/ford/labs/retroquest/api/MetricsApiTest.java
@@ -91,8 +91,10 @@ public class MetricsApiTest extends ControllerTest {
 
         Feedback feedback1 = new Feedback();
         feedback1.setStars(4);
+        feedback1.setDateCreated(LocalDateTime.now());
         Feedback feedback2 = new Feedback();
         feedback2.setStars(2);
+        feedback2.setDateCreated(LocalDateTime.now());
         feedbackRepository.save(asList(feedback1, feedback2));
 
 
@@ -109,8 +111,10 @@ public class MetricsApiTest extends ControllerTest {
 
         Feedback feedback1 = new Feedback();
         feedback1.setStars(4);
+        feedback1.setDateCreated(LocalDateTime.now());
         Feedback feedback2 = new Feedback();
         feedback2.setStars(0);
+        feedback2.setDateCreated(LocalDateTime.now());
         feedbackRepository.save(asList(feedback1, feedback2));
 
         MvcResult result = mockMvc.perform(get("/api/admin/metrics/feedback/average")
@@ -197,18 +201,18 @@ public class MetricsApiTest extends ControllerTest {
         feedback1.setStars(1);
         Feedback feedback2 = new Feedback();
         feedback2.setDateCreated(LocalDateTime.of(2018, 10, 31, 1, 1));
-        feedback2.setStars(1);
+        feedback2.setStars(2);
         Feedback feedback3 = new Feedback();
         feedback3.setDateCreated(LocalDateTime.of(2018, 12, 25, 1, 1));
         feedback3.setStars(1);
 
         feedbackRepository.save(asList(feedback1, feedback2, feedback3));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/average?start=2018-05-01&end2018-12-31")
+        mockMvc.perform(get("/api/admin/metrics/feedback/average?start=2018-05-01&end=2018-12-01")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", getBasicAuthToken()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(1.0)));
+                .andExpect(jsonPath("$", Matchers.is(2.0)));
     }
 
     @Test
@@ -219,7 +223,7 @@ public class MetricsApiTest extends ControllerTest {
         feedback1.setStars(1);
         Feedback feedback2 = new Feedback();
         feedback2.setDateCreated(LocalDateTime.of(1996, 2, 13, 1, 1));
-        feedback2.setStars(1);
+        feedback2.setStars(3);
 
         feedbackRepository.save(asList(feedback1, feedback2));
 
@@ -227,14 +231,14 @@ public class MetricsApiTest extends ControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", getBasicAuthToken()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(1.0)));
+                .andExpect(jsonPath("$", Matchers.is(3.0)));
     }
 
     @Test
     public void whenGettingTheAverageRating_providingOnlyAnEndDate_getsAllFromNowToThatDate() throws Exception {
 
         Feedback feedback1 = new Feedback();
-        feedback1.setStars(1);
+        feedback1.setStars(3);
         feedback1.setDateCreated(LocalDateTime.of(1995, 5, 8, 1, 1));
         Feedback feedback2 = new Feedback();
         feedback2.setStars(1);
@@ -246,7 +250,7 @@ public class MetricsApiTest extends ControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", getBasicAuthToken()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(1.0)));
+                .andExpect(jsonPath("$", Matchers.is(3.0)));
     }
 
     @Test

--- a/api/src/apiTest/java/com/ford/labs/retroquest/api/MetricsApiTest.java
+++ b/api/src/apiTest/java/com/ford/labs/retroquest/api/MetricsApiTest.java
@@ -271,6 +271,60 @@ public class MetricsApiTest extends ControllerTest {
                 .andExpect(jsonPath("$", Matchers.is(1)));
     }
 
+    @Test
+    public void whenGettingTeamLogins_providingOnlyAStartDate_getsAllFromThenToNow() throws Exception {
+        Team team1 = new Team();
+        team1.setUri("teamLoginOnlyStartDate1");
+        team1.setLastLoginDate(LocalDate.of(2018, 1, 1));
+        Team team2 = new Team();
+        team2.setUri("teamLoginOnlyStartDate2");
+        team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
+        teamRepository.save(asList(team1, team2));
+
+        mockMvc.perform(get("/api/admin/metrics/team/logins?start=2018-02-02")
+                .header("Authorization", getBasicAuthToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.is(1)));
+    }
+
+    @Test
+    public void whenGettingTeamLogins_providingOnlyAnEndDate_getsAllFromTheBegginingOfTimeToThatDate() throws Exception {
+        Team team1 = new Team();
+        team1.setUri("teamLoginsOnlyEndDate1");
+        team1.setLastLoginDate(LocalDate.of(2018, 1, 1));
+        Team team2 = new Team();
+        team2.setUri("teamLoginsOnlyEndDate2");
+        team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
+        teamRepository.save(asList(team1, team2));
+
+        mockMvc.perform(get("/api/admin/metrics/team/logins?end=2018-02-02")
+                .header("Authorization", getBasicAuthToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.is(1)));
+    }
+
+    @Test
+    public void whenGettingTeamLogins_providingAStartAndEndDate_getsAllBetweenThem() throws Exception {
+        Team team1 = new Team();
+        team1.setUri("teamLoginStartAndEndDate1");
+        team1.setName("teamLoginStartAndEndDate1");
+        team1.setLastLoginDate(LocalDate.of(2018, 1, 1));
+        Team team2 = new Team();
+        team2.setUri("teamLoginStartAndEndDate2");
+        team2.setName("teamLoginStartAndEndDate2");
+        team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
+        Team team3 = new Team();
+        team3.setUri("teamLoginStartAndEndDate3");
+        team3.setName("teamLoginStartAndEndDate3");
+        team3.setLastLoginDate(LocalDate.of(2018, 5, 5));
+        teamRepository.save(asList(team1, team2, team3));
+
+        mockMvc.perform(get("/api/admin/metrics/team/logins?start=2018-02-02&end=2018-04-04")
+                .header("Authorization", getBasicAuthToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.is(1)));
+    }
+
     private String getToken(String adminUsername, String adminPassword) {
         return Base64.getEncoder().encodeToString((adminUsername + ":"+ adminPassword).getBytes());
     }

--- a/api/src/apiTest/java/com/ford/labs/retroquest/api/MetricsApiTest.java
+++ b/api/src/apiTest/java/com/ford/labs/retroquest/api/MetricsApiTest.java
@@ -4,17 +4,20 @@ import com.ford.labs.retroquest.feedback.Feedback;
 import com.ford.labs.retroquest.feedback.FeedbackRepository;
 import com.ford.labs.retroquest.team.Team;
 import com.ford.labs.retroquest.team.TeamRepository;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.time.LocalDateTime;
 import java.util.Base64;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class MetricsApiTest extends ControllerTest {
@@ -57,6 +60,7 @@ public class MetricsApiTest extends ControllerTest {
     public void canGetFeedbackCount() throws Exception {
 
         Feedback feedback = new Feedback();
+        feedback.setDateCreated(LocalDateTime.now());
         feedbackRepository.save(feedback);
 
         MvcResult result = mockMvc.perform(get("/api/admin/metrics/feedback/count")
@@ -128,6 +132,59 @@ public class MetricsApiTest extends ControllerTest {
     public void cannotGetAverageRatingWithoutAuthorization() throws Exception {
         mockMvc.perform(get("/api/admin/metrics/feedback/average"))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void whenGettingTheTotalNumberofReviews_providingOnlyAStartDate_getsAllFromThatDateUntilNow() throws Exception {
+
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(1995, 5, 8, 1, 1));
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(1996, 2, 13, 1, 1));
+
+        feedbackRepository.save(asList(feedback1, feedback2));
+
+        mockMvc.perform(get("/api/admin/metrics/feedback/count?start=1996-01-01")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", getBasicAuthToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.is(1)));
+    }
+
+    @Test
+    public void whenGettingTheTotalNumberofReviews_providingOnlyAnEndDate_getsAllFromNowToThatDate() throws Exception {
+
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(1995, 5, 8, 1, 1));
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(1996, 2, 13, 1, 1));
+
+        feedbackRepository.save(asList(feedback1, feedback2));
+
+        mockMvc.perform(get("/api/admin/metrics/feedback/count?end=1996-01-01")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", getBasicAuthToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.is(1)));
+    }
+
+    @Test
+    public void whenGettingTheTotalNumberofReviews_providingOnlyStartAndEndDate_getsAllBetweenThoseDates() throws Exception {
+
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(2018, 4, 1, 1, 1));
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(2018, 10, 31, 1, 1));
+        Feedback feedback3 = new Feedback();
+        feedback3.setDateCreated(LocalDateTime.of(2018, 12, 25, 1, 1));
+
+        feedbackRepository.save(asList(feedback1, feedback2, feedback3));
+
+        mockMvc.perform(get("/api/admin/metrics/feedback/count?start=2018-05-01&end=2018-12-31")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", getBasicAuthToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.is(2)));
     }
 
     private String getToken(String adminUsername, String adminPassword) {

--- a/api/src/apiTest/java/com/ford/labs/retroquest/api/TeamRetroDownloadTest.java
+++ b/api/src/apiTest/java/com/ford/labs/retroquest/api/TeamRetroDownloadTest.java
@@ -1,18 +1,12 @@
 package com.ford.labs.retroquest.api;
 
-import com.ford.labs.retroquest.MainApplication;
 import com.ford.labs.retroquest.security.JwtBuilder;
 import com.ford.labs.retroquest.team.LoginRequest;
 import com.ford.labs.retroquest.team.TeamRepository;
 import org.junit.After;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.Assert.assertEquals;

--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.transaction.Transactional;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.LocalDate;
 import java.util.List;
 
 @RestController

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/AdminFeedbackController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/AdminFeedbackController.java
@@ -18,11 +18,10 @@
 package com.ford.labs.retroquest.feedback;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 
 @RestController

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/Feedback.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/Feedback.java
@@ -18,7 +18,6 @@
 package com.ford.labs.retroquest.feedback;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -46,10 +45,5 @@ public class Feedback {
 
     @JsonFormat(pattern = "MM/dd/yy hh:mm:ss.SSS")
     private LocalDateTime dateCreated;
-
-    @PrePersist
-    void setDateCreated() {
-        dateCreated = LocalDateTime.now();
-    }
 
 }

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/feedback")
@@ -38,6 +39,7 @@ public class FeedbackController {
 
     @PostMapping
     public ResponseEntity saveFeedback(@RequestBody Feedback feedback) throws URISyntaxException {
+        feedback.setDateCreated(LocalDateTime.now());
         Feedback savedFeedback = feedbackRepository.save(feedback);
         return ResponseEntity.created(new URI("/api/feedback/" + savedFeedback.getId())).build();
     }

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
@@ -6,8 +6,12 @@ import com.ford.labs.retroquest.team.TeamRepository;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.OptionalDouble;
+
+import static java.util.stream.Collectors.toList;
 
 @ManagedResource
 public class Metrics {
@@ -27,6 +31,16 @@ public class Metrics {
     @ManagedAttribute
     public int getFeedbackCount() {
         return feedbackRepository.findAll().size();
+    }
+
+    int getFeedbackCount(LocalDate startTime, LocalDate endTime) {
+        LocalDateTime finalEndTime = endTime == null ? LocalDateTime.now() : endTime.atStartOfDay();
+        LocalDateTime finalStartTime = startTime == null ? LocalDateTime.MIN : startTime.atStartOfDay();
+        List<Feedback> feedbackList =  feedbackRepository.findAll().stream()
+                .filter(feedback -> !feedback.getDateCreated().isBefore(finalStartTime))
+                .filter(feedback -> !feedback.getDateCreated().isAfter(finalEndTime))
+                .collect(toList());
+        return feedbackList.size();
     }
 
     @ManagedAttribute

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
@@ -28,6 +28,15 @@ public class Metrics {
         return teamRepository.findAll().size();
     }
 
+    public int getTeamCount(LocalDate startDate, LocalDate endDate) {
+        LocalDate finalStartTime = startDate == null ? LocalDate.MIN : startDate;
+        LocalDate finalEndTime = endDate == null ? LocalDate.now() : endDate;
+        return teamRepository.findAll().stream()
+                .filter(team -> !team.getDateCreated().isBefore(finalStartTime))
+                .filter(team -> !team.getDateCreated().isAfter(finalEndTime))
+                .collect(toList()).size();
+    }
+
     @ManagedAttribute
     public int getFeedbackCount() {
         return feedbackRepository.findAll().size();

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
@@ -49,4 +49,15 @@ public class Metrics {
         OptionalDouble average = allFeedback.stream().mapToDouble(Feedback::getStars).average();
         return average.isPresent() ? average.getAsDouble() : 0.0;
     }
+
+    double getAverageRating(LocalDate startTime, LocalDate endTime) {
+        LocalDateTime finalEndTime = endTime == null ? LocalDateTime.now() : endTime.atStartOfDay();
+        LocalDateTime finalStartTime = startTime == null ? LocalDateTime.MIN : startTime.atStartOfDay();
+        return feedbackRepository.findAllByStarsIsGreaterThanEqual(1).stream()
+                .filter(feedback -> !feedback.getDateCreated().isBefore(finalStartTime))
+                .filter(feedback -> !feedback.getDateCreated().isAfter(finalEndTime))
+                .mapToInt(Feedback::getStars)
+                .average()
+                .orElse(0);
+    }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
@@ -69,4 +69,13 @@ public class Metrics {
                 .average()
                 .orElse(0);
     }
+
+    public int getTeamLogins(LocalDate startDate, LocalDate endDate) {
+        LocalDate finalEndDate = endDate == null ? LocalDate.now() : endDate;
+        LocalDate finalStartDate = startDate == null ? LocalDate.MIN : startDate;
+        return teamRepository.findAll().stream()
+                .filter(team -> !team.getLastLoginDate().isBefore(finalStartDate))
+                .filter(team -> !team.getLastLoginDate().isAfter(finalEndDate))
+                .collect(toList()).size();
+    }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
@@ -1,8 +1,12 @@
 package com.ford.labs.retroquest.metrics;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/admin/metrics")
@@ -20,8 +24,15 @@ public class MetricsController {
     }
 
     @GetMapping("/feedback/count")
-    public int getFeedbackCount() {
-        return metrics.getFeedbackCount();
+    public int getFeedbackCount(
+            @RequestParam(name = "start", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate startDate,
+            @RequestParam(name = "end", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate endDate
+    ) {
+        return metrics.getFeedbackCount(startDate, endDate);
     }
 
     @GetMapping("/feedback/average")

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
@@ -19,8 +19,15 @@ public class MetricsController {
     }
 
     @GetMapping("/team/count")
-    public int getTeamCount() {
-        return metrics.getTeamCount();
+    public int getTeamCount(
+            @RequestParam(name = "start", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate startDate,
+            @RequestParam(name = "end", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate endDate
+    ) {
+        return metrics.getTeamCount(startDate, endDate);
     }
 
     @GetMapping("/feedback/count")

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
@@ -53,4 +53,16 @@ public class MetricsController {
     ) {
         return metrics.getAverageRating(startDate, endDate);
     }
+
+    @GetMapping("/team/logins")
+    public int getLogins(
+            @RequestParam(name = "start", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate startDate,
+            @RequestParam(name = "end", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate endDate
+    ) {
+        return metrics.getTeamLogins(startDate, endDate);
+    }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
@@ -36,7 +36,14 @@ public class MetricsController {
     }
 
     @GetMapping("/feedback/average")
-    public double getAverageRating() {
+    public double getAverageRating(
+            @RequestParam(name = "start", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate startDate,
+            @RequestParam(name = "end", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                    LocalDate endDate
+    ) {
         return metrics.getAverageRating();
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
@@ -51,6 +51,6 @@ public class MetricsController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
                     LocalDate endDate
     ) {
-        return metrics.getAverageRating();
+        return metrics.getAverageRating(startDate, endDate);
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/Team.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/Team.java
@@ -62,9 +62,4 @@ public class Team implements Persistable<String> {
     public boolean isNew() {
         return uri != null;
     }
-
-    @PrePersist
-    void setDateCreated() {
-        dateCreated = LocalDate.now();
-    }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/Team.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/Team.java
@@ -46,6 +46,9 @@ public class Team implements Persistable<String> {
 
     private Integer failedAttempts;
 
+    @JsonIgnore
+    private LocalDate lastLoginDate;
+
     Team(String uri, String name, String password) {
         this.uri = uri;
         this.name = name;

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
@@ -28,6 +28,7 @@ import com.ford.labs.retroquest.thought.ThoughtRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -69,6 +70,7 @@ public class TeamService {
         Team teamEntity = new Team();
         teamEntity.setName(requestedName);
         teamEntity.setUri(convertTeamNameToURI(requestedName));
+        teamEntity.setDateCreated(LocalDate.now());
 
         String encryptedPassword = passwordEncoder.encode(createTeamRequest.getPassword());
         teamEntity.setPassword(encryptedPassword);

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
@@ -108,6 +108,8 @@ public class TeamService {
             throw new PasswordInvalidException();
         }
 
+        savedTeam.setLastLoginDate(LocalDate.now());
+        teamRepository.save(savedTeam);
         updateFailedAttempts(savedTeam, 0);
         return savedTeam;
     }

--- a/api/src/main/java/com/ford/labs/retroquest/team/validation/CaptchaValidator.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/validation/CaptchaValidator.java
@@ -18,7 +18,9 @@
 package com.ford.labs.retroquest.team.validation;
 
 import com.ford.labs.retroquest.exception.CaptchaInvalidException;
-import com.ford.labs.retroquest.team.*;
+import com.ford.labs.retroquest.team.CaptchaService;
+import com.ford.labs.retroquest.team.LoginRequest;
+import com.ford.labs.retroquest.team.TeamRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;

--- a/api/src/main/resources/db/h2/V001__create_action_item_table.sql
+++ b/api/src/main/resources/db/h2/V001__create_action_item_table.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS `team` (
   `name` varchar(255) DEFAULT NULL,
   `password` varchar(255) DEFAULT NULL,
   `failed_attempts` int,
+  `last_login_date` varbinary,
   PRIMARY KEY (`uri`)
 );
 

--- a/api/src/main/resources/db/migration/V009__add_last_logged_in_date.sql
+++ b/api/src/main/resources/db/migration/V009__add_last_logged_in_date.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `team`
+ADD `last_login_date` tinyblob

--- a/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
@@ -169,4 +169,39 @@ public class MetricsTest {
 
         assertEquals(1.0, metrics.getAverageRating(null, LocalDate.of(2018, 4, 4)), .001);
     }
+
+    @Test
+    public void returnsOnlyLoginsBeforeEndDate_whenOnlyGivenEndDate() {
+        Team team1 = new Team();
+        team1.setLastLoginDate(LocalDate.of(2018, 1, 1));
+        Team team2 = new Team();
+        team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
+        when(mockTeamRepository.findAll()).thenReturn(asList(team1, team2));
+
+        assertEquals(1, metrics.getTeamLogins(null, LocalDate.of(2018, 2, 2)));
+    }
+
+    @Test
+    public void returnsOnlyLoginsAfterStart_whenOnlyGivenStartDate() {
+        Team team1 = new Team();
+        team1.setLastLoginDate(LocalDate.of(2018, 1, 1));
+        Team team2 = new Team();
+        team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
+        when(mockTeamRepository.findAll()).thenReturn(asList(team1, team2));
+
+        assertEquals(1, metrics.getTeamLogins(LocalDate.of(2018, 2, 2), null));
+    }
+
+    @Test
+    public void returnsOnlyLoginsBetweenDates_whenGivenStartAndEndDate() {
+        Team team1 = new Team();
+        team1.setLastLoginDate(LocalDate.of(2018, 1, 1));
+        Team team2 = new Team();
+        team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
+        Team team3 = new Team();
+        team3.setLastLoginDate(LocalDate.of(2018, 5, 5));
+        when(mockTeamRepository.findAll()).thenReturn(asList(team1, team2, team3));
+
+        assertEquals(1, metrics.getTeamLogins(LocalDate.of(2018, 2, 2), LocalDate.of(2018, 4, 4)));
+    }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
@@ -38,6 +38,38 @@ public class MetricsTest {
     }
 
     @Test
+    public void returnsTheTotalNumberOfTeams_whenGivenOnlyAStartDate() {
+        Team team1 = new Team();
+        team1.setDateCreated(LocalDate.of(2018, 1, 1));
+        Team team2 = new Team();
+        team2.setDateCreated(LocalDate.of(2018, 3, 3));
+        when(mockTeamRepository.findAll()).thenReturn(asList(team1, team2));
+        assertEquals(1, metrics.getTeamCount(LocalDate.of(2018, 2, 2), null));
+    }
+
+    @Test
+    public void returnsTheTotalNumberOfTeams_whenGivenOnlyAnEndDate() {
+        Team team1 = new Team();
+        team1.setDateCreated(LocalDate.of(2018, 1, 1));
+        Team team2 = new Team();
+        team2.setDateCreated(LocalDate.of(2018, 3, 3));
+        when(mockTeamRepository.findAll()).thenReturn(asList(team1, team2));
+        assertEquals(1, metrics.getTeamCount(null, LocalDate.of(2018, 2, 2)));
+    }
+
+    @Test
+    public void returnsTheTotalNumberOfTeams_whenGivenBothAStartAndEndDate() {
+        Team team1 = new Team();
+        team1.setDateCreated(LocalDate.of(2018, 1, 1));
+        Team team2 = new Team();
+        team2.setDateCreated(LocalDate.of(2018, 3, 3));
+        Team team3 = new Team();
+        team3.setDateCreated(LocalDate.of(2018, 5, 5));
+        when(mockTeamRepository.findAll()).thenReturn(asList(team1, team2, team3));
+        assertEquals(1, metrics.getTeamCount(LocalDate.of(2018, 2, 2), LocalDate.of(2018, 4, 4)));
+    }
+
+    @Test
     public void returnsTheFeedbackCount() {
         when(mockFeedbackRepository.findAll()).thenReturn(asList(new Feedback(), new Feedback()));
         assertEquals(2, metrics.getFeedbackCount());

--- a/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
@@ -72,7 +72,7 @@ public class MetricsTest {
     }
 
     @Test
-    public void returnsAppropraiteFeedbackCount_whenGivenAStartAndEndDate() {
+    public void returnsAppropriateFeedbackCount_whenGivenAStartAndEndDate() {
 
         Feedback feedback1 = new Feedback();
         feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
@@ -86,7 +86,7 @@ public class MetricsTest {
     }
 
     @Test
-    public void returnsAppropriatFeedbackCount_whenOnlyGivenAndEndDate() {
+    public void returnsAppropriateFeedbackCount_whenOnlyGivenAndEndDate() {
         Feedback feedback1 = new Feedback();
         feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
         Feedback feedback2 = new Feedback();
@@ -94,5 +94,47 @@ public class MetricsTest {
         when(mockFeedbackRepository.findAll()).thenReturn(asList(feedback1, feedback2));
 
         assertEquals(1, metrics.getFeedbackCount(null, LocalDate.of(2018, 2, 2)));
+    }
+
+    @Test
+    public void returnsAppropriateFeedbackAverage_whenOnlyGivenAStartTime() {
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
+        feedback1.setStars(1);
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
+        feedback2.setStars(1);
+        when(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).thenReturn(asList(feedback1, feedback2));
+
+        assertEquals(1.0, metrics.getAverageRating(LocalDate.of(2018, 1, 1), null), .001);
+    }
+
+    @Test
+    public void returnsAppropriateFeedbackAverage_whenOnlyGivenBothAStartAndEndTime() {
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
+        feedback1.setStars(1);
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
+        feedback2.setStars(1);
+        Feedback feedback3 = new Feedback();
+        feedback3.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
+        feedback3.setStars(1);
+        when(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).thenReturn(asList(feedback1, feedback2));
+
+        assertEquals(1.0, metrics.getAverageRating(LocalDate.of(2018, 2, 2), LocalDate.of(2018, 4, 4)), .001);
+    }
+
+    @Test
+    public void returnsAppropriateFeedbackAverage_whenOnlyGivenAnEndTime() {
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
+        feedback1.setStars(1);
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
+        feedback2.setStars(1);
+        when(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).thenReturn(asList(feedback1, feedback2));
+
+        assertEquals(1.0, metrics.getAverageRating(null, LocalDate.of(2018, 4, 4)), .001);
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
@@ -10,9 +10,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.Arrays;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -31,13 +33,13 @@ public class MetricsTest {
 
     @Test
     public void returnsTheTotalNumberOfTeamsCreated() {
-        when(mockTeamRepository.findAll()).thenReturn(Arrays.asList(new Team(), new Team()));
+        when(mockTeamRepository.findAll()).thenReturn(asList(new Team(), new Team()));
         assertEquals(2, metrics.getTeamCount());
     }
 
     @Test
     public void returnsTheFeedbackCount() {
-        when(mockFeedbackRepository.findAll()).thenReturn(Arrays.asList(new Feedback(), new Feedback()));
+        when(mockFeedbackRepository.findAll()).thenReturn(asList(new Feedback(), new Feedback()));
         assertEquals(2, metrics.getFeedbackCount());
     }
 
@@ -48,7 +50,7 @@ public class MetricsTest {
         Feedback threeStarFeedback = new Feedback();
         threeStarFeedback.setStars(3);
 
-        when(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).thenReturn(Arrays.asList(twoStarFeeback, threeStarFeedback));
+        when(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).thenReturn(asList(twoStarFeeback, threeStarFeedback));
         assertEquals(2.5, metrics.getAverageRating(), 0);
     }
 
@@ -56,5 +58,41 @@ public class MetricsTest {
     public void returnsZeroWhenNoFeedbackIsPresent() {
         when(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).thenReturn(Collections.emptyList());
         assertEquals(0.0, metrics.getAverageRating(), 0);
+    }
+
+    @Test
+    public void returnsAppropriateFeedbackCount_whenOnlyStartDateIsProvided() {
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3 ,3, 3));
+        when(mockFeedbackRepository.findAll()).thenReturn(asList(feedback1, feedback2));
+
+        assertEquals(1, metrics.getFeedbackCount(LocalDate.of(2018, 2, 2), null));
+    }
+
+    @Test
+    public void returnsAppropraiteFeedbackCount_whenGivenAStartAndEndDate() {
+
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
+        Feedback feedback3 = new Feedback();
+        feedback3.setDateCreated(LocalDateTime.of(2018, 5, 5, 5, 5));
+        when(mockFeedbackRepository.findAll()).thenReturn(asList(feedback1, feedback2));
+
+        assertEquals(1, metrics.getFeedbackCount(LocalDate.of(2018, 2, 2), LocalDate.of(2018, 4, 4)));
+    }
+
+    @Test
+    public void returnsAppropriatFeedbackCount_whenOnlyGivenAndEndDate() {
+        Feedback feedback1 = new Feedback();
+        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
+        Feedback feedback2 = new Feedback();
+        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3 ,3, 3));
+        when(mockFeedbackRepository.findAll()).thenReturn(asList(feedback1, feedback2));
+
+        assertEquals(1, metrics.getFeedbackCount(null, LocalDate.of(2018, 2, 2)));
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/team/TeamServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/team/TeamServiceTest.java
@@ -218,4 +218,23 @@ public class TeamServiceTest {
 
         assertEquals(uri, actualTeam.getUri());
     }
+
+    @Test
+    public void loggingInUpdatesLastLoginDateOfTeam() {
+
+        Team savedTeam = new Team();
+        savedTeam.setName("Name");
+        savedTeam.setPassword("Password");
+        when(teamRepository.findTeamByName(savedTeam.getName())).thenReturn(Optional.of(savedTeam));
+
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setName("Name");
+        loginRequest.setPassword("Password");
+        when(passwordEncoder.matches(loginRequest.getPassword(), savedTeam.getPassword())).thenReturn(true);
+
+        teamService.login(loginRequest);
+
+        assertTrue(savedTeam.getLastLoginDate().isEqual(LocalDate.now()));
+        verify(teamRepository, times(2)).save(savedTeam);
+    }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/team/TeamServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/team/TeamServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -66,14 +67,14 @@ public class TeamServiceTest {
         savedEntity.setUri("a-name");
         savedEntity.setName("A name");
         savedEntity.setPassword("encryptedPassword");
-        savedEntity.setDateCreated();
+        savedEntity.setDateCreated(LocalDate.now());
 
         CreateTeamRequest requestedTeam = new CreateTeamRequest();
         requestedTeam.setName("A name");
         requestedTeam.setPassword("password");
 
         when(passwordEncoder.encode("password")).thenReturn("encryptedPassword");
-        when(this.teamRepository.save(expectedSaveEntity)).thenReturn(savedEntity);
+        when(this.teamRepository.save(any(Team.class))).then(returnsFirstArg());
 
         Team actualTeam = teamService.createNewTeam(requestedTeam);
 

--- a/ui/src/app/modules/teams/components/header/header.component.scss
+++ b/ui/src/app/modules/teams/components/header/header.component.scss
@@ -19,7 +19,6 @@
 
 #header {
   background-color: $clouds;
-  box-shadow: 0 1px 2px opacity($black, .1);
   box-sizing: border-box;
   color: $button-blue;
   font-weight: normal;

--- a/ui/src/app/modules/teams/components/header/header.component.scss
+++ b/ui/src/app/modules/teams/components/header/header.component.scss
@@ -19,6 +19,7 @@
 
 #header {
   background-color: $clouds;
+  box-shadow: 0 1px 2px opacity($black, .1);
   box-sizing: border-box;
   color: $button-blue;
   font-weight: normal;


### PR DESCRIPTION
## Overview
This pull requests builds out the available set of metrics by allowing the user to define time frames that confine queries, as well as introduces login activity metrics. These are outlines in #69. Basically, for all metrics endpoints, it adds the `start` and `end` query parameters. Adding the `start` parameter will exclude all entities occurring before that date, and the `end` parameter will exclude all entities occurring after that date. Excluding `start` will default to the beginning of time (or as close to it as Java will allow), and excluding `end` will default to the moment the request is processed. 

### Demo
##### Team Count
For example, if there were teams created on 1/1/2018, 3/3/2018, and 5/5/208:
`/api/admin/metrics/team/count?start=2018-04-04` **returns 1**
`/api/admin/metrics/team/count?end=2018-02-02` **returns 1**
`/api/admin/metrics/team/count?start=2018-02-02&end2018-04-04` **returns 1**

##### Feedback Count
For example, if there was feedback created on 1/1/2018, 3/3/2018, and 5/5/208:
`/api/admin/metrics/feedback/count?start=2018-04-04` **returns 1**
`/api/admin/metrics/feedback/count?end=2018-02-02` **returns 1**
`/api/admin/metrics/feedback/count?start=2018-02-02&end2018-04-04` **returns 1**

##### Feedback Average
For example, if there was feedback created on 1/1/2018 (with a rating of 2), 3/3/2018 (with a rating of 3), and 5/5/208 (with a rating of 4):
`/api/admin/metrics/feedback/average?start=2018-04-04` **returns 4.0**
`/api/admin/metrics/feedback/average?end=2018-02-02` **returns 2.0**
`/api/admin/metrics/feedback/average?start=2018-02-02&end2018-04-04` **returns 3.0**

##### Team Count
For example, if there were teams with last login dates on 1/1/2018, 3/3/2018, and 5/5/208:
`/api/admin/metrics/team/logins?start=2018-04-04` **returns 1**
`/api/admin/metrics/team/logins?end=2018-02-02` **returns 1**
`/api/admin/metrics/team/logins?start=2018-02-02&end2018-04-04` **returns 1**