### PR TITLE
Change edit thoughts and action items to be textareas instead of divs

### DIFF
--- a/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.html
+++ b/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.html
@@ -23,5 +23,6 @@
   (deleted)="emitDeleted()"
   (messageChanged)="emitMessageChanged($event)"
   (assigneeUpdated)="emitAssigneeUpdated($event)"
+  class="dialog-task"
 >
 </rq-action-item-task>

--- a/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.scss
+++ b/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.scss
@@ -47,11 +47,12 @@
     box-shadow: $action-shadow;
     box-sizing: border-box;
     font-size: 1rem;
-
     height: auto;
+    max-height: 50%;
+    max-width: 650px;
+    overflow: hidden;
     transform: scale(1.65);
-
-    width: 450px;
+    width: 50%;
 
     &:hover {
       box-shadow: $action-shadow;

--- a/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.ts
+++ b/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.ts
@@ -45,10 +45,12 @@ export class ActionItemDialogComponent {
     this.visible = false;
     this.visibilityChanged.emit(this.visible);
     document.onkeydown = null;
+    document.body.style.overflow = null;
   }
 
   public show(): void {
     this.visible = true;
+    document.body.style.overflow = 'hidden';
     document.onkeydown = event => {
       if (event.keyCode === ESC_KEY) {
         this.hide();

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
@@ -36,16 +36,16 @@
   >{{emojifyText(actionItem.task)}}</span>
 
     <ng-template #content_textarea>
-      <div
-        #content_value
-        class="content-message editable-div"
-        contenteditable="true"
-        (keydown.enter)="updateActionItemMessage(content_value.textContent); forceBlur()"
-        (blur)="updateActionItemMessage(content_value.textContent); toggleEditMode()"
-        (keydown)="onKeyDown($event, content_value.textContent)"
-        (keyup)="onKeyUp(content_value.textContent, content_value.innerText)"
-      >{{actionItem.task}}
-      </div>
+      <textarea #content_value [ngModel]="actionItem.task"
+                class="content-message edit-input"
+                (blur)="updateActionItemMessage($event, content_value.value); toggleEditMode()"
+                (keydown.enter)="updateActionItemMessage($event, content_value.value); forceBlur()"
+                (keydown.escape)="updateActionItemMessage($event, content_value.value); forceBlur()"
+                (input)="setMessageLength(content_value.value)"
+                [maxlength]="maxMessageLength"
+                onfocus="this.style.height = '';this.style.height = this.scrollHeight + 'px'"
+                oninput="this.style.height = '';this.style.height = this.scrollHeight + 'px'"
+      ></textarea>
 
       <rq-floating-character-countdown
         [characterCount]="textValueLength"

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
@@ -58,7 +58,7 @@
   </div>
 </div>
 
-<div class="assigned-to-section" [ngClass]="{'disable': taskEditModeEnabled}">
+<div class="assigned-to-section" [ngClass]="{'disable': taskEditModeEnabled || actionItem.completed}">
   <div class="label">assigned to</div>
   <input
     [readonly]="readOnly"

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
@@ -55,31 +55,24 @@
       </rq-floating-character-countdown>
 
     </ng-template>
-
-
-  </div>
-
-  <div
-    class="assigned-to-section"
-    [ngClass]="{'disable': taskEditModeEnabled}"
-  >
-    <div class="label">assigned to</div>
-    <input
-      [readonly]="readOnly"
-      #assignee_text_field
-      class="value"
-      [type]="'text'"
-      [(ngModel)]="actionItem.assignee"
-      (blur)="emitAssigneeUpdated()"
-      (keydown.enter)="forceBlurOnAssigneeTextField()"
-    >
   </div>
 </div>
 
-<div class="footer">
-  <div
-    class="container date-created-container"
+<div class="assigned-to-section" [ngClass]="{'disable': taskEditModeEnabled}">
+  <div class="label">assigned to</div>
+  <input
+    [readonly]="readOnly"
+    #assignee_text_field
+    class="value"
+    [type]="'text'"
+    [(ngModel)]="actionItem.assignee"
+    (blur)="emitAssigneeUpdated()"
+    (keydown.enter)="forceBlurOnAssigneeTextField()"
   >
+</div>
+
+<div class="footer">
+  <div class="container date-created-container">
     <div class="date-created-header"
          [ngClass]="{'disable': actionItem.completed || taskEditModeEnabled}"
     >created

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -151,14 +151,21 @@
         height: auto;
         min-height: 40px;
         padding: 18px;
+        white-space: pre-wrap;
         width: 100%;
 
-        &.editable-div {
-          border-radius: inherit;
+        &.edit-input {
+          border: 0;
+          border-radius: 6px 6px 0 0;
           box-shadow: none;
           cursor: text;
           display: inline-block;
+          font-family: inherit;
+          font-size: inherit;
+          font-weight: inherit;
           outline: none;
+          overflow: auto;
+          resize: none;
         }
       }
     }

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -92,48 +92,6 @@
     word-break: break-word;
     word-wrap: break-word;
 
-    .assigned-to-section {
-      $label-color: #a9a9a9;
-      box-sizing: border-box;
-      margin-bottom: 12px;
-      padding: 0 18px;
-      width: 100%;
-
-      .label {
-        cursor: default;
-        font-size: .7rem;
-        opacity: .6;
-        text-transform: lowercase;
-      }
-
-      .value {
-        border: 0;
-        border-bottom: 2px solid $action-yellow;
-        color: inherit;
-        display: inline-block;
-        font-size: .8rem;
-        font-weight: bold;
-        height: 18px;
-        outline: none;
-        text-overflow: ellipsis;
-        transition: border-bottom-color .2s cubic-bezier(.25, .8, .25, 1);
-
-        width: 100%;
-
-        @media only screen and (max-width: 610px) {
-          font-size: 1rem;
-        }
-
-        &:hover {
-          border-bottom-color: $grape;
-        }
-
-        &:focus {
-          border-bottom-color: $grape;
-        }
-      }
-    }
-
     .content-container {
       flex: auto;
       position: relative;
@@ -167,6 +125,48 @@
           overflow: auto;
           resize: none;
         }
+      }
+    }
+  }
+
+  .assigned-to-section {
+    $label-color: #a9a9a9;
+    box-sizing: border-box;
+    margin-bottom: 12px;
+    padding: 0 18px;
+    width: 100%;
+
+    .label {
+      cursor: default;
+      font-size: .7rem;
+      opacity: .6;
+      text-transform: lowercase;
+    }
+
+    .value {
+      border: 0;
+      border-bottom: 2px solid $action-yellow;
+      color: inherit;
+      display: inline-block;
+      font-size: .8rem;
+      font-weight: bold;
+      height: 18px;
+      outline: none;
+      text-overflow: ellipsis;
+      transition: border-bottom-color .2s cubic-bezier(.25, .8, .25, 1);
+
+      width: 100%;
+
+      @media only screen and (max-width: 610px) {
+        font-size: 1rem;
+      }
+
+      &:hover {
+        border-bottom-color: $grape;
+      }
+
+      &:focus {
+        border-bottom-color: $grape;
       }
     }
   }
