### PR TITLE
Fixes team name on mobile overflowing

### DIFF
--- a/ui/src/app/modules/teams/components/header/header.component.html
+++ b/ui/src/app/modules/teams/components/header/header.component.html
@@ -23,7 +23,7 @@
         <img src="/assets/RetroQuest.png" title="RetroQuest Logo" id="logo"/>
       </a>
       <div class="horizontal-separator"></div>
-      <span id="teamName">{{teamName}}</span>
+      <div id="teamName">{{teamName}}</div>
     </div>
   </div>
 

--- a/ui/src/app/modules/teams/components/header/header.component.scss
+++ b/ui/src/app/modules/teams/components/header/header.component.scss
@@ -90,8 +90,11 @@
 
       #teamName {
         color: opacity($wet-asphalt, .8);
+        flex: 1;
         font-size: 1.5rem;
         margin-left: 24px;
+        overflow: hidden;
+        text-overflow: ellipsis;
 
         @media only screen and (max-width: 610px) {
           font-size: 1rem;


### PR DESCRIPTION
## Overview
Makes it so on mobile devices, the team name will have ellipsis if the text overflows

### Demo
![image](https://user-images.githubusercontent.com/6293337/44495515-301a1900-a63e-11e8-81cf-74a057485546.png)
