### PR TITLE
Github contributors board

### DIFF
--- a/api/src/apiTest/java/com/ford/labs/retroquest/api/ContributorControllerApiTest.java
+++ b/api/src/apiTest/java/com/ford/labs/retroquest/api/ContributorControllerApiTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.api;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Base64;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ContributorControllerApiTest extends ControllerTest {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Test
+    public void canRetrieveFromGithubApi() throws Exception {
+        MockRestServiceServer mockGithub = MockRestServiceServer.bindTo(restTemplate).build();
+        mockGithub.expect(requestTo("https://api.github.com/repos/FordLabs/retroquest/contributors"))
+                .andRespond(withSuccess("" +
+                        "[\n" +
+                        "    {\n" +
+                        "        \"avatar_url\": \"https://avatars0.githubusercontent.com/u/0000000?v=4\",\n" +
+                        "        \"html_url\": \"profileUrl\"\n" +
+                        "    }" +
+                        "]", MediaType.APPLICATION_JSON));
+        mockGithub.expect(requestTo("https://avatars0.githubusercontent.com/u/0000000?v=4"))
+                .andRespond(withSuccess("THIS IS AN IMAGE", MediaType.IMAGE_PNG));
+        mockMvc.perform(get("/api/contributors"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].accountUrl", is("profileUrl")))
+                .andExpect(jsonPath("$[0].image", is(Base64.getEncoder().encodeToString("THIS IS AN IMAGE".getBytes()))));
+    }
+}

--- a/api/src/main/java/com/ford/labs/retroquest/contributors/Contributor.java
+++ b/api/src/main/java/com/ford/labs/retroquest/contributors/Contributor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.contributors;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Contributor {
+    private byte[] image;
+    private String accountUrl;
+}

--- a/api/src/main/java/com/ford/labs/retroquest/contributors/ContributorController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/contributors/ContributorController.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.contributors;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@RestController
+public class ContributorController {
+
+    private final RestTemplate restTemplate;
+
+    public ContributorController(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @GetMapping("/api/contributors")
+    public List<Contributor> getContributors() {
+        GithubContributor[] response = this.restTemplate.getForObject(
+                "https://api.github.com/repos/FordLabs/retroquest/contributors",
+                GithubContributor[].class,
+                Collections.emptyMap()
+        );
+        return Arrays.stream(response)
+                .filter(githubContributor -> !githubContributor.getAccountUrl().endsWith("/invalid-email-address"))
+                .map(githubContributor -> new Contributor(
+                        getAvatar(githubContributor.getAvatarUrl()), githubContributor.getAccountUrl()
+                )).collect(Collectors.toList());
+    }
+
+    private byte[] getAvatar(String avatarUrl) {
+        return this.restTemplate.getForObject(avatarUrl, byte[].class, Collections.emptyMap());
+    }
+}

--- a/api/src/main/java/com/ford/labs/retroquest/contributors/GithubContributor.java
+++ b/api/src/main/java/com/ford/labs/retroquest/contributors/GithubContributor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.contributors;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GithubContributor {
+
+    @JsonProperty("avatar_url")
+    private String avatarUrl;
+
+    @JsonProperty("html_url")
+    private String accountUrl;
+}

--- a/api/src/test/java/com/ford/labs/retroquest/contributors/ContributorControllerTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/contributors/ContributorControllerTest.java
@@ -1,0 +1,104 @@
+package com.ford.labs.retroquest.contributors;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.never;
+
+public class ContributorControllerTest {
+
+    private RestTemplate restTemplate;
+    private ContributorController subject;
+
+    @Before
+    public void setUp() {
+        restTemplate = Mockito.mock(RestTemplate.class);
+        subject = new ContributorController(restTemplate);
+    }
+
+    @Test
+    public void getContributorsGetsTheRepositoryDataFromGithub() {
+        GithubContributor[] data = {};
+
+        Mockito.when(restTemplate.getForObject(
+                Mockito.eq("https://api.github.com/repos/FordLabs/retroquest/contributors"),
+                Mockito.eq(GithubContributor[].class),
+                Mockito.any(Map.class)
+        )).thenReturn(data);
+        subject.getContributors();
+        Mockito.verify(restTemplate).getForObject(
+                Mockito.eq("https://api.github.com/repos/FordLabs/retroquest/contributors"),
+                Mockito.eq(GithubContributor[].class),
+                Mockito.any(Map.class)
+        );
+    }
+
+    @Test
+    public void getContributorsShouldGetTheAvatarsForEachContributor() {
+        GithubContributor[] data = {
+                new GithubContributor("avatarUrl", "")
+        };
+
+        Mockito.when(restTemplate.getForObject(
+                Mockito.eq("https://api.github.com/repos/FordLabs/retroquest/contributors"),
+                Mockito.eq(GithubContributor[].class),
+                Mockito.any(Map.class)
+        )).thenReturn(data);
+        subject.getContributors();
+        Mockito.verify(restTemplate).getForObject(
+                Mockito.eq("avatarUrl"),
+                Mockito.eq(byte[].class),
+                Mockito.any(Map.class)
+        );
+    }
+
+    @Test
+    public void getContributorsShoulConvertRetrunedGithubContributorsToContributors() {
+        GithubContributor[] data = {
+                new GithubContributor("avatarUrl", "accountUrl")
+        };
+
+        Mockito.when(restTemplate.getForObject(
+                Mockito.eq("https://api.github.com/repos/FordLabs/retroquest/contributors"),
+                Mockito.eq(GithubContributor[].class),
+                Mockito.any(Map.class)
+        )).thenReturn(data);
+        Mockito.when(restTemplate.getForObject(
+                Mockito.eq("avatarUrl"),
+                Mockito.eq(byte[].class),
+                Mockito.any(Map.class)
+        )).thenReturn("AVATAR".getBytes());
+        List<Contributor> response = subject.getContributors();
+        Assertions.assertThat(response.get(0)).hasFieldOrPropertyWithValue("image", "AVATAR".getBytes());
+        Assertions.assertThat(response.get(0)).hasFieldOrPropertyWithValue("accountUrl", "accountUrl");
+    }
+
+    @Test
+    public void getContributorsShouldFiterContributorWithAccountUrlEndingInInvalidEmailAddress() {
+        GithubContributor[] data = {
+                new GithubContributor("avatarUrl", "acount/invalid-email-address")
+        };
+        Mockito.when(restTemplate.getForObject(
+                Mockito.eq("https://api.github.com/repos/FordLabs/retroquest/contributors"),
+                Mockito.eq(GithubContributor[].class),
+                Mockito.any(Map.class)
+        )).thenReturn(data);
+        List<Contributor> response = subject.getContributors();
+        Mockito.verify(restTemplate, never()).getForObject(
+                Mockito.eq("avatarUrl"),
+                Mockito.any(),
+                Mockito.any(Map.class)
+        );
+        Assertions.assertThat(response).hasSize(0);
+    }
+
+}

--- a/api/src/test/java/com/ford/labs/retroquest/contributors/ContributorControllerTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/contributors/ContributorControllerTest.java
@@ -6,18 +6,16 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.never;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 public class ContributorControllerTest {
-
     private RestTemplate restTemplate;
     private ContributorController subject;
+
+    private long MILLISECONDS_IN_DAY = 86400000;
 
     @Before
     public void setUp() {
@@ -35,7 +33,7 @@ public class ContributorControllerTest {
                 Mockito.any(Map.class)
         )).thenReturn(data);
         subject.getContributors();
-        Mockito.verify(restTemplate).getForObject(
+        verify(restTemplate).getForObject(
                 Mockito.eq("https://api.github.com/repos/FordLabs/retroquest/contributors"),
                 Mockito.eq(GithubContributor[].class),
                 Mockito.any(Map.class)
@@ -54,7 +52,7 @@ public class ContributorControllerTest {
                 Mockito.any(Map.class)
         )).thenReturn(data);
         subject.getContributors();
-        Mockito.verify(restTemplate).getForObject(
+        verify(restTemplate).getForObject(
                 Mockito.eq("avatarUrl"),
                 Mockito.eq(byte[].class),
                 Mockito.any(Map.class)
@@ -78,8 +76,8 @@ public class ContributorControllerTest {
                 Mockito.any(Map.class)
         )).thenReturn("AVATAR".getBytes());
         List<Contributor> response = subject.getContributors();
-        Assertions.assertThat(response.get(0)).hasFieldOrPropertyWithValue("image", "AVATAR".getBytes());
-        Assertions.assertThat(response.get(0)).hasFieldOrPropertyWithValue("accountUrl", "accountUrl");
+        assertThat(response.get(0)).hasFieldOrPropertyWithValue("image", "AVATAR".getBytes());
+        assertThat(response.get(0)).hasFieldOrPropertyWithValue("accountUrl", "accountUrl");
     }
 
     @Test
@@ -93,12 +91,57 @@ public class ContributorControllerTest {
                 Mockito.any(Map.class)
         )).thenReturn(data);
         List<Contributor> response = subject.getContributors();
-        Mockito.verify(restTemplate, never()).getForObject(
+        verify(restTemplate, never()).getForObject(
                 Mockito.eq("avatarUrl"),
                 Mockito.any(),
                 Mockito.any(Map.class)
         );
-        Assertions.assertThat(response).hasSize(0);
+        assertThat(response).hasSize(0);
+    }
+
+    @Test
+    public void getContributorsShouldNotQueryGithubApiWhenLastUpdateWasLessThanADayAgo() {
+        subject.setEpochMilisOfLastRequest(System.currentTimeMillis());
+        subject.getContributors();
+        verify(restTemplate, never()).getForObject(Mockito.any(String.class), Mockito.any(), Mockito.any(Map.class));
+    }
+
+    @Test
+    public void getContributorsShouldQueryGithubApiIfTheTimeSinceLastUpdateIsMoreThanADay() {
+        GithubContributor[] data = {
+                new GithubContributor("avatarUrl", "account/email-address")
+        };
+        Mockito.when(restTemplate.getForObject(
+                Mockito.eq("https://api.github.com/repos/FordLabs/retroquest/contributors"),
+                Mockito.eq(GithubContributor[].class),
+                Mockito.any(Map.class)
+        )).thenReturn(data);
+        subject.setEpochMilisOfLastRequest(System.currentTimeMillis() - MILLISECONDS_IN_DAY - 1);
+        subject.getContributors();
+        verify(restTemplate, times(1)).getForObject(Mockito.eq("avatarUrl"), Mockito.any(), Mockito.any(Map.class));
+    }
+
+    @Test
+    public void getContributorsShouldLoadResultsIntoCacheWhenCalled() {
+
+        GithubContributor[] data = {
+                new GithubContributor("avatarUrl", "account/email-address")
+        };
+        Mockito.when(restTemplate.getForObject(
+                Mockito.eq("https://api.github.com/repos/FordLabs/retroquest/contributors"),
+                Mockito.eq(GithubContributor[].class),
+                Mockito.any(Map.class)
+        )).thenReturn(data);
+        List<Contributor> result = subject.getContributors();
+        assertThat(result).isEqualTo(subject.getCachedContributors());
+    }
+
+    @Test
+    public void getContributorsShouldReturnCachedResultsWhenNotCallingTheGithubApi() {
+        subject.setEpochMilisOfLastRequest(System.currentTimeMillis());
+        subject.setCachedContributors(Arrays.asList(new Contributor(new byte[]{}, "accountUrl")));
+        List<Contributor> result = subject.getContributors();
+        assertThat(result).isEqualTo(subject.getCachedContributors());
     }
 
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "@angular/cli": "~6.0.7",
     "@angular/compiler-cli": "^6.0.3",
     "@angular/language-service": "^6.0.3",
-    "@types/jasmine": "~2.8.6",
+    "@types/jasmine": "2.8.9",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",
     "codelyzer": "~4.2.1",

--- a/ui/src/app/modules/auth/token-interceptor/token.interceptor.ts
+++ b/ui/src/app/modules/auth/token-interceptor/token.interceptor.ts
@@ -23,8 +23,11 @@ import {AuthService} from '../auth.service';
 @Injectable()
 export class TokenInterceptor implements HttpInterceptor {
 
-  intercept (request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    if (AuthService.getToken() !== null && request.url !== '/api/team' && request.url !== '/api/team/login') {
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    if (AuthService.getToken() !== null && request.url !== '/api/team' &&
+      request.url !== '/api/team/login' &&
+      request.url !== 'https://api.github.com/repos/FordLabs/retroquest/contributors'
+    ) {
       request = request.clone({
         setHeaders: {
           Authorization: `Bearer ${AuthService.getToken()}`

--- a/ui/src/app/modules/boards/boards.module.ts
+++ b/ui/src/app/modules/boards/boards.module.ts
@@ -26,6 +26,7 @@ import {BrandFooterComponent} from './components/brand-footer/brand-footer.compo
 import {RecaptchaModule} from 'ng-recaptcha';
 import {ControlsModule} from '../controls/controls.module';
 import {FocusOnLoadDirective} from './pages/directives/focus-on-load.component';
+import { ContributorsComponent } from './components/contributors/contributors.component';
 
 @NgModule({
   imports: [
@@ -45,6 +46,7 @@ import {FocusOnLoadDirective} from './pages/directives/focus-on-load.component';
     AppTitleComponent,
     BrandFooterComponent,
     FocusOnLoadDirective,
+    ContributorsComponent,
   ],
   exports: [CreateComponent]
 })

--- a/ui/src/app/modules/boards/components/brand-footer/brand-footer.component.scss
+++ b/ui/src/app/modules/boards/components/brand-footer/brand-footer.component.scss
@@ -56,3 +56,7 @@
     padding: 0;
   }
 }
+
+.contributors {
+  margin-top: 2rem;
+}

--- a/ui/src/app/modules/boards/components/contributors/contributors.component.html
+++ b/ui/src/app/modules/boards/components/contributors/contributors.component.html
@@ -15,22 +15,13 @@
   ~ limitations under the License.
   -->
 
-<div class="rq-brand-footer">
-  <a class="labs-text">Powered By <a
-    class="labs-link"
-    href="https://thehubat.ford.com/groups/fordlabs"
-    target="_blank"
-  >FordLabs</a>
-  </a>
-
-  <span class="vertical-seperator"></span>
-
-  <a
-    class="github-link"
-    href="https://github.com/FordLabs/retroquest"
-    target="_blank"
-  >Github</a>
-</div>
 <div class="contributors">
-  <rq-contributors></rq-contributors>
+  <div class="contributors-title">
+    Contributors
+  </div>
+  <div *ngFor="let contributorRow of contributors">
+    <a *ngFor="let contributor of contributorRow" href="{{contributor.accountUrl}}" target="_blank">
+      <img [src]="contributor.image" >
+    </a>
+  </div>
 </div>

--- a/ui/src/app/modules/boards/components/contributors/contributors.component.scss
+++ b/ui/src/app/modules/boards/components/contributors/contributors.component.scss
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.contributors {
+
+  .contributors-title {
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin-bottom: .5rem;
+  }
+
+  a {
+    padding: 0;
+
+    img {
+      padding: 3px;
+      width: calc(20% - 6px);
+    }
+  }
+}
+

--- a/ui/src/app/modules/boards/components/contributors/contributors.component.spec.ts
+++ b/ui/src/app/modules/boards/components/contributors/contributors.component.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ContributorsComponent } from './contributors.component';
+import {ContributorsService} from './contributors.service';
+import {Contributor} from '../../../domain/contributor';
+import {Subject} from 'rxjs';
+
+describe('ContributorsComponent', () => {
+  let component: ContributorsComponent;
+  let mockContrbutorsServerice: ContributorsService;
+  let mockContributorSubject: Subject<Contributor[]>;
+
+  beforeEach(() => {
+    mockContributorSubject = new Subject<Contributor[]>();
+    mockContrbutorsServerice = jasmine.createSpyObj({
+      getContributors: mockContributorSubject
+    });
+    component = new ContributorsComponent(mockContrbutorsServerice);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    it('should load the contributors', () => {
+
+      const contributor: Contributor = {
+        accountUrl: 'url',
+        image: 'avatar'
+      };
+
+      const contributors = [];
+      contributors.push(contributor);
+
+      component.ngOnInit();
+      mockContributorSubject.next(contributors);
+      expect(component.contributors[0][0]).toBe(contributor);
+    });
+
+    it('should properly format contributors into multiple rows', () => {
+      const contributor: Contributor = {
+        accountUrl: 'url',
+        image: 'avatar'
+      };
+      const contributors = [
+        { accountUrl: 'url1', image: 'avatar1'},
+        { accountUrl: 'url2', image: 'avatar2'},
+        { accountUrl: 'url3', image: 'avatar3'},
+        { accountUrl: 'url4', image: 'avatar4'},
+        { accountUrl: 'url5', image: 'avatar5'},
+        contributor
+      ];
+      component.ngOnInit();
+      mockContributorSubject.next(contributors);
+      expect(component.contributors.length).toBe(2);
+      expect(component.contributors[0].length).toBe(5);
+      expect(component.contributors[1].length).toBe(1);
+      expect(component.contributors[1][0]).toBe(contributor);
+    });
+  });
+});

--- a/ui/src/app/modules/boards/components/contributors/contributors.component.ts
+++ b/ui/src/app/modules/boards/components/contributors/contributors.component.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, OnInit} from '@angular/core';
+import {ContributorsService} from './contributors.service';
+import {Contributor} from '../../../domain/contributor';
+import {combineAll} from 'rxjs/operators';
+
+@Component({
+  selector: 'rq-contributors',
+  templateUrl: './contributors.component.html',
+  styleUrls: ['./contributors.component.scss']
+})
+export class ContributorsComponent implements OnInit {
+
+  contributors: Contributor[][];
+
+  ROW_SIZE = 5;
+
+  constructor(
+    private contributorService: ContributorsService
+  ) {
+  }
+
+  ngOnInit() {
+    this.contributorService.getContributors().subscribe((result) => {
+      const rows = Math.ceil(result.length / 5);
+      this.contributors = new Array(rows);
+      let currentRow;
+      let contributorsPos = 0;
+      for (currentRow = 0; currentRow < this.contributors.length; currentRow++) {
+        this.contributors[currentRow] = new Array(this.remaningSpace(result, currentRow));
+        let currentColumn;
+        for (currentColumn = 0; currentColumn < this.contributors[currentRow].length; currentColumn++) {
+          this.contributors[currentRow][currentColumn] = result[contributorsPos];
+          contributorsPos++;
+        }
+      }
+    });
+  }
+
+  private rowCountFromContributorCount(contributors: Contributor[]) {
+    return Math.ceil(contributors.length / this.ROW_SIZE);
+  }
+
+  private remaningSpace(contributors: Contributor[], currentRow: number): number {
+    const rows = this.rowCountFromContributorCount(contributors);
+    const leftover: number = contributors.length % this.ROW_SIZE;
+    if (currentRow === rows - 1) {
+      return leftover;
+    }
+    return this.ROW_SIZE;
+  }
+}

--- a/ui/src/app/modules/boards/components/contributors/contributors.service.spec.ts
+++ b/ui/src/app/modules/boards/components/contributors/contributors.service.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ContributorsService} from './contributors.service';
+import {HttpClient} from '@angular/common/http';
+import {Subject} from 'rxjs';
+
+describe('ContributorsService', () => {
+
+  let service: ContributorsService;
+  let mockHttpClient: HttpClient;
+  let mockHttpClientGetSubject: Subject<any>;
+
+  beforeEach(() => {
+    mockHttpClientGetSubject = new Subject<any>();
+    mockHttpClient = jasmine.createSpyObj({
+      get: mockHttpClientGetSubject
+    });
+    service = new ContributorsService(mockHttpClient);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getContributors', () => {
+    it('should request the contributors from github', () => {
+      service.getContributors().subscribe(() => {
+        expect(mockHttpClient.get).toHaveBeenCalledWith('/api/contributors');
+      });
+      mockHttpClientGetSubject.next([]);
+    });
+    it('should prepend data:image/png;base64 to all image data', () => {
+      service.getContributors().subscribe(result => {
+        expect(result[0].image.startsWith('data:image/png;base64,')).toBeTruthy();
+      });
+      mockHttpClientGetSubject.next([{accountUrl: 'accountUrl', image: 'imageData'}]);
+    });
+  });
+});

--- a/ui/src/app/modules/boards/components/contributors/contributors.service.ts
+++ b/ui/src/app/modules/boards/components/contributors/contributors.service.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {Observable} from 'rxjs';
+import {Contributor} from '../../../domain/contributor';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ContributorsService {
+
+  constructor(
+    private http: HttpClient
+  ) { }
+
+  public getContributors(): Observable<Contributor[]> {
+    return new Observable<Contributor[]>(observer => {
+      this.http.get<Contributor[]>('/api/contributors').subscribe(result => {
+        result.forEach(contributor => {
+          contributor.image = `data:image/png;base64,${contributor.image}`;
+        });
+        observer.next(result);
+      });
+    });
+  }
+}

--- a/ui/src/app/modules/domain/contributor.ts
+++ b/ui/src/app/modules/domain/contributor.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Contributor {
+  accountUrl: string;
+  image: string;
+}


### PR DESCRIPTION
## Overview
This will create a board of the GitHub profiles on the login and board creation pages.

### Demo
<img width="396" alt="screen shot 2018-12-12 at 12 41 16 pm" src="https://user-images.githubusercontent.com/18236455/49887817-4f1a0200-fe0b-11e8-9752-1fe745fc2c9d.png">


### Notes
Anyone that has a commit in retroquest will show up as a contributor on the front page. Accounts that don't have a valid account (AKA Ordlab1) are filtered out.