### PR TITLE
Add tooltips for task actions

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "@angular/cli": "~6.0.7",
     "@angular/compiler-cli": "^6.0.3",
     "@angular/language-service": "^6.0.3",
-    "@types/jasmine": "~2.8.6",
+    "@types/jasmine": "2.8.9",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",
     "codelyzer": "~4.2.1",

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
@@ -111,6 +111,7 @@
       'dark-theme': darkThemeIsEnabled
     }"
   >
+    <span class="tooltip">Edit</span>
     <i class="fas fa-edit"
        [ngClass]="{'opacify': actionItem.completed || taskEditModeEnabled || readOnly}"
     ></i>
@@ -124,6 +125,7 @@
       }"
       (click)="forceBlur()"
     >
+      <span class="tooltip">Cancel</span>
       <i class="fas fa-times exit-edit-mode-icon"></i>
     </div>
   </ng-template>
@@ -137,13 +139,16 @@
     <i class="fas fa-trash-alt"
        [ngClass]="{'opacify': readOnly}"
     ></i>
+    <span class="tooltip">Delete</span>
   </div>
 
   <div
-    class="complete-container"
+    class=" complete-container"
     [ngClass]="{'opacify': taskEditModeEnabled || readOnly}"
     (click)="toggleTaskComplete()"
   >
+    <span *ngIf="actionItem.completed" class="tooltip">Open</span>
+    <span *ngIf="!actionItem.completed" class="tooltip">Close</span>
     <div
       class="checkbox"
       [ngClass]="{'completed-task':  actionItem.completed}"

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -225,6 +225,20 @@
   }
 
   .footer {
+
+    .tooltip {
+      visibility: hidden;
+      width: 8rem;
+      background-color: black;
+      color: #fff;
+      text-align: center;
+      padding: 5px 0;
+      border-radius: 6px;
+
+      position: absolute;
+      bottom: 2.65rem;
+    }
+
     border-bottom-left-radius: inherit;
     border-bottom-right-radius: inherit;
     border-top: 2px solid opacity($wet-asphalt, .06);
@@ -288,11 +302,18 @@
           font-size: 1.1rem;
         }
       }
+    } :hover .tooltip {
+      visibility: visible;
     }
 
     .edit-container,
     .delete-container {
       font-size: 1rem;
+    } :hover .tooltip {
+      visibility: visible;
+    }
+    .edit-container :hover .tooltip {
+      visibility: visible;
     }
 
     .date-created-container {

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -226,19 +226,6 @@
 
   .footer {
 
-    .tooltip {
-      visibility: hidden;
-      width: 8rem;
-      background-color: black;
-      color: #fff;
-      text-align: center;
-      padding: 5px 0;
-      border-radius: 6px;
-
-      position: absolute;
-      bottom: 2.65rem;
-    }
-
     border-bottom-left-radius: inherit;
     border-bottom-right-radius: inherit;
     border-top: 2px solid opacity($wet-asphalt, .06);
@@ -246,6 +233,18 @@
     height: 40px;
     justify-content: flex-start;
     width: 100%;
+
+    .tooltip {
+      background-color: $black;
+      border-radius: 6px;
+      bottom: 2.65rem;
+      color: $white;
+      padding: 5px 0;
+      position: absolute;
+      text-align: center;
+      visibility: hidden;
+      width: 8rem;
+    }
 
     &.dark-theme {
       border-top-color: $task-footer-separator-dark;
@@ -302,20 +301,18 @@
           font-size: 1.1rem;
         }
       }
-    } :hover .tooltip {
-      visibility: visible;
     }
 
     .edit-container,
     .delete-container {
       font-size: 1rem;
-    } :hover .tooltip {
-      visibility: visible;
     }
-    .edit-container :hover .tooltip {
+
+    :hover > .tooltip {
       visibility: visible;
     }
 
+    .edit-container,
     .date-created-container {
       cursor: default;
       flex-direction: column;
@@ -338,6 +335,10 @@
       .date-created-value {
         font-size: .75rem;
         font-weight: bold;
+      }
+
+      :hover > .tooltip {
+        visibility: visible;
       }
     }
   }

--- a/ui/src/app/modules/controls/task/task.component.html
+++ b/ui/src/app/modules/controls/task/task.component.html
@@ -69,6 +69,7 @@
       'dark-theme': darkThemeIsEnabled
     }"
   >
+    <span class="tooltip">Upvote</span>
     <div class="star-background"
          [ngClass]="{
           'opacify': task.discussed || taskEditModeEnabled,
@@ -97,6 +98,7 @@
       'dark-theme': darkThemeIsEnabled
     }"
   >
