### PR TITLE
Radiator view uses unsorted and noncompleted action items.

### DIFF
--- a/ui/src/app/modules/teams/pages/team/team.page.html
+++ b/ui/src/app/modules/teams/pages/team/team.page.html
@@ -25,7 +25,7 @@
   </rq-header>
 
   <rq-actions-radiator-view
-    [actionItems]="actionItems"
+    [actionItems]="unsortedAndUncompletedActionItems"
     [visible]="actionsRadiatorViewIsSelected()"
   >
   </rq-actions-radiator-view>

--- a/ui/src/app/modules/teams/pages/team/team.page.spec.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.spec.ts
@@ -369,7 +369,14 @@ describe('TeamPageComponent', () => {
 
       expect(component.actionItems.length).toEqual(1);
 
-      const updatedActionItem = {'id': 1, 'task': 'hi phil', 'completed': false, 'teamId': 'test', 'assignee': '', state: 'active'};
+      const updatedActionItem = {
+        'id': 1,
+        'task': 'hi phil',
+        'completed': false,
+        'teamId': 'test',
+        'assignee': '',
+        state: 'active'
+      };
       actionItemTopic.next({bodyJson: {type: 'put', payload: updatedActionItem}});
 
       expect(component.actionItems.length).toEqual(1);
@@ -531,6 +538,18 @@ describe('TeamPageComponent', () => {
       component.onActionItemsSortChanged(true);
       component.onActionItemsSortChanged(false);
       expect(component.actionItemsAreSorted).toBeFalsy();
+    });
+  });
+
+  describe('unsortedAndUncompletedActionItems', () => {
+
+    beforeEach(() => {
+      component.actionItems = [emptyActionItem(), emptyActionItem(), emptyActionItem()];
+      component.actionItems[1].completed = true;
+    });
+
+    it('should return the list of action items that are unsorted and not completed', () => {
+      expect(component.unsortedAndUncompletedActionItems.length).toEqual(2);
     });
   });
 });

--- a/ui/src/app/modules/teams/pages/team/team.page.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.ts
@@ -128,6 +128,10 @@ export class TeamPageComponent implements OnInit {
     return thoughtsInColumn;
   }
 
+  get unsortedAndUncompletedActionItems(): Array<ActionItem> {
+    return this.actionItems.filter((actionItem) => !actionItem.completed);
+  }
+
   public resetThoughts(): void {
     this.thoughtsArray.splice(0, this.thoughtsArray.length);
   }


### PR DESCRIPTION
Signed-off-by: Lee Lazarecky <llazarec@ford.com>

## Overview
The action item radiator view now will only use uncompleted action items and have them unsorted