### PR TITLE
Team logins fix

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
@@ -74,6 +74,7 @@ public class Metrics {
         LocalDate finalEndDate = endDate == null ? LocalDate.now() : endDate;
         LocalDate finalStartDate = startDate == null ? LocalDate.MIN : startDate;
         return teamRepository.findAll().stream()
+                .filter(team -> team.getLastLoginDate() != null)
                 .filter(team -> !team.getLastLoginDate().isBefore(finalStartDate))
                 .filter(team -> !team.getLastLoginDate().isAfter(finalEndDate))
                 .collect(toList()).size();

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
@@ -72,11 +72,7 @@ public class Metrics {
 
     public int getTeamLogins(LocalDate startDate, LocalDate endDate) {
         LocalDate finalEndDate = endDate == null ? LocalDate.now() : endDate;
-        LocalDate finalStartDate = startDate == null ? LocalDate.MIN : startDate;
-        return teamRepository.findAll().stream()
-                .filter(team -> team.getLastLoginDate() != null)
-                .filter(team -> !team.getLastLoginDate().isBefore(finalStartDate))
-                .filter(team -> !team.getLastLoginDate().isAfter(finalEndDate))
-                .collect(toList()).size();
+        LocalDate finalStartDate = startDate == null ? LocalDate.of(1900, 1, 1) : startDate;
+        return teamRepository.findAllByLastLoginDateBetween(finalStartDate, finalEndDate).size();
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
@@ -20,10 +20,13 @@ package com.ford.labs.retroquest.team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, String> {
     Optional<Team> findTeamByName(String name);
     Optional<Team> findTeamByUri(String uri);
+    List<Team> findAllByLastLoginDateAfterAndLastLoginDateBefore(LocalDate start, LocalDate end);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
@@ -28,5 +28,5 @@ import java.util.Optional;
 public interface TeamRepository extends JpaRepository<Team, String> {
     Optional<Team> findTeamByName(String name);
     Optional<Team> findTeamByUri(String uri);
-    List<Team> findAllByLastLoginDateAfterAndLastLoginDateBefore(LocalDate start, LocalDate end);
+    List<Team> findAllByLastLoginDateBetween(LocalDate start, LocalDate end);
 }

--- a/api/src/main/resources/application-h2.properties
+++ b/api/src/main/resources/application-h2.properties
@@ -26,3 +26,6 @@ spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
 
 flyway.locations=db/h2
+
+com.retroquest.adminUsername=admin
+com.retroquest.adminPassword=password

--- a/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
@@ -16,6 +16,8 @@ import java.util.Collections;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -171,44 +173,14 @@ public class MetricsTest {
     }
 
     @Test
-    public void returnsOnlyLoginsBeforeEndDate_whenOnlyGivenEndDate() {
-        Team team1 = new Team();
-        team1.setLastLoginDate(LocalDate.of(2018, 1, 1));
-        Team team2 = new Team();
-        team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
-        when(mockTeamRepository.findAll()).thenReturn(asList(team1, team2));
-
-        assertEquals(1, metrics.getTeamLogins(null, LocalDate.of(2018, 2, 2)));
+    public void nullStartDate_becomesDefaultStatDate() {
+        metrics.getTeamLogins(null, LocalDate.of(2018, 1, 1));
+        verify(mockTeamRepository).findAllByLastLoginDateBetween(LocalDate.of(1900, 1, 1), LocalDate.of(2018, 1, 1));
     }
 
     @Test
-    public void returnsOnlyLoginsAfterStart_whenOnlyGivenStartDate() {
-        Team team1 = new Team();
-        team1.setLastLoginDate(LocalDate.of(2018, 1, 1));
-        Team team2 = new Team();
-        team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
-        when(mockTeamRepository.findAll()).thenReturn(asList(team1, team2));
-
-        assertEquals(1, metrics.getTeamLogins(LocalDate.of(2018, 2, 2), null));
-    }
-
-    @Test
-    public void returnsOnlyLoginsBetweenDates_whenGivenStartAndEndDate() {
-        Team team1 = new Team();
-        team1.setLastLoginDate(LocalDate.of(2018, 1, 1));
-        Team team2 = new Team();
-        team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
-        Team team3 = new Team();
-        team3.setLastLoginDate(LocalDate.of(2018, 5, 5));
-        when(mockTeamRepository.findAll()).thenReturn(asList(team1, team2, team3));
-
-        assertEquals(1, metrics.getTeamLogins(LocalDate.of(2018, 2, 2), LocalDate.of(2018, 4, 4)));
-    }
-
-    @Test
-    public void doesntReturnTeamsWithNoLoginDates() {
-        Team team1 = new Team();
-        when(mockTeamRepository.findAll()).thenReturn(asList(team1));
-        assertEquals(0, metrics.getTeamLogins(null, null));
+    public void nullEndDate_becomesDefaulEndDate() {
+        metrics.getTeamLogins(LocalDate.of(2018, 1, 1), null);
+        verify(mockTeamRepository).findAllByLastLoginDateBetween(LocalDate.of(2018, 1, 1), LocalDate.now());
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/metrics/MetricsTest.java
@@ -204,4 +204,11 @@ public class MetricsTest {
 
         assertEquals(1, metrics.getTeamLogins(LocalDate.of(2018, 2, 2), LocalDate.of(2018, 4, 4)));
     }
+
+    @Test
+    public void doesntReturnTeamsWithNoLoginDates() {
+        Team team1 = new Team();
+        when(mockTeamRepository.findAll()).thenReturn(asList(team1));
+        assertEquals(0, metrics.getTeamLogins(null, null));
+    }
 }


### PR DESCRIPTION
## Overview
Handles cases when getting the team login counts for a team that has never logged in by ignoring them int he count.

Connects #126 