+    <span class="tooltip">Edit</span>
     <i class="fas fa-edit"
        [ngClass]="{'opacify': task.discussed || taskEditModeEnabled || readOnly}"
     ></i>
@@ -110,6 +112,7 @@
       }"
       (click)="forceBlur()"
     >
+    <span class="tooltip">Cancel</span>
       <i class="fas fa-times exit-edit-mode-icon"></i>
     </div>
   </ng-template>
@@ -122,6 +125,7 @@
     (click)="emitDeleteItem()"
     [ngClass]="{'disable': readOnly}"
   >
+    <span class="tooltip">Delete</span>
     <i class="fas fa-trash-alt"
        [ngClass]="{'opacify': readOnly}"
     ></i>
@@ -135,6 +139,8 @@
     }"
     (click)="toggleTaskComplete()"
   >
+    <span *ngIf="task.discussed" class="tooltip">Open</span>
+    <span *ngIf="!task.discussed" class="tooltip">Close</span>
     <div
       class="checkbox"
       [ngClass]="{'completed-task':  task.discussed}"

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -207,19 +207,6 @@
 
   .footer {
 
-    .tooltip {
-      visibility: hidden;
-      width: 8rem;
-      background-color: black;
-      color: #fff;
-      text-align: center;
-      padding: 5px 0;
-      border-radius: 6px;
-
-      position: absolute;
-      bottom: 2.65rem;
-    }
-
     background-color: inherit;
     border-bottom-left-radius: inherit;
     border-bottom-right-radius: inherit;
@@ -228,6 +215,18 @@
     height: 40px;
     justify-content: flex-start;
     width: 100%;
+
+    .tooltip {
+      background-color: $black;
+      border-radius: 6px;
+      bottom: 2.65rem;
+      color: $white;
+      padding: 5px 0;
+      position: absolute;
+      text-align: center;
+      visibility: hidden;
+      width: 8rem;
+    }
 
     &.dark-theme {
       border-top-color: $task-footer-separator-dark;
@@ -283,19 +282,14 @@
           font-size: 1.1rem;
         }
       }
-    } :hover .tooltip {
+    }
+
+    :hover > .tooltip {
       visibility: visible;
     }
 
-    .edit-container {
-
-    } :hover .tooltip {
-      visibility: visible;
-    }
     .delete-container {
       font-size: 1rem;
-    } :hover .tooltip {
-      visibility: visible;
     }
 
     .star-count-container {
@@ -339,8 +333,6 @@
           }
         }
       }
-    } :hover .tooltip {
-      visibility: visible;
     }
   }
 }

--- a/ui/src/app/modules/controls/task/task.component.scss
+++ b/ui/src/app/modules/controls/task/task.component.scss
@@ -206,6 +206,20 @@
   }
 
   .footer {
+
+    .tooltip {
+      visibility: hidden;
+      width: 8rem;
+      background-color: black;
+      color: #fff;
+      text-align: center;
+      padding: 5px 0;
+      border-radius: 6px;
+
+      position: absolute;
+      bottom: 2.65rem;
+    }
+
     background-color: inherit;
     border-bottom-left-radius: inherit;
     border-bottom-right-radius: inherit;
@@ -269,11 +283,19 @@
           font-size: 1.1rem;
         }
       }
+    } :hover .tooltip {
+      visibility: visible;
     }
 
-    .edit-container,
+    .edit-container {
+
+    } :hover .tooltip {
+      visibility: visible;
+    }
     .delete-container {
       font-size: 1rem;
+    } :hover .tooltip {
+      visibility: visible;
     }
 
     .star-count-container {
@@ -317,6 +339,8 @@
           }
         }
       }
+    } :hover .tooltip {
+      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
## Overview
Outlines what each of the actions beneath the task cards do.

Connects #166 

### Demo
When hovering over the actions in the footer of the tasks/action items, you will see something like this:

<img width="354" alt="screen shot 2018-12-10 at 3 02 33 pm" src="https://user-images.githubusercontent.com/18236455/49758419-df7e0880-fc8c-11e8-9656-6d9a8f30db36.png">


### Notes
There is a tooltip for each of the actions that read as follow:

Starring a task: **Upvote**
Editing a task: **Edit** (**Cancel** when closing the edit window)
Deleting a task: **Delete**
Hitting the check mark: **Close** (**Open** when unchecking the task**)
Editing action item: **Edit** (**Cancel** when closing the edit window)
Deleting an action item **Delete**
Hitting the check mark: **Close** (**Open when unchecking the action item**)

## Testing Instructions
Start the application, create a task/action item, and hover over the actions as necessary.