### PR TITLE
Esc closes header

### DIFF
--- a/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.spec.ts
+++ b/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.spec.ts
@@ -64,6 +64,9 @@ describe('ActionItemDialogComponent', () => {
       expect(component.visible).toBeTruthy();
     });
 
+    it('should set a function callback to document.onkeydown', () => {
+      expect(document.onkeydown).not.toBeNull();
+    });
   });
 
   describe('emitDeleted', () => {
@@ -90,6 +93,11 @@ describe('ActionItemDialogComponent', () => {
 
       expect(component.visible).toEqual(false);
       expect(component.visibilityChanged.emit).toHaveBeenCalledWith(false);
+    });
+
+    it('should set the document.onkeydown callback to null', () => {
+      component.emitDeleted();
+      expect(document.onkeydown).toBeNull();
     });
 
   });

--- a/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.ts
+++ b/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.ts
@@ -18,6 +18,8 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {ActionItem, emptyActionItem} from '../../domain/action-item';
 
+const ESC_KEY = 27;
+
 @Component({
   selector: 'rq-action-item-dialog',
   templateUrl: './action-item-dialog.component.html',
@@ -42,10 +44,16 @@ export class ActionItemDialogComponent {
   private hide(): void {
     this.visible = false;
     this.visibilityChanged.emit(this.visible);
+    document.onkeydown = null;
   }
 
   public show(): void {
     this.visible = true;
+    document.onkeydown = event => {
+      if (event.keyCode === ESC_KEY) {
+        this.hide();
+      }
+    };
   }
 
   public emitDeleted(): void {

--- a/ui/src/app/modules/controls/column-header/column-header.component.html
+++ b/ui/src/app/modules/controls/column-header/column-header.component.html
@@ -19,9 +19,10 @@
   #inputField
   [readonly]="readOnlyEnabled"
   [maxlength]="maxTextLength"
-  [(ngModel)]="title"
+  [(ngModel)]="titleCopy"
   (blur)="emitTitleChangedAndEnableReadonlyMode()"
   (keydown.enter)="blurInput()"
+  (keydown.escape)="onEscapeKeyPressed()"
   [ngClass]="{'hide': readOnlyEnabled}"
 />
 
@@ -52,7 +53,7 @@
 </span>
 
 <rq-floating-character-countdown
-  [characterCount]="readOnlyEnabled ? 0 : title.length"
+  [characterCount]="readOnlyEnabled ? 0 : titleCopy.length"
   [maxCharacterCount]="maxTextLength"
   [charsAreRunningOutThreshold]="5"
 >

--- a/ui/src/app/modules/controls/column-header/column-header.component.spec.ts
+++ b/ui/src/app/modules/controls/column-header/column-header.component.spec.ts
@@ -52,9 +52,15 @@ describe('ColumnHeaderComponent', () => {
 
   describe('emitTitleChangedAndEnableReadonlyMode', () => {
 
+    const fakeText = 'MODIFIED TEXT';
+
+    beforeEach(() => {
+      component.escapeKeyPressed = false;
+      component.titleCopy = fakeText;
+    });
+
     it('should emit the modified title', () => {
       component.titleChanged = jasmine.createSpyObj({emit: null});
-      component.title = 'MODIFIED TEXT';
 
       component.emitTitleChangedAndEnableReadonlyMode();
 
@@ -73,6 +79,29 @@ describe('ColumnHeaderComponent', () => {
       component.emitTitleChangedAndEnableReadonlyMode();
 
       expect(component.readOnlyEnabled).toBeTruthy();
+    });
+
+    it('should copy the value of temp title into the title variable ' +
+      'if the escape key was not pressed', () => {
+      component.emitTitleChangedAndEnableReadonlyMode();
+
+      expect(component.title).toEqual(fakeText);
+    });
+
+    it('should not copy the value of temp title into the title variable' +
+      'if the escape key was pressed', () => {
+      component.escapeKeyPressed = true;
+      component.emitTitleChangedAndEnableReadonlyMode();
+
+      expect(component.title).toEqual('');
+    });
+
+    it('should set the temp title to empty string' +
+      'if the escape key was pressed', () => {
+      component.escapeKeyPressed = true;
+      component.emitTitleChangedAndEnableReadonlyMode();
+
+      expect(component.titleCopy).toEqual('');
     });
   });
 
@@ -129,6 +158,36 @@ describe('ColumnHeaderComponent', () => {
 
     it('should blur the input field', () => {
       component.blurInput();
+      expect(component.inputFieldRef.nativeElement.blur).toHaveBeenCalled();
+    });
+  });
+
+  describe('onEscapeKeyPressed', () => {
+
+    let originalSetTimeoutFunction = null;
+    const mockInputFieldRef = {
+      nativeElement: jasmine.createSpyObj({blur: null})
+    };
+
+    beforeEach(() => {
+      component.inputFieldRef = mockInputFieldRef;
+      originalSetTimeoutFunction = window.setTimeout;
+      window.setTimeout = (fn) => fn();
+
+      component.escapeKeyPressed = false;
+      component.onEscapeKeyPressed();
+    });
+
+    afterEach(() => {
+      window.setTimeout = originalSetTimeoutFunction;
+      mockInputFieldRef.nativeElement.blur.calls.reset();
+    });
+
+    it('should set the escape key was pressed flag to true', () => {
+      expect(component.escapeKeyPressed).toBeTruthy();
+    });
+
+    it('should blur the input field', () => {
       expect(component.inputFieldRef.nativeElement.blur).toHaveBeenCalled();
     });
   });

--- a/ui/src/app/modules/controls/column-header/column-header.component.ts
+++ b/ui/src/app/modules/controls/column-header/column-header.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {Component, ElementRef, EventEmitter, Input, Output, ViewChild} from '@angular/core';
+import {Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
 import {Column} from '../../domain/column';
 
 @Component({
@@ -29,7 +29,7 @@ import {Column} from '../../domain/column';
     '[class.action]': 'type === \'action\''
   }
 })
-export class ColumnHeaderComponent {
+export class ColumnHeaderComponent implements OnInit {
 
   @Input() title = '';
   @Input() type = '';
@@ -42,15 +42,23 @@ export class ColumnHeaderComponent {
 
   @ViewChild('inputField') inputFieldRef: ElementRef;
 
+  titleCopy: string;
   readOnlyEnabled = true;
   sorted = false;
   maxTextLength = 16;
+  escapeKeyPressed = false;
 
-  constructor () {
+  public ngOnInit() {
+    this.titleCopy = this.title.slice(0);
   }
 
   public emitTitleChangedAndEnableReadonlyMode(): void {
-    this.titleChanged.emit(this.title);
+    if (this.escapeKeyPressed) {
+      this.titleCopy = '';
+    } else {
+      this.title = this.titleCopy.slice(0);
+      this.titleChanged.emit(this.titleCopy);
+    }
     this.readOnlyEnabled = true;
   }
 
@@ -75,7 +83,10 @@ export class ColumnHeaderComponent {
     setTimeout(() => {
       this.inputFieldRef.nativeElement.blur();
     }, 0);
-
   }
 
+  public onEscapeKeyPressed(): void {
+    this.escapeKeyPressed = true;
+    this.blurInput();
+  }
 }

--- a/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.spec.ts
+++ b/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.spec.ts
@@ -45,5 +45,20 @@ describe('EndRetroDialogComponent', () => {
       expect(component.visible).toBeFalsy();
     });
 
+    it('should set the document.onkeydown callback to null', () => {
+      expect(document.onkeydown).toBeNull();
+    });
+
+  });
+
+  describe('show', () => {
+
+    beforeEach(() => {
+      component.show();
+    });
+
+    it('should set a function callback to document.onkeydown', () => {
+      expect(document.onkeydown).not.toBeNull();
+    });
   });
 });

--- a/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.ts
+++ b/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.ts
@@ -18,6 +18,8 @@
 import {Component, EventEmitter, Input, Output, ViewChild} from '@angular/core';
 import {ThoughtService} from '../../teams/services/thought.service';
 
+const ESC_KEY = 27;
+
 @Component({
   selector: 'rq-end-retro-dialog',
   templateUrl: './end-retro-dialog.component.html',
@@ -38,10 +40,16 @@ export class EndRetroDialogComponent {
 
   public hide(): void {
     this.visible = false;
+    document.onkeydown = null;
   }
 
   public show(): void {
     this.visible = true;
+    document.onkeydown = event => {
+      if (event.keyCode === ESC_KEY) {
+        this.hide();
+      }
+    };
   }
 
   public submit(): void {

--- a/ui/src/app/modules/controls/feedback-dialog/feedback-dialog.component.spec.ts
+++ b/ui/src/app/modules/controls/feedback-dialog/feedback-dialog.component.spec.ts
@@ -34,6 +34,10 @@ describe('DialogComponent', () => {
       component.show();
       expect(component.visible).toBeTruthy();
     });
+
+    it('should set a function callback to document.onkeydown', () => {
+      expect(document.onkeydown).not.toBeNull();
+    });
   });
 
   describe('hide', () => {
@@ -52,6 +56,11 @@ describe('DialogComponent', () => {
     it('should emit the visibility changed signal', () => {
       expect(component.visibilityChanged.emit).toHaveBeenCalled();
     });
+
+    it('should set the document.onkeydown callback to null', () => {
+      expect(document.onkeydown).toBeNull();
+    });
+
   });
 
   describe('onStarClicked', () => {

--- a/ui/src/app/modules/controls/feedback-dialog/feedback-dialog.component.ts
+++ b/ui/src/app/modules/controls/feedback-dialog/feedback-dialog.component.ts
@@ -18,6 +18,8 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {emptyFeedback, Feedback} from '../../domain/feedback';
 
+const ESC_KEY = 27;
+
 @Component({
   selector: 'rq-feedback-dialog',
   templateUrl: './feedback-dialog.component.html',
@@ -44,10 +46,16 @@ export class FeedbackDialogComponent {
     this.feedback = emptyFeedback();
     this.starsClicked = false;
     this.clearStars();
+    document.onkeydown = null;
   }
 
   public show(): void {
     this.visible = true;
+    document.onkeydown = event => {
+      if (event.keyCode === ESC_KEY) {
+        this.hide();
+      }
+    };
   }
 
   public onSendButtonClicked(): void {

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.spec.ts
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.spec.ts
@@ -63,6 +63,17 @@ describe('TaskDialogComponent', () => {
       expect(component.visible).toBeTruthy();
     });
 
+    it('should set a function callback to document.onkeydown', () => {
+      expect(document.onkeydown).not.toBeNull();
+    });
+
+  });
+
+  describe('hide', () => {
+    it('should set the document.onkeydown callback to null', () => {
+      component.hide();
+      expect(document.onkeydown).toBeNull();
+    });
   });
 
   describe('emitDeleted', () => {

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.ts
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.ts
@@ -18,6 +18,8 @@
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 import {emptyThought, Thought} from '../../domain/thought';
 
+const ESC_KEY = 27;
+
 @Component({
   selector: 'rq-task-dialog',
   templateUrl: './task-dialog.component.html',
@@ -43,10 +45,16 @@ export class TaskDialogComponent {
   public hide(): void {
     this.visible = false;
     this.visibilityChanged.emit(this.visible);
+    document.onkeydown = null;
   }
 
   public show(): void {
     this.visible = true;
+    document.onkeydown = event => {
+      if (event.keyCode === ESC_KEY) {
+        this.hide();
+      }
+    };
   }
 
   public emitDeleted(): void {


### PR DESCRIPTION
## Overview
Pressing the ESC key while changing the column header title keeps the original title and switches back to the read only mode.

Fixes issue #62