### PR TITLE
Reduces feedback dialog on mobile

### DIFF
--- a/ui/src/app/modules/controls/feedback-dialog/feedback-dialog.component.scss
+++ b/ui/src/app/modules/controls/feedback-dialog/feedback-dialog.component.scss
@@ -56,6 +56,7 @@
 
     @media only screen and (max-width: 610px) {
       margin: $border-width;
+      padding: 12px 6px;
       transform: none;
       width: calc(100% - 16px);
     }
@@ -151,6 +152,12 @@
           padding: 12px;
           resize: none;
           width: 100%;
+
+          @media only screen and (max-width: 610px) {
+            font-size: 1rem;
+            height: 85px;
+            margin-top: 6px;
+          }
         }
       }
 
@@ -175,6 +182,11 @@
           outline: none;
           padding: 0 0 3px;
           width: 100%;
+
+          @media only screen and (max-width: 610px) {
+            font-size: 1rem;
+            margin-top: 6px;
+          }
         }
       }
 
@@ -193,7 +205,7 @@
 
       @media only screen and (max-width: 610px) {
         height: 50px;
-        margin-top: 24px;
+        margin-top: 12px;
         padding-bottom: 0;
         padding-top: 0;
       }


### PR DESCRIPTION
## Overview
The feedback modal needs to have its padding reduced on mobile because on my IPhone SE, it doesn't fit all the way without it.