@@ -252,6 +252,20 @@
         font-size: .75rem;
         font-weight: bold;
       }
+    }
+  }
+
+  &.dialog-task {
+    .content-area {
+      overflow: auto;
+    }
+
+    .assigned-to-section {
+      margin-bottom: 54px;
+    }
+
+    .footer {
+      position: absolute;
     }
   }
 }

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.spec.ts
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.spec.ts
@@ -187,71 +187,29 @@ describe('ThoughtComponent', () => {
     });
   });
 
-  describe('onKeyDown', () => {
-    const fakeTextValue = 'XX';
-
-    it('should prevent the key event from being processed if the task has reached the max length', () => {
-      const fakeKeyEvent = jasmine.createSpyObj({
-        preventDefault: null
-      });
-      fakeKeyEvent.key = 'a';
-
-      component.maxMessageLength = 2;
-      component.onKeyDown(fakeKeyEvent, fakeTextValue);
-      expect(fakeKeyEvent.preventDefault).toHaveBeenCalled();
-    });
-
-    it('should allow the key event if the max message length has not been reached', () => {
-      const fakeKeyEvent = jasmine.createSpyObj({
-        preventDefault: null
-      });
-      fakeKeyEvent.key = 'a';
-
-      component.maxMessageLength = 3;
-      component.actionItem.task = 'XX';
-      component.onKeyDown(fakeKeyEvent, fakeTextValue);
-      expect(fakeKeyEvent.preventDefault).not.toHaveBeenCalled();
-    });
-
-    it('should allow the backspace key event even if the max length has been reached', () => {
-      const fakeBackspaceEvent = jasmine.createSpyObj({
-        preventDefault: null
-      });
-
-      fakeBackspaceEvent.keyCode = 8;
-
-      component.maxMessageLength = 2;
-      component.actionItem.task = 'XX';
-      component.onKeyDown(fakeBackspaceEvent, fakeTextValue);
-      expect(fakeBackspaceEvent.preventDefault).not.toHaveBeenCalled();
-    });
-
-    it('should allow the delete key event even if the max length has been reached', () => {
-      const fakeDeleteKeyEvent = jasmine.createSpyObj({
-        preventDefault: null,
-      });
-
-      fakeDeleteKeyEvent.keyCode = 46;
-
-      component.maxMessageLength = 2;
-      component.actionItem.task = 'XX';
-      component.onKeyDown(fakeDeleteKeyEvent, fakeTextValue);
-      expect(fakeDeleteKeyEvent.preventDefault).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('onKeyUp', () => {
-    it('should set the text value length to the min between both parameter string lengths', () => {
-      component.onKeyUp('aa', 'a');
+  describe('setMessageLength', () => {
+    it('should set the text value length to the length of the string parameter', () => {
+      component.setMessageLength('a');
       expect(component.textValueLength).toEqual(1);
     });
   });
 
   describe('updateActionItemMessage', () => {
+    const fakeText = 'HELLO I AM TEXT';
+    let fakeEvent;
+
+    beforeEach(() => {
+      fakeEvent = jasmine.createSpyObj(['preventDefault']);
+    });
+
     it('should set the action item message to the passed in string', () => {
-      const fakeText = 'HELLO I AM TEXT';
-      component.updateActionItemMessage(fakeText);
+      component.updateActionItemMessage(fakeEvent, fakeText);
       expect(component.actionItem.task).toEqual(fakeText);
+    });
+
+    it(`should prevent the default event`, () => {
+      component.updateActionItemMessage(fakeEvent, fakeText);
+      expect(fakeEvent.preventDefault).toHaveBeenCalled();
     });
   });
 });

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.ts
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.ts
@@ -20,9 +20,6 @@ import {ActionItem, emptyActionItem} from '../../domain/action-item';
 import * as moment from 'moment';
 import {emojify} from '../../utils/EmojiGenerator';
 
-const BACKSPACE_KEY = 8;
-const DELETE_KEY = 46;
-
 @Component({
   selector: 'rq-action-item-task',
   templateUrl: './action-item-task.component.html',
@@ -128,24 +125,13 @@ export class ActionItemTaskComponent {
     document.execCommand('selectAll', false, null);
   }
 
-  public onKeyDown(keyEvent: KeyboardEvent, innerText: string) {
-    if (!this.keyEventIsAnAction(keyEvent)) {
-      if (innerText.length + keyEvent.key.length > this.maxMessageLength) {
-        keyEvent.preventDefault();
-      }
-    }
+  public setMessageLength(textContent: string): void {
+    this._textValueLength = textContent.length;
   }
 
-  public onKeyUp(textContent: string, innerText: string): void {
-    this._textValueLength = Math.min(textContent.length, innerText.length);
-  }
-
-  public updateActionItemMessage(innerText: string): void {
+  public updateActionItemMessage(event, innerText: string): void {
+    event.preventDefault();
     this.actionItem.task = innerText;
-  }
-
-  private keyEventIsAnAction(keyEvent: KeyboardEvent): boolean {
-    return keyEvent.keyCode === BACKSPACE_KEY || keyEvent.keyCode === DELETE_KEY;
   }
 
   get textValueLength(): number {

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.html
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.html
@@ -24,4 +24,5 @@
   (deleted)="emitDeleted()"
   (messageChanged)="emitMessageChanged($event)"
   (starCountIncreased)="emitStarCountIncreased($event)"
+  class="dialog-task"
 ></rq-task>

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
@@ -53,10 +53,10 @@
     font-size: 1rem;
     height: auto;
     max-height: 50%;
+    max-width: 650px;
     overflow: hidden;
     transform: scale(1.65);
     width: 50%;
-    max-width: 650px;
 
     @media only screen and (max-width: 770px) {
       transform: scale(1.3);

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.scss
@@ -34,7 +34,6 @@
 
   @media only screen and (max-width: 610px) {
     flex-direction: column;
-    justify-content: flex-end;
   }
 
   rq-task {
@@ -53,18 +52,19 @@
     box-sizing: border-box;
     font-size: 1rem;
     height: auto;
-
+    max-height: 50%;
+    overflow: hidden;
     transform: scale(1.65);
-    width: 450px;
+    width: 50%;
+    max-width: 650px;
 
     @media only screen and (max-width: 770px) {
       transform: scale(1.3);
     }
 
     @media only screen and (max-width: 610px) {
-      height: 280px;
       margin: $border-width;
-      max-height: 280px;
+      max-height: 80%;
       transform: none;
       width: calc(100% - 16px);
     }

--- a/ui/src/app/modules/controls/task-dialog/task-dialog.component.ts
+++ b/ui/src/app/modules/controls/task-dialog/task-dialog.component.ts
@@ -46,10 +46,12 @@ export class TaskDialogComponent {
     this.visible = false;
     this.visibilityChanged.emit(this.visible);
     document.onkeydown = null;
+    document.body.style.overflow = null;
   }
 
   public show(): void {
     this.visible = true;
+    document.body.style.overflow = 'hidden';
     document.onkeydown = event => {
       if (event.keyCode === ESC_KEY) {
         this.hide();

--- a/ui/src/app/modules/controls/task/task.component.html
+++ b/ui/src/app/modules/controls/task/task.component.html
@@ -33,16 +33,16 @@
   >{{emojifyText(task.message)}}</span>
 
   <div *ngIf="taskEditModeEnabled">
-    <div
-      #content_value
-      class="content-message editable-div"
-      contenteditable="true"
-      (keydown.enter)="updateTaskMessage(content_value.textContent); forceBlur()"
-      (blur)="updateTaskMessage(content_value.textContent); toggleEditMode()"
-      (keydown)="onKeyDown($event, content_value.textContent)"
-      (keyup)="onKeyUp(content_value.textContent, content_value.innerText)"
-    >{{task.message}}
-    </div>
+    <textarea #content_value [ngModel]="task.message"
+           class="content-message edit-input"
+           (blur)="updateTaskMessage($event, content_value.value); toggleEditMode()"
+           (keydown.enter)="updateTaskMessage($event, content_value.value); forceBlur()"
+           (keydown.escape)="updateTaskMessage($event, content_value.value); forceBlur()"
+           (input)="setMessageLength(content_value.value)"
+           [maxlength]="maxMessageLength"
+           onfocus="this.style.height = '';this.style.height = this.scrollHeight + 'px'"
+           oninput="this.style.height = '';this.style.height = this.scrollHeight + 'px'"
+    ></textarea>
 
     <rq-floating-character-countdown
       [characterCount]="textValueLength"

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -169,14 +169,21 @@
       height: auto;
       min-height: 40px;
       padding: 18px;
+      white-space: pre-wrap;
       width: 100%;
 
-      &.editable-div {
-        border-radius: inherit;
+      &.edit-input {
+        border: 0;
+        border-radius: 6px 6px 0 0;
         box-shadow: none;
         cursor: text;
         display: inline-block;
+        font-family: inherit;
+        font-size: inherit;
+        font-weight: inherit;
         outline: none;
+        overflow: auto;
+        resize: none;
       }
     }
   }

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -285,4 +285,15 @@
       }
     }
   }
+
+  &.dialog-task {
+    .content-area {
+      margin-bottom: 42px;
+      overflow: auto;
+    }
+
+    .footer {
+      position: absolute;
+    }
+  }
 }

--- a/ui/src/app/modules/controls/task/task.component.spec.ts
+++ b/ui/src/app/modules/controls/task/task.component.spec.ts
@@ -208,69 +208,29 @@ describe('ThoughtComponent', () => {
     });
   });
 
-  describe('onKeyDown', () => {
-
-    const fakeTextValue = 'XX';
-
-    it('should prevent the key event from being processed if the task has reached the max length', () => {
-      const fakeKeyEvent = jasmine.createSpyObj({
-        preventDefault: null
-      });
-
-      fakeKeyEvent.key = 'a';
-
-      component.maxMessageLength = 2;
-      component.onKeyDown(fakeKeyEvent, fakeTextValue);
-      expect(fakeKeyEvent.preventDefault).toHaveBeenCalled();
-    });
-
-    it('should allow the key event if the max message length has not been reached', () => {
-      const fakeKeyEvent = jasmine.createSpyObj({
-        preventDefault: null
-      });
-      fakeKeyEvent.key = 'a';
-
-      component.maxMessageLength = 3;
-      component.onKeyDown(fakeKeyEvent, fakeTextValue);
-      expect(fakeKeyEvent.preventDefault).not.toHaveBeenCalled();
-    });
-
-    it('should allow the backspace key event even if the max length has been reached', () => {
-      const fakeBackspaceEvent = jasmine.createSpyObj({
-        preventDefault: null
-      });
-      fakeBackspaceEvent.keyCode = 8;
-
-      component.maxMessageLength = 2;
-      component.onKeyDown(fakeBackspaceEvent, fakeTextValue);
-      expect(fakeBackspaceEvent.preventDefault).not.toHaveBeenCalled();
-    });
-
-    it('should allow the delete key event even if the max length has been reached', () => {
-      const fakeDeleteKeyEvent = jasmine.createSpyObj({
-        preventDefault: null,
-      });
-
-      fakeDeleteKeyEvent.keyCode = 46;
-
-      component.maxMessageLength = 2;
-      component.onKeyDown(fakeDeleteKeyEvent, fakeTextValue);
-      expect(fakeDeleteKeyEvent.preventDefault).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('onKeyUp', () => {
-    it('should set the text value length to the min between both parameter string lengths', () => {
-      component.onKeyUp('aa', 'a');
+  describe('setMessageLength', () => {
+    it('should set the text value length to the length of the input string', () => {
+      component.setMessageLength('a');
       expect(component.textValueLength).toEqual(1);
     });
   });
 
   describe('updateTaskMessage', () => {
+    const fakeText = 'HELLO I AM TEXT';
+    let fakeEvent;
+
+    beforeEach(() => {
+      fakeEvent = jasmine.createSpyObj(['preventDefault']);
+    });
+
     it('should set the thought message to the passed in string', () => {
-      const fakeText = 'HELLO I AM TEXT';
-      component.updateTaskMessage(fakeText);
+      component.updateTaskMessage(fakeEvent, fakeText);
       expect(component.task.message).toEqual(fakeText);
+    });
+
+    it(`should prevent the default event`, () => {
+      component.updateTaskMessage(fakeEvent, fakeText);
+      expect(fakeEvent.preventDefault).toHaveBeenCalled();
     });
   });
 

--- a/ui/src/app/modules/controls/task/task.component.ts
+++ b/ui/src/app/modules/controls/task/task.component.ts
@@ -20,9 +20,6 @@ import {emptyThought, Thought} from '../../domain/thought';
 import {emojify} from '../../utils/EmojiGenerator';
 
 
-const BACKSPACE_KEY = 8;
-const DELETE_KEY = 46;
-
 @Component({
   selector: 'rq-task',
   templateUrl: './task.component.html',
@@ -117,24 +114,13 @@ export class TaskComponent {
     }, 0);
   }
 
-  public onKeyDown(keyEvent: KeyboardEvent, innerText: string) {
-    if (!this.keyEventIsAnAction(keyEvent)) {
-      if (innerText.length + keyEvent.key.length > this.maxMessageLength) {
-        keyEvent.preventDefault();
-      }
-    }
+  public setMessageLength(textContent: string): void {
+    this._textValueLength = textContent.length;
   }
 
-  public onKeyUp(textContent: string, innerText: string): void {
-    this._textValueLength = Math.min(textContent.length, innerText.length);
-  }
-
-  public updateTaskMessage(innerText: string): void {
-    this.task.message = innerText;
-  }
-
-  private keyEventIsAnAction(keyEvent: KeyboardEvent): boolean {
-    return keyEvent.keyCode === BACKSPACE_KEY || keyEvent.keyCode === DELETE_KEY;
+  public updateTaskMessage(event, value: string): void {
+    event.preventDefault();
+    this.task.message = value;
   }
 
   get textValueLength(): number {

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -32,6 +32,7 @@ body {
   font-weight: normal;
   height: 100%;
   margin: 0;
+  overflow: auto;
   padding: 0;
 }
 


### PR DESCRIPTION
## Overview
This pull request will change the edit thoughts/action items inputs to be textareas instead of content editable divs. 

This fixes #140 and other small issues such as not being able to use the arrow keys when there are too many characters and the number of available characters decreasing every time the edit box is opened.

Also adds the ability to use shift+enter to add newlines into thoughts/action items.