### PR TITLE
Puts a min height on action items.

### DIFF
--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -75,6 +75,7 @@
     flex: 1;
     flex-direction: column;
     font-size: inherit;
+    min-height: 102px;
     position: relative;
     word-break: break-word;
     word-wrap: break-word;


### PR DESCRIPTION
## Overview
This fixes issue #105. It adds in a minimum height on action items so that height auto will only be used to obtain a higher height.

### Demo
![capture](https://user-images.githubusercontent.com/6293337/45007340-555a4000-afcb-11e8-91e5-2bcd3f14328b.PNG)
