### PR TITLE
Fill username when accessing a team directly but login is required

### DIFF
--- a/ui/src/app/modules/auth/auth-guard/auth.guard.spec.ts
+++ b/ui/src/app/modules/auth/auth-guard/auth.guard.spec.ts
@@ -45,7 +45,7 @@ describe('AuthGuard', () => {
     const mockState = null;
 
     (guard.canActivate(mockNextRouteSnapshot, mockState) as Observable<boolean>).subscribe(() => {
-      expect(mockRouter.navigate).toHaveBeenCalledWith(['login']);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['login', 'incorrect-team']);
     });
     mockTeamService.validateTeamId().error();
   });

--- a/ui/src/app/modules/auth/auth-guard/auth.guard.ts
+++ b/ui/src/app/modules/auth/auth-guard/auth.guard.ts
@@ -37,12 +37,14 @@ export class AuthGuard implements CanActivate {
 
     return new Observable<boolean>(observer => {
 
-      this.teamService.validateTeamId(next.url[1].path).subscribe(
+      const teamId = next.url[1].path;
+
+      this.teamService.validateTeamId(teamId).subscribe(
         () => {
           observer.next(true);
         },
         () => {
-          this.router.navigate(['login']);
+          this.router.navigate(['login', teamId]);
           observer.next(true);
         }
       );

--- a/ui/src/app/modules/boards/boards.module.ts
+++ b/ui/src/app/modules/boards/boards.module.ts
@@ -34,7 +34,8 @@ import {FocusOnLoadDirective} from './pages/directives/focus-on-load.component';
     ControlsModule,
     RouterModule.forChild([
       {path: 'create', component: CreateComponent},
-      {path: 'login', component: LoginComponent}
+      {path: 'login', component: LoginComponent},
+      {path: 'login/:teamId', component: LoginComponent}
     ]),
     RecaptchaModule.forRoot(),
     RecaptchaModule

--- a/ui/src/app/modules/boards/pages/login/login.page.spec.ts
+++ b/ui/src/app/modules/boards/pages/login/login.page.spec.ts
@@ -17,13 +17,16 @@
 
 import {LoginComponent} from './login.page';
 import {AuthService} from '../../../auth/auth.service';
-import {Subject, throwError} from 'rxjs';
+import {Subject, Observable, from, throwError} from 'rxjs';
 import {of} from 'rxjs/internal/observable/of';
 import {HttpHeaders, HttpResponse} from '@angular/common/http';
+import { ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let mockTeamService;
+  let mockRoute;
   let mockRouter;
   let mockRecaptchaComponent;
 
@@ -32,14 +35,25 @@ describe('LoginComponent', () => {
       login: new Subject(),
       isCaptchaEnabledForTeam: new Subject()
     });
+
+    const mockActivatedRoute = new ActivatedRoute();
+
+    mockActivatedRoute.snapshot = new ActivatedRouteSnapshot();
+    mockActivatedRoute.snapshot.params = {teamId: 'devs'};
+
     mockRouter = jasmine.createSpyObj({navigateByUrl: null});
     mockRecaptchaComponent = jasmine.createSpyObj({reset: null, execute: null});
 
     spyOn(AuthService, 'setToken');
     spyOn(console, 'error');
 
-    component = new LoginComponent(mockTeamService, mockRouter);
+    component = new LoginComponent(mockTeamService, mockActivatedRoute, mockRouter);
+    component.ngOnInit();
     component.recaptchaComponent = mockRecaptchaComponent;
+  });
+
+  it('should set the team name from the route', () => {
+    expect(component.teamName).toEqual('devs');
   });
 
   describe('requestCaptchaStateAndLogIn', () => {

--- a/ui/src/app/modules/boards/pages/login/login.page.spec.ts
+++ b/ui/src/app/modules/boards/pages/login/login.page.spec.ts
@@ -26,7 +26,6 @@ import { TestBed } from '@angular/core/testing';
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let mockTeamService;
-  let mockRoute;
   let mockRouter;
   let mockRecaptchaComponent;
 

--- a/ui/src/app/modules/boards/pages/login/login.page.ts
+++ b/ui/src/app/modules/boards/pages/login/login.page.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import {Component, ViewChild} from '@angular/core';
-import {Router} from '@angular/router';
+import {Component, ViewChild, OnInit} from '@angular/core';
+import {ActivatedRoute, Router} from '@angular/router';
 
 import {AuthService} from '../../../auth/auth.service';
 import {TeamService} from '../../../teams/services/team.service';
@@ -32,9 +32,9 @@ import {of} from 'rxjs/internal/observable/of';
   templateUrl: './login.page.html',
   styleUrls: ['./login.page.scss'],
 })
-export class LoginComponent {
+export class LoginComponent implements OnInit {
 
-  constructor(private teamService: TeamService, private router: Router) {
+  constructor(private teamService: TeamService, private route: ActivatedRoute, private router: Router) {
   }
 
   @ViewChild(RecaptchaComponent) recaptchaComponent: RecaptchaComponent;
@@ -42,6 +42,10 @@ export class LoginComponent {
   teamName: string;
   password: string;
   errorMessage: string;
+
+  ngOnInit() {
+    this.teamName = this.route.snapshot.params['teamId'];
+  }
 
   requestCaptchaStateAndLogIn(): void {
     if (!this.validateInput()) {


### PR DESCRIPTION
## Overview
Addresses https://github.com/FordLabs/retroquest/issues/18

## Testing Instructions
Attempt to access a `team/{ team-name }` route