### PR TITLE
Adds a stronger end retro dialog subheading.

### DIFF
--- a/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.html
+++ b/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.html
@@ -19,7 +19,7 @@
 <div class="dialog">
 
   <div class="content-area">
-    <div>Do you want to end the retro?</div>
+    <div class="heading">Do you want to end the retro?</div>
     <div class="sub-heading">This will delete all thoughts!</div>
   </div>
 

--- a/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.html
+++ b/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.html
@@ -18,7 +18,10 @@
 
 <div class="dialog">
 
-  <div class="content-area">Do you want to end the retro?</div>
+  <div class="content-area">
+    <div>Do you want to end the retro?</div>
+    <div class="sub-heading">This will delete all thoughts!</div>
+  </div>
 
   <div class="footer">
     <div class="container" id="cancel-button-container">

--- a/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.scss
+++ b/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.scss
@@ -67,24 +67,32 @@
     .content-area {
       $content-area-padding: 12px;
 
-      background-color: inherit;
+      align-items: center;
 
+      background-color: inherit;
       border-top-left-radius: inherit;
       border-top-right-radius: inherit;
       cursor: default;
+      display: flex;
       flex: 1;
+      flex-direction: column;
       font-size: inherit;
       font-weight: inherit;
+      justify-content: center;
       padding: 24px 48px;
       position: relative;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      flex-direction: column;
 
       .sub-heading {
-        font-size: 1rem;
         color: opacity($wet-asphalt, .5);
+        font-size: 1rem;
+      }
+
+      @media only screen and (max-width: 610px) {
+        padding: 24px;
+
+        .heading {
+          font-size: 1.1rem;
+        }
       }
     }
 

--- a/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.scss
+++ b/ui/src/app/modules/controls/end-retro-dialog/end-retro-dialog.component.scss
@@ -77,7 +77,15 @@
       font-weight: inherit;
       padding: 24px 48px;
       position: relative;
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-direction: column;
+
+      .sub-heading {
+        font-size: 1rem;
+        color: opacity($wet-asphalt, .5);
+      }
     }
 
     .footer {


### PR DESCRIPTION
## Overview
Adds in a stronger end retro dialog that is more informative as to what will happen when you click it.

Solves issue #148 

### Demo
![capture](https://user-images.githubusercontent.com/6293337/45989717-d47ee900-c04a-11e8-9d7d-5158dc917135.PNG)

![capture](https://user-images.githubusercontent.com/6293337/45989977-e4e39380-c04b-11e8-9a5d-6d0c059f2365.PNG)

## Testing Instructions
Just click the end retro button and view the new end retro dialog.