### PR TITLE
Fixes a few minor css and event propagation issues.

### DIFF
--- a/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.scss
+++ b/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.scss
@@ -41,6 +41,7 @@
     $base-drop-shadow: 0 19px 38px opacity($black, .3);
     $border-width: 8px;
     $action-shadow: 0 0 0 $border-width $action-yellow, $base-drop-shadow;
+    $edit-mode-shadow:  0 0 0 8px $grape, $base-drop-shadow;
 
     border-radius: 6px;
     box-shadow: $action-shadow;
@@ -54,6 +55,14 @@
 
     &:hover {
       box-shadow: $action-shadow;
+    }
+
+    &.edit-mode {
+      box-shadow: $edit-mode-shadow;
+
+      &:hover {
+        box-shadow: $edit-mode-shadow;
+      }
     }
 
     @media only screen and (max-width: 770px) {

--- a/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.html
+++ b/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.html
@@ -16,7 +16,7 @@
   -->
 
 
-<div class="dialog">
+<div class="dialog" (click)="$event.stopPropagation()">
 
   <div class="content-area">Do you want to end the retro?</div>
 

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
@@ -43,10 +43,11 @@
 
     $action-shadow: 0 0 0 $border-width $action-yellow, $base-drop-shadow;
 
-
     $confused-shadow: 0 0 0 $border-width $confused-blue, $base-drop-shadow;
     $happy-shadow: 0 0 0 $border-width $happy-green, $base-drop-shadow;
     $sad-shadow: 0 0 0 $border-width $unhappy-red, $base-drop-shadow;
+
+    $edit-mode-shadow: 0 0 0 8px $grape, $base-drop-shadow;
 
     border-radius: 6px;
     box-sizing: border-box;
@@ -74,6 +75,15 @@
       &:hover {
         box-shadow: $happy-shadow;
       }
+
+      &.edit-mode {
+        box-shadow: $edit-mode-shadow;
+
+        &:hover {
+          box-shadow: $edit-mode-shadow;
+        }
+      }
+
     }
 
     &.confused {
@@ -82,6 +92,14 @@
       &:hover {
         box-shadow: $confused-shadow;
       }
+
+      &.edit-mode {
+        box-shadow: $edit-mode-shadow;
+
+        &:hover {
+          box-shadow: $edit-mode-shadow;
+        }
+      }
     }
 
     &.sad {
@@ -89,6 +107,14 @@
 
       &:hover {
         box-shadow: $sad-shadow;
+      }
+
+      &.edit-mode {
+        box-shadow: $edit-mode-shadow;
+
+        &:hover {
+          box-shadow: $edit-mode-shadow;
+        }
       }
     }
   }

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -62,6 +62,14 @@
     &:hover {
       box-shadow: 0 0 0 $host-border-width $happy-green;
     }
+
+    &.edit-mode {
+      box-shadow: 0 0 0 4px $grape;
+
+      &:hover {
+        box-shadow: 0 0 0 4px $grape;
+      }
+    }
   }
 
   &.confused {


### PR DESCRIPTION
## Overview
This PR makes it so clicking on the normal info text in the End Retro dialog does not close the dialog like before. It also makes it so the color of the border on thought dialogs and action item dialogs changes to purple when editing.

### Demo
Can't capture it without loosing focus. :|