### PR TITLE
Increases the task and action item dialog size to 1.65 scale

### DIFF
--- a/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.scss
+++ b/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.scss
@@ -48,12 +48,16 @@
     font-size: 1rem;
 
     height: auto;
-    transform: scale(1.3);
+    transform: scale(1.65);
 
     width: 450px;
 
     &:hover {
       box-shadow: $action-shadow;
+    }
+
+    @media only screen and (max-width: 770px) {
+      transform: scale(1.3);
     }
 
     @media only screen and (max-width: 610px) {

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
@@ -53,8 +53,12 @@
     font-size: 1rem;
     height: auto;
 
-    transform: scale(1.3);
+    transform: scale(1.65);
     width: 450px;
+
+    @media only screen and (max-width: 770px) {
+      transform: scale(1.3);
+    }
 
     @media only screen and (max-width: 610px) {
       height: 280px;


### PR DESCRIPTION
## Overview
Increases the size of the task and action item dialog. The original property on the dialog was the scale it 1.3x when you clicked on it. This change increases this size the 1.65x because of having issues with reading this during out last retro.

This is just css changes.

### Demo
The demo sizes don't do it justice, you'd have to see it yourself.

Old size:
![image](https://user-images.githubusercontent.com/6293337/44760096-57c02400-ab0b-11e8-8b60-1f4f7852950a.png)

New size:
![image](https://user-images.githubusercontent.com/6293337/44760086-424afa00-ab0b-11e8-85fd-7016fbe1978f.png)
