### PR TITLE
Delete confirmation

### DIFF
--- a/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.html
+++ b/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.html
@@ -16,6 +16,7 @@
   -->
 
 <rq-action-item-task
+  [enableOverlayBorder]="true"
   [actionItem]="actionItem"
   (click)="$event.stopPropagation()"
   (completed)="emitCompleted($event)"

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
@@ -15,6 +15,14 @@
   ~ limitations under the License.
   -->
 
+<rq-deletion-overlay
+  *ngIf="deleteWasToggled"
+  (declineButtonClicked)="deleteWasToggled = false"
+  (acceptButtonClicked)="emitDeleteItem()"
+  (blur)="onDeleteConfirmationBlur()"
+  heading="Delete this Action Item?"
+></rq-deletion-overlay>
+
 <div class="content-area"
      [ngClass]="{'disable': actionItem.completed}"
 >

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -30,9 +30,9 @@
   font-weight: bold;
   height: 75px;
   justify-content: flex-end;
+  position: relative;
   transition: box-shadow .2s cubic-bezier(.25, .8, .25, 1);
   width: 100px;
-  position: relative;
 
   &.dialog-overlay-border {
     rq-deletion-overlay {

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -34,6 +34,14 @@
   width: 100px;
   position: relative;
 
+  &.dialog-overlay-border {
+    rq-deletion-overlay {
+      $border-width: 8px;
+
+      box-shadow: 0 0 0 $border-width $unhappy-red;
+    }
+  }
+
   &.push-order-to-bottom {
     box-shadow: none;
     order: 99;

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -32,6 +32,7 @@
   justify-content: flex-end;
   transition: box-shadow .2s cubic-bezier(.25, .8, .25, 1);
   width: 100px;
+  position: relative;
 
   &.push-order-to-bottom {
     box-shadow: none;

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.spec.ts
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.spec.ts
@@ -111,14 +111,28 @@ describe('ThoughtComponent', () => {
 
   describe('emitDeleteItem', () => {
 
-    it('should emit the actionItem to be deleted', () => {
+    it('should emit the actionItem to be deleted if the deletion flag is set to true', () => {
       component.deleted = jasmine.createSpyObj({emit: null});
 
       component.actionItem = emptyActionItem();
       component.actionItem.task = 'FAKE TASK';
+      component.deleteWasToggled = true;
+
       component.emitDeleteItem();
 
       expect(component.deleted.emit).toHaveBeenCalledWith(component.actionItem);
+    });
+
+    it('should not emit the actionItem to be deleted if the deletion flag is set to false', () => {
+      component.deleted = jasmine.createSpyObj({emit: null});
+
+      component.actionItem = emptyActionItem();
+      component.actionItem.task = 'FAKE TASK';
+      component.deleteWasToggled = false;
+
+      component.emitDeleteItem();
+
+      expect(component.deleted.emit).not.toHaveBeenCalledWith(component.actionItem);
     });
 
   });

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.ts
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.ts
@@ -48,8 +48,13 @@ export class ActionItemTaskComponent {
   taskEditModeEnabled = false;
   maxMessageLength = 255;
   _textValueLength = 0;
+  deleteWasToggled = false;
 
   constructor() {
+  }
+
+  public onDeleteConfirmationBlur(): void {
+    this.toggleDeleteConfirmation();
   }
 
   public toggleEditMode(): void {
@@ -62,7 +67,10 @@ export class ActionItemTaskComponent {
   }
 
   public emitDeleteItem(): void {
-    this.deleted.emit(this.actionItem);
+    this.toggleDeleteConfirmation();
+    if (!this.deleteWasToggled) {
+      this.deleted.emit(this.actionItem);
+    }
   }
 
   public emitTaskContentClicked(): void {
@@ -139,6 +147,10 @@ export class ActionItemTaskComponent {
 
   get textValueLength(): number {
     return this._textValueLength;
+  }
+
+  public toggleDeleteConfirmation(): void {
+    this.deleteWasToggled = !this.deleteWasToggled;
   }
 }
 

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.ts
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.ts
@@ -28,13 +28,15 @@ const DELETE_KEY = 46;
   styleUrls: ['./action-item-task.component.scss'],
   host: {
     '[class.push-order-to-bottom]': 'actionItem.completed',
-    '[class.edit-mode]': 'taskEditModeEnabled'
+    '[class.edit-mode]': 'taskEditModeEnabled',
+    '[class.dialog-overlay-border]': 'enableOverlayBorder'
   }
 })
 export class ActionItemTaskComponent {
 
   @Input() actionItem = emptyActionItem();
   @Input() readOnly = false;
+  @Input() enableOverlayBorder = false;
 
   @Output() messageChanged: EventEmitter<string> = new EventEmitter<string>();
   @Output() deleted: EventEmitter<ActionItem> = new EventEmitter<ActionItem>();

--- a/ui/src/app/modules/controls/controls.module.ts
+++ b/ui/src/app/modules/controls/controls.module.ts
@@ -34,6 +34,7 @@ import {ActionItemDialogComponent} from './action-item-dialog/action-item-dialog
 import {EndRetroDialogComponent} from './end-retro-dialog/end-retro-dialog.component';
 import {FeedbackDialogComponent} from './feedback-dialog/feedback-dialog.component';
 import {ActionsRadiatorViewComponent} from './actions-radiator-view/actions-radiator-view.component';
+import { DeletionOverlayComponent } from './deletion-overlay/deletion-overlay.component';
 
 @NgModule({
   imports: [
@@ -58,7 +59,8 @@ import {ActionsRadiatorViewComponent} from './actions-radiator-view/actions-radi
     ActionItemDialogComponent,
     EndRetroDialogComponent,
     FeedbackDialogComponent,
-    ActionsRadiatorViewComponent
+    ActionsRadiatorViewComponent,
+    DeletionOverlayComponent
   ],
 
   exports: [
@@ -76,7 +78,8 @@ import {ActionsRadiatorViewComponent} from './actions-radiator-view/actions-radi
     ActionItemDialogComponent,
     EndRetroDialogComponent,
     FeedbackDialogComponent,
-    ActionsRadiatorViewComponent
+    ActionsRadiatorViewComponent,
+    DeletionOverlayComponent
   ]
 
 })

--- a/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.html
+++ b/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.html
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright (c) 2018 Ford Motor Company
+  ~ All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<input
+  #hiddenDeleteInput
+  class="hidden-input"
+  (blur)="emitBlur()"
+>
+
+<div class="heading">
+  <div>{{heading}}</div>
+</div>
+<div class="button-container">
+  <rq-button
+    class="delete-decline-button"
+    type="secondary"
+    text="no"
+    (click)="emitDeclineButtonClicked()"
+  ></rq-button>
+  <rq-button
+    class="delete-accept-button"
+    type="primary"
+    text="yes"
+    (mousedown)="$event.preventDefault()"
+    (click)="emitAcceptButtonClicked(); hiddenDeleteInput.blur()"
+  ></rq-button>
+</div>

--- a/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.scss
+++ b/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.scss
@@ -18,28 +18,28 @@
 @import 'color-vars';
 
 :host {
-  box-sizing: border-box;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 20;
   background-color: opacity($white, .98);
   border-radius: 6px;
+  bottom: 0;
   box-shadow: 0 0 0 4px $unhappy-red;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100%;
+  z-index: 20;
 
   .hidden-input {
-    border: none;
-    padding: 0;
+    border: 0;
+    height: 0;
     margin: 0;
     opacity: 0;
+    padding: 0;
     pointer-events: none;
-    height: 0;
     width: 0;
   }
 
@@ -47,28 +47,28 @@
     align-items: center;
     box-sizing: border-box;
     display: flex;
+    flex: 1;
     font-size: 1rem;
     justify-content: center;
     min-height: 40px;
-    flex: 1;
   }
 
   .button-container {
     align-items: center;
+    border-top: 2px solid opacity($wet-asphalt, .06);
     display: flex;
     height: 40px;
     justify-content: center;
-    border-top: 2px solid opacity($wet-asphalt, .06);
 
     rq-button {
+      border-radius: 0;
       flex: 1;
       font-size: 1rem;
       height: 100%;
-      border-radius: 0;
 
       &.delete-decline-button {
-        box-sizing: border-box;
         border-right: 2px solid opacity($wet-asphalt, .06);
+        box-sizing: border-box;
 
         &:hover {
           color: $wet-asphalt;
@@ -77,8 +77,8 @@
 
       &.delete-accept-button {
         background-color: transparent;
+        border-radius: 0 0 6px;
         box-shadow: none;
-        border-radius: 0 0 6px 0;
         color: $unhappy-red;
       }
     }

--- a/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.scss
+++ b/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.scss
@@ -1,0 +1,87 @@
+/*!
+ * Copyright (c) 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import 'color-vars';
+
+:host {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 20;
+  background-color: opacity($white, .98);
+  border-radius: 6px;
+  box-shadow: 0 0 0 4px $unhappy-red;
+  display: flex;
+  flex-direction: column;
+
+  .hidden-input {
+    border: none;
+    padding: 0;
+    margin: 0;
+    opacity: 0;
+    pointer-events: none;
+    height: 0;
+    width: 0;
+  }
+
+  .heading {
+    align-items: center;
+    box-sizing: border-box;
+    display: flex;
+    font-size: 1rem;
+    justify-content: center;
+    min-height: 40px;
+    flex: 1;
+  }
+
+  .button-container {
+    align-items: center;
+    display: flex;
+    height: 40px;
+    justify-content: center;
+    border-top: 2px solid opacity($wet-asphalt, .06);
+
+    rq-button {
+      flex: 1;
+      font-size: 1rem;
+      height: 100%;
+      border-radius: 0;
+
+      &.delete-decline-button {
+        box-sizing: border-box;
+        border-right: 2px solid opacity($wet-asphalt, .06);
+
+        &:hover {
+          color: $wet-asphalt;
+        }
+      }
+
+      &.delete-accept-button {
+        background-color: transparent;
+        box-shadow: none;
+        border-radius: 0 0 6px 0;
+        color: $unhappy-red;
+      }
+    }
+
+  }
+}

--- a/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.spec.ts
+++ b/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.spec.ts
@@ -27,4 +27,46 @@ describe('DeletionOverlayComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('emitAcceptButtonClicked', () => {
+
+    beforeEach(() => {
+      component.acceptButtonClicked = jasmine.createSpyObj({
+        emit: null
+      });
+      component.emitAcceptButtonClicked();
+    });
+
+    it('should emit the accept button clicked signal', () => {
+      expect(component.acceptButtonClicked.emit).toHaveBeenCalled();
+    });
+  });
+
+  describe('emitDeclineButtonClicked', () => {
+
+    beforeEach(() => {
+      component.declineButtonClicked = jasmine.createSpyObj({
+        emit: null
+      });
+      component.emitDeclineButtonClicked();
+    });
+
+    it('should emit the accept button clicked signal', () => {
+      expect(component.declineButtonClicked.emit).toHaveBeenCalled();
+    });
+  });
+
+  describe('emitBlur', () => {
+
+    beforeEach(() => {
+      component.blur = jasmine.createSpyObj({
+        emit: null
+      });
+      component.emitBlur();
+    });
+
+    it('should emit the accept button clicked signal', () => {
+      expect(component.blur.emit).toHaveBeenCalled();
+    });
+  });
 });

--- a/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.spec.ts
+++ b/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.spec.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DeletionOverlayComponent } from './deletion-overlay.component';
+
+describe('DeletionOverlayComponent', () => {
+  let component: DeletionOverlayComponent;
+
+  beforeEach(() => {
+    component = new DeletionOverlayComponent();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.ts
+++ b/ui/src/app/modules/controls/deletion-overlay/deletion-overlay.component.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, EventEmitter } from '@angular/core';
+import {ViewChild} from '@angular/core';
+import {ElementRef} from '@angular/core';
+import {Output, Input} from '@angular/core';
+import {OnInit} from '@angular/core';
+
+@Component({
+  selector: 'rq-deletion-overlay',
+  templateUrl: './deletion-overlay.component.html',
+  styleUrls: ['./deletion-overlay.component.scss']
+})
+export class DeletionOverlayComponent implements OnInit {
+
+  @Input() heading = '';
+
+  @Output() acceptButtonClicked: EventEmitter<void> = new EventEmitter<void>();
+  @Output() declineButtonClicked: EventEmitter<void> = new EventEmitter<void>();
+  @Output() blur: EventEmitter<void> = new EventEmitter<void>();
+
+  @ViewChild('hiddenDeleteInput') hiddenDeleteInput: ElementRef;
+
+  public ngOnInit(): void {
+    setTimeout(() => {
+      this.hiddenDeleteInput.nativeElement.focus();
+    }, 0);
+  }
+
+  emitAcceptButtonClicked() {
+    this.acceptButtonClicked.emit();
+  }
+
+  emitDeclineButtonClicked() {
+    this.declineButtonClicked.emit();
+  }
+
+  emitBlur() {
+    this.blur.emit();
+  }
+
+}

--- a/ui/src/app/modules/controls/style-guide-page/style-guide-page.component.html
+++ b/ui/src/app/modules/controls/style-guide-page/style-guide-page.component.html
@@ -106,7 +106,7 @@
         [task]="{
         completed: false,
         hearts: 3,
-        message: 'I am sad because it is who I am!'
+        message: 'Hello World!'
       }"
       ></rq-task>
     </div>

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.html
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.html
@@ -16,6 +16,7 @@
   -->
 
 <rq-task
+  [enableOverlayBorder]="true"
   [type]="type"
   [task]="task"
   (click)="$event.stopPropagation()"

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
@@ -68,10 +68,6 @@
       width: calc(100% - 16px);
     }
 
-    rq-deletion-overlay {
-      background-color: pink;
-    }
-
     &.happy {
       box-shadow: $happy-shadow;
 

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
@@ -68,6 +68,10 @@
       width: calc(100% - 16px);
     }
 
+    rq-deletion-overlay {
+      background-color: pink;
+    }
+
     &.happy {
       box-shadow: $happy-shadow;
 

--- a/ui/src/app/modules/controls/task/task.component.html
+++ b/ui/src/app/modules/controls/task/task.component.html
@@ -15,38 +15,13 @@
   ~ limitations under the License.
   -->
 
-<div
-  class="delete-confirmation"
+<rq-deletion-overlay
   *ngIf="deleteWasToggled"
-  (focusout)="onDeleteConfirmationBlur($event)"
->
-
-  <input
-    #hiddenDeleteInput
-    class="hidden-input"
-    (blur)="onDeleteConfirmationBlur($event)"
-  >
-
-  <div class="heading">
-    <div>Delete this thought?</div>
-  </div>
-  <div class="button-container">
-    <rq-button
-      class="delete-decline-button"
-      type="secondary"
-      text="no"
-      (click)="deleteWasToggled = false;"
-    ></rq-button>
-    <rq-button
-      class="delete-accept-button"
-      type="primary"
-      text="yes"
-      (mousedown)="$event.preventDefault()"
-      (click)="emitDeleteItem(); hiddenDeleteInput.blur()"
-    ></rq-button>
-  </div>
-
-</div>
+  (declineButtonClicked)="deleteWasToggled = false"
+  (acceptButtonClicked)="emitDeleteItem()"
+  (blur)="onDeleteConfirmationBlur()"
+  heading="Delete this thought?"
+></rq-deletion-overlay>
 
 <div class="content-area"
      (click)="emitTaskContentClicked()"

--- a/ui/src/app/modules/controls/task/task.component.html
+++ b/ui/src/app/modules/controls/task/task.component.html
@@ -17,14 +17,14 @@
 
 <div class="content-area"
      (click)="emitTaskContentClicked()"
-     [ngClass]="{'disable': task.discussed}"
 >
   <span
     class="content-message"
-    *ngIf="!taskEditModeEnabled; else content_textarea"
+    [ngClass]="{'disable': task.discussed || deleteWasToggled}"
+    *ngIf="!taskEditModeEnabled && !deleteWasToggled"
   >{{task.message}}</span>
 
-  <ng-template #content_textarea>
+  <div *ngIf="taskEditModeEnabled">
     <div
       #content_value
       class="content-message editable-div"
@@ -43,7 +43,30 @@
     >
     </rq-floating-character-countdown>
 
-  </ng-template>
+  </div>
+
+  <div
+    class="delete-confirmation"
+    *ngIf="deleteWasToggled"
+  >
+    <div class="heading">
+      <div>Delete this thought?</div>
+    </div>
+    <div class="button-container">
+      <rq-button
+        class="delete-decline-button"
+        type="secondary"
+        text="no"
+        (click)="deleteWasToggled = false; $event.stopPropagation()"
+      ></rq-button>
+      <rq-button
+        class="delete-accept-button"
+        type="primary"
+        text="yes"
+        (click)="emitDeleteItem(); $event.stopPropagation()"
+      ></rq-button>
+    </div>
+  </div>
 
 
 </div>
@@ -51,14 +74,20 @@
 <div class="footer">
   <div
     class="container star-count-container"
-    [ngClass]="{'disable': task.discussed || taskEditModeEnabled}"
     (click)="addStar()"
     *ngIf="type !== 'action'; else date_created_container"
   >
-    <div class="star-background">
+    <div
+      class="star-background"
+      [ngClass]="{'disable': task.discussed || taskEditModeEnabled || deleteWasToggled}"
+    >
       <i class="fas fa-star star-icon"></i>
     </div>
-    <div class="star-count">{{task.hearts}}</div>
+    <div
+      class="star-count"
+      [ngClass]="{'disable': task.discussed || taskEditModeEnabled || deleteWasToggled}"
+    >{{task.hearts}}
+    </div>
   </div>
 
   <ng-template #date_created_container>
@@ -69,11 +98,13 @@
   </ng-template>
   <div
     class="container edit-container"
-    [ngClass]="{'disable': task.discussed || taskEditModeEnabled}"
     (click)="toggleEditMode()"
     *ngIf="!taskEditModeEnabled; else exit_edit_mode_icon"
   >
-    <i class="fas fa-edit"></i>
+    <i
+      class="fas fa-edit"
+      [ngClass]="{'disable': task.discussed || taskEditModeEnabled || deleteWasToggled}"
+    ></i>
   </div>
 
   <ng-template #exit_edit_mode_icon>
@@ -87,14 +118,16 @@
 
   <div
     class="container delete-container"
-    [ngClass]="{'disable': task.discussed || taskEditModeEnabled}"
-    (click)="emitDeleteItem()">
-    <i class="fas fa-trash-alt"></i>
+    (click)="toggleDeleteConfirmation()">
+    <i
+      class="fas fa-trash-alt"
+      [ngClass]="{'disable': task.discussed || taskEditModeEnabled}"
+    ></i>
   </div>
 
   <div
     class="complete-container"
-    [ngClass]="{'disable': taskEditModeEnabled}"
+    [ngClass]="{'disable': taskEditModeEnabled || deleteWasToggled}"
     (click)="toggleTaskComplete()"
   >
     <div

--- a/ui/src/app/modules/controls/task/task.component.html
+++ b/ui/src/app/modules/controls/task/task.component.html
@@ -15,13 +15,46 @@
   ~ limitations under the License.
   -->
 
+<div
+  class="delete-confirmation"
+  *ngIf="deleteWasToggled"
+  (focusout)="onDeleteConfirmationBlur($event)"
+>
+
+  <input
+    #hiddenDeleteInput
+    class="hidden-input"
+    (blur)="onDeleteConfirmationBlur($event)"
+  >
+
+  <div class="heading">
+    <div>Delete this thought?</div>
+  </div>
+  <div class="button-container">
+    <rq-button
+      class="delete-decline-button"
+      type="secondary"
+      text="no"
+      (click)="deleteWasToggled = false;"
+    ></rq-button>
+    <rq-button
+      class="delete-accept-button"
+      type="primary"
+      text="yes"
+      (mousedown)="$event.preventDefault()"
+      (click)="emitDeleteItem(); hiddenDeleteInput.blur()"
+    ></rq-button>
+  </div>
+
+</div>
+
 <div class="content-area"
      (click)="emitTaskContentClicked()"
 >
   <span
     class="content-message"
-    [ngClass]="{'disable': task.discussed || deleteWasToggled}"
-    *ngIf="!taskEditModeEnabled && !deleteWasToggled"
+    [ngClass]="{'disable': task.discussed}"
+    *ngIf="!taskEditModeEnabled"
   >{{task.message}}</span>
 
   <div *ngIf="taskEditModeEnabled">
@@ -45,49 +78,20 @@
 
   </div>
 
-  <div
-    class="delete-confirmation"
-    *ngIf="deleteWasToggled"
-  >
-    <div class="heading">
-      <div>Delete this thought?</div>
-    </div>
-    <div class="button-container">
-      <rq-button
-        class="delete-decline-button"
-        type="secondary"
-        text="no"
-        (click)="deleteWasToggled = false; $event.stopPropagation()"
-      ></rq-button>
-      <rq-button
-        class="delete-accept-button"
-        type="primary"
-        text="yes"
-        (click)="emitDeleteItem(); $event.stopPropagation()"
-      ></rq-button>
-    </div>
-  </div>
-
-
 </div>
+
 
 <div class="footer">
   <div
     class="container star-count-container"
+    [ngClass]="{'disable': task.discussed || taskEditModeEnabled}"
     (click)="addStar()"
     *ngIf="type !== 'action'; else date_created_container"
   >
-    <div
-      class="star-background"
-      [ngClass]="{'disable': task.discussed || taskEditModeEnabled || deleteWasToggled}"
-    >
+    <div class="star-background">
       <i class="fas fa-star star-icon"></i>
     </div>
-    <div
-      class="star-count"
-      [ngClass]="{'disable': task.discussed || taskEditModeEnabled || deleteWasToggled}"
-    >{{task.hearts}}
-    </div>
+    <div class="star-count">{{task.hearts}}</div>
   </div>
 
   <ng-template #date_created_container>
@@ -98,13 +102,11 @@
   </ng-template>
   <div
     class="container edit-container"
+    [ngClass]="{'disable': task.discussed || taskEditModeEnabled}"
     (click)="toggleEditMode()"
     *ngIf="!taskEditModeEnabled; else exit_edit_mode_icon"
   >
-    <i
-      class="fas fa-edit"
-      [ngClass]="{'disable': task.discussed || taskEditModeEnabled || deleteWasToggled}"
-    ></i>
+    <i class="fas fa-edit"></i>
   </div>
 
   <ng-template #exit_edit_mode_icon>
@@ -118,16 +120,14 @@
 
   <div
     class="container delete-container"
-    (click)="toggleDeleteConfirmation()">
-    <i
-      class="fas fa-trash-alt"
-      [ngClass]="{'disable': task.discussed || taskEditModeEnabled}"
-    ></i>
+    [ngClass]="{'disable': task.discussed || taskEditModeEnabled}"
+    (click)="emitDeleteItem()">
+    <i class="fas fa-trash-alt"></i>
   </div>
 
   <div
     class="complete-container"
-    [ngClass]="{'disable': taskEditModeEnabled || deleteWasToggled}"
+    [ngClass]="{'disable': taskEditModeEnabled}"
     (click)="toggleTaskComplete()"
   >
     <div
@@ -144,3 +144,4 @@
   </div>
 
 </div>
+

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -108,7 +108,7 @@
     z-index: 20;
     background-color: opacity($white, .98);
     border-radius: 6px;
-    box-shadow: 0 0 0 $host-border-width $unhappy-red;
+    box-shadow: 0 0 0 4px $unhappy-red;
     display: flex;
     flex-direction: column;
 

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -153,6 +153,48 @@
         outline: none;
       }
     }
+
+    .delete-confirmation {
+      box-sizing: border-box;
+      height: auto;
+      min-height: 40px;
+      padding: 18px;
+      width: 100%;
+
+      .heading {
+        align-items: center;
+        box-sizing: border-box;
+        display: flex;
+        font-size: .9rem;
+        justify-content: center;
+        margin-bottom: 12px;
+      }
+
+      .button-container {
+        align-items: center;
+        box-sizing: border-box;
+        display: flex;
+        height: 30px;
+        justify-content: center;
+        padding: 0 48px;
+
+        rq-button {
+          flex: 1;
+          font-size: 1rem;
+          height: 100%;
+
+          &.delete-decline-button {
+            opacity: .5;
+          }
+
+          &.delete-accept-button {
+            background-color: $unhappy-red;
+            box-shadow: none;
+          }
+        }
+
+      }
+    }
   }
 
   .footer {
@@ -182,6 +224,7 @@
     }
 
     .complete-container {
+      box-sizing: border-box;
       cursor: pointer;
       position: relative;
 

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 @import 'color-vars';
 
 :host {
@@ -94,75 +95,6 @@
     opacity: $host-opacity;
     pointer-events: none;
     user-select: none;
-  }
-
-  .delete-confirmation {
-    box-sizing: border-box;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 20;
-    background-color: opacity($white, .98);
-    border-radius: 6px;
-    box-shadow: 0 0 0 4px $unhappy-red;
-    display: flex;
-    flex-direction: column;
-
-    .hidden-input {
-      border: none;
-      padding: 0;
-      margin: 0;
-      opacity: 0;
-      pointer-events: none;
-      height: 0;
-      width: 0;
-    }
-
-    .heading {
-      align-items: center;
-      box-sizing: border-box;
-      display: flex;
-      font-size: 1rem;
-      justify-content: center;
-      min-height: 40px;
-      flex: 1;
-    }
-
-    .button-container {
-      align-items: center;
-      display: flex;
-      height: 40px;
-      justify-content: center;
-      border-top: 2px solid opacity($wet-asphalt, .06);
-
-      rq-button {
-        flex: 1;
-        font-size: 1rem;
-        height: 100%;
-        border-radius: 0;
-
-        &.delete-decline-button {
-          box-sizing: border-box;
-          border-right: 2px solid opacity($wet-asphalt, .06);
-
-          &:hover {
-            color: $wet-asphalt;
-          }
-        }
-
-        &.delete-accept-button {
-          background-color: transparent;
-          box-shadow: none;
-          border-radius: 0 0 6px 0;
-          color: $unhappy-red;
-        }
-      }
-
-    }
   }
 
   .content-area {

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -35,6 +35,16 @@
   width: 100px;
   position: relative;
 
+  &.dialog-overlay-border {
+    rq-deletion-overlay {
+      $border-width: 8px;
+
+      box-shadow: 0 0 0 $border-width $unhappy-red;
+    }
+  }
+
+
+
   &.delete-mode {
     box-shadow: none;
   }

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -30,10 +30,10 @@
   font-weight: bold;
   height: 75px;
   justify-content: flex-end;
-  transition: box-shadow .2s cubic-bezier(.25, .8, .25, 1);
-
-  width: 100px;
   position: relative;
+
+  transition: box-shadow .2s cubic-bezier(.25, .8, .25, 1);
+  width: 100px;
 
   &.dialog-overlay-border {
     rq-deletion-overlay {

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -32,6 +32,11 @@
   transition: box-shadow .2s cubic-bezier(.25, .8, .25, 1);
 
   width: 100px;
+  position: relative;
+
+  &.delete-mode {
+    box-shadow: none;
+  }
 
   &.push-order-to-bottom {
     box-shadow: none;
@@ -89,6 +94,75 @@
     opacity: $host-opacity;
     pointer-events: none;
     user-select: none;
+  }
+
+  .delete-confirmation {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 20;
+    background-color: opacity($white, .98);
+    border-radius: 6px;
+    box-shadow: 0 0 0 $host-border-width $unhappy-red;
+    display: flex;
+    flex-direction: column;
+
+    .hidden-input {
+      border: none;
+      padding: 0;
+      margin: 0;
+      opacity: 0;
+      pointer-events: none;
+      height: 0;
+      width: 0;
+    }
+
+    .heading {
+      align-items: center;
+      box-sizing: border-box;
+      display: flex;
+      font-size: 1rem;
+      justify-content: center;
+      min-height: 40px;
+      flex: 1;
+    }
+
+    .button-container {
+      align-items: center;
+      display: flex;
+      height: 40px;
+      justify-content: center;
+      border-top: 2px solid opacity($wet-asphalt, .06);
+
+      rq-button {
+        flex: 1;
+        font-size: 1rem;
+        height: 100%;
+        border-radius: 0;
+
+        &.delete-decline-button {
+          box-sizing: border-box;
+          border-right: 2px solid opacity($wet-asphalt, .06);
+
+          &:hover {
+            color: $wet-asphalt;
+          }
+        }
+
+        &.delete-accept-button {
+          background-color: transparent;
+          box-shadow: none;
+          border-radius: 0 0 6px 0;
+          color: $unhappy-red;
+        }
+      }
+
+    }
   }
 
   .content-area {
@@ -151,48 +225,6 @@
         cursor: text;
         display: inline-block;
         outline: none;
-      }
-    }
-
-    .delete-confirmation {
-      box-sizing: border-box;
-      height: auto;
-      min-height: 40px;
-      padding: 18px;
-      width: 100%;
-
-      .heading {
-        align-items: center;
-        box-sizing: border-box;
-        display: flex;
-        font-size: .9rem;
-        justify-content: center;
-        margin-bottom: 12px;
-      }
-
-      .button-container {
-        align-items: center;
-        box-sizing: border-box;
-        display: flex;
-        height: 30px;
-        justify-content: center;
-        padding: 0 48px;
-
-        rq-button {
-          flex: 1;
-          font-size: 1rem;
-          height: 100%;
-
-          &.delete-decline-button {
-            opacity: .5;
-          }
-
-          &.delete-accept-button {
-            background-color: $unhappy-red;
-            box-shadow: none;
-          }
-        }
-
       }
     }
   }

--- a/ui/src/app/modules/controls/task/task.component.spec.ts
+++ b/ui/src/app/modules/controls/task/task.component.spec.ts
@@ -134,14 +134,26 @@ describe('ThoughtComponent', () => {
 
   describe('emitDeleteItem', () => {
 
-    it('should emit the actionItem to be deleted', () => {
+    it('should emit the actionItem to be deleted is the deletion flag is set to true', () => {
       component.deleted = jasmine.createSpyObj({emit: null});
-
       component.task = emptyThought();
       component.task.hearts = 1;
+
+      component.deleteWasToggled = true;
       component.emitDeleteItem();
 
       expect(component.deleted.emit).toHaveBeenCalledWith(component.task);
+    });
+
+    it('should not emit the actionItem to be deleted is the deletion flag is set to false', () => {
+      component.deleted = jasmine.createSpyObj({emit: null});
+      component.task = emptyThought();
+      component.task.hearts = 1;
+
+      component.deleteWasToggled = false;
+      component.emitDeleteItem();
+
+      expect(component.deleted.emit).not.toHaveBeenCalledWith(component.task);
     });
 
   });

--- a/ui/src/app/modules/controls/task/task.component.spec.ts
+++ b/ui/src/app/modules/controls/task/task.component.spec.ts
@@ -273,4 +273,20 @@ describe('ThoughtComponent', () => {
       expect(component.task.message).toEqual(fakeText);
     });
   });
+
+  describe('toggleDeleteConfirmation', () => {
+    it('should set the deletion flag to true if it was false before', () => {
+      component.deleteWasToggled = false;
+      component.toggleDeleteConfirmation();
+      expect(component.deleteWasToggled).toBeTruthy();
+    });
+  });
+
+  describe('toggleDeleteConfirmation', () => {
+    it('should set the deletion flag to false if it was true before', () => {
+      component.deleteWasToggled = true;
+      component.toggleDeleteConfirmation();
+      expect(component.deleteWasToggled).toBeFalsy();
+    });
+  });
 });

--- a/ui/src/app/modules/controls/task/task.component.ts
+++ b/ui/src/app/modules/controls/task/task.component.ts
@@ -32,7 +32,8 @@ const DELETE_KEY = 46;
     '[class.happy]': 'type === \'happy\'',
     '[class.confused]': 'type === \'confused\'',
     '[class.sad]': 'type === \'unhappy\'',
-    '[class.action]': 'type === \'action\''
+    '[class.action]': 'type === \'action\'',
+    '[class.delete-mode]': 'deleteWasToggled'
   }
 })
 export class TaskComponent {
@@ -52,6 +53,7 @@ export class TaskComponent {
   maxMessageLength = 255;
   taskEditModeEnabled = false;
   _textValueLength = 0;
+  deleteWasToggled = false;
 
   constructor() {
   }
@@ -72,7 +74,10 @@ export class TaskComponent {
   }
 
   public emitDeleteItem(): void {
-    this.deleted.emit(this.task);
+    this.toggleDeleteConfirmation();
+    if (!this.deleteWasToggled) {
+      this.deleted.emit(this.task);
+    }
   }
 
   public emitTaskContentClicked(): void {
@@ -126,6 +131,10 @@ export class TaskComponent {
 
   get textValueLength(): number {
     return this._textValueLength;
+  }
+
+  public toggleDeleteConfirmation(): void {
+    this.deleteWasToggled = !this.deleteWasToggled;
   }
 }
 

--- a/ui/src/app/modules/controls/task/task.component.ts
+++ b/ui/src/app/modules/controls/task/task.component.ts
@@ -48,7 +48,6 @@ export class TaskComponent {
   @Output() completed: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   @ViewChild('content_value') editableTextArea: ElementRef;
-  @ViewChild('hiddenDeleteInput') hiddenDeleteInput: ElementRef;
 
   starCountMax = 99;
   maxMessageLength = 255;
@@ -60,7 +59,7 @@ export class TaskComponent {
   }
 
 
-  public onDeleteConfirmationBlur(event): void {
+  public onDeleteConfirmationBlur(): void {
     this.toggleDeleteConfirmation();
   }
 
@@ -83,10 +82,6 @@ export class TaskComponent {
     this.toggleDeleteConfirmation();
     if (!this.deleteWasToggled) {
       this.deleted.emit(this.task);
-    } else {
-      setTimeout(() => {
-        this.hiddenDeleteInput.nativeElement.focus();
-      }, 0);
     }
   }
 

--- a/ui/src/app/modules/controls/task/task.component.ts
+++ b/ui/src/app/modules/controls/task/task.component.ts
@@ -33,13 +33,15 @@ const DELETE_KEY = 46;
     '[class.confused]': 'type === \'confused\'',
     '[class.sad]': 'type === \'unhappy\'',
     '[class.action]': 'type === \'action\'',
-    '[class.delete-mode]': 'deleteWasToggled'
+    '[class.delete-mode]': 'deleteWasToggled',
+    '[class.dialog-overlay-border]': 'enableOverlayBorder'
   }
 })
 export class TaskComponent {
 
   @Input() type = '';
   @Input() task = emptyThought();
+  @Input() enableOverlayBorder = false;
 
   @Output() messageChanged: EventEmitter<string> = new EventEmitter<string>();
   @Output() deleted: EventEmitter<Thought> = new EventEmitter<Thought>();

--- a/ui/src/app/modules/controls/task/task.component.ts
+++ b/ui/src/app/modules/controls/task/task.component.ts
@@ -48,6 +48,7 @@ export class TaskComponent {
   @Output() completed: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   @ViewChild('content_value') editableTextArea: ElementRef;
+  @ViewChild('hiddenDeleteInput') hiddenDeleteInput: ElementRef;
 
   starCountMax = 99;
   maxMessageLength = 255;
@@ -56,6 +57,11 @@ export class TaskComponent {
   deleteWasToggled = false;
 
   constructor() {
+  }
+
+
+  public onDeleteConfirmationBlur(event): void {
+    this.toggleDeleteConfirmation();
   }
 
   public toggleEditMode(): void {
@@ -77,6 +83,10 @@ export class TaskComponent {
     this.toggleDeleteConfirmation();
     if (!this.deleteWasToggled) {
       this.deleted.emit(this.task);
+    } else {
+      setTimeout(() => {
+        this.hiddenDeleteInput.nativeElement.focus();
+      }, 0);
     }
   }
 

--- a/ui/src/app/modules/teams/components/actions-column/actions-column.component.spec.ts
+++ b/ui/src/app/modules/teams/components/actions-column/actions-column.component.spec.ts
@@ -69,24 +69,10 @@ describe('ActionsColumnComponent', () => {
 
   describe('onDeleted', () => {
 
-    it('should display a confirm dialog', () => {
-      const mockConfirm = spyOn(window, 'confirm').and.returnValue(true);
-      component.onDeleted(0);
-      expect(mockConfirm).toHaveBeenCalled();
-    });
-
-    it('should delete the action item on the backend if the user confirms the deletion', () => {
-      spyOn(window, 'confirm').and.returnValue(true);
+    it('should delete the action item on the backend', () => {
       component.onDeleted(0);
 
       expect(mockActionItemService.deleteActionItem).toHaveBeenCalledWith(component.actionItems[0]);
-    });
-
-    it('should not delete the action item on the backend if the user cancels the deletion', () => {
-      spyOn(window, 'confirm').and.returnValue(false);
-      component.onDeleted(0);
-
-      expect(mockActionItemService.deleteActionItem).not.toHaveBeenCalled();
     });
 
   });

--- a/ui/src/app/modules/teams/components/actions-column/actions-column.component.ts
+++ b/ui/src/app/modules/teams/components/actions-column/actions-column.component.ts
@@ -48,9 +48,7 @@ export class ActionsColumnComponent {
   }
 
   public onDeleted(index: number) {
-    if (confirm('Are you sure you want to delete this action item?')) {
-      this.actionItemService.deleteActionItem(this.actionItems[index]);
-    }
+    this.actionItemService.deleteActionItem(this.actionItems[index]);
   }
 
   public onMessageChanged(message: string, index: number): void {

--- a/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.ts
+++ b/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.ts
@@ -85,9 +85,7 @@ export class ThoughtsColumnComponent {
   }
 
   onDeleted(thought: Thought) {
-    if (confirm('Are you sure you want to delete this thought?')) {
-      this.thoughtService.deleteThought(thought);
-    }
+    this.thoughtService.deleteThought(thought);
   }
 
   starCountChanged(starCount: number, index: number) {


### PR DESCRIPTION
## Overview
Removes the rude window confirmation dialog when deleting an action item and instead, shows an inline deletion overlay.

### Demo
<img width="351" alt="screen shot 2018-09-14 at 2 14 41 pm" src="https://user-images.githubusercontent.com/6293337/45567661-6d7e5a80-b828-11e8-8173-c8c8110109d0.png">
<img width="860" alt="screen shot 2018-09-14 at 2 14 53 pm" src="https://user-images.githubusercontent.com/6293337/45567669-7111e180-b828-11e8-8474-b9eb6d082f91.png">

## Testing Instructions
1. Add a thought and action item.
2. Click on the trash icon.
3. See the new overlay.
4. Click Yes, No, or off of the item, it should behave as you expect.