### PR TITLE
Parses out the assignees from the action item's message.

### DIFF
--- a/ui/src/app/modules/teams/components/actions-header/actions-header.component.spec.ts
+++ b/ui/src/app/modules/teams/components/actions-header/actions-header.component.spec.ts
@@ -37,7 +37,7 @@ describe('ActionsHeaderComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  describe('addThought', () => {
+  describe('addActionItem', () => {
 
     const mockDateString = '2018-01-01';
     const mockDate = moment(mockDateString).toDate();
@@ -50,22 +50,58 @@ describe('ActionsHeaderComponent', () => {
       jasmine.clock().uninstall();
     });
 
-    it('should construct the thought and call ThoughtService.addThought', () => {
-      const newTask = 'a new actionItem';
+    it('should construct the action item and call the backend', () => {
+      const newMessage = 'a new actionItem';
 
       const expectedActionItem: ActionItem = {
         id: null,
         teamId: teamId,
-        task: newTask,
+        task: newMessage,
         completed: false,
         assignee: null,
         dateCreated: moment(mockDateString).format()
       };
 
-      component.addActionItem(newTask);
+      component.addActionItem(newMessage);
 
       expect(mockActionItemService.addActionItem).toHaveBeenCalledWith(expectedActionItem);
     });
+
+    it('should parse out the assignees from the new message and add it to the action item', () => {
+      const newUnformattedMessage = `a new actionItem @ben @frank`;
+      const expectedFormattedMessage = 'a new actionItem';
+
+      const expectedActionItem: ActionItem = {
+        id: null,
+        teamId: teamId,
+        task: expectedFormattedMessage,
+        completed: false,
+        assignee: 'ben, frank',
+        dateCreated: moment(mockDateString).format()
+      };
+
+      component.addActionItem(newUnformattedMessage);
+
+      expect(mockActionItemService.addActionItem).toHaveBeenCalledWith(expectedActionItem);
+    });
+
+    it('should set the assignees in the action item to null if none could be parsed out of the message',
+      () => {
+        const newMessage = `a new actionItem`;
+
+        const expectedActionItem: ActionItem = {
+          id: null,
+          teamId: teamId,
+          task: newMessage,
+          completed: false,
+          assignee: null,
+          dateCreated: moment(mockDateString).format()
+        };
+
+        component.addActionItem(newMessage);
+
+        expect(mockActionItemService.addActionItem).toHaveBeenCalledWith(expectedActionItem);
+      });
   });
 
   describe('onSortChanged', () => {

--- a/ui/src/app/modules/teams/components/actions-header/actions-header.component.spec.ts
+++ b/ui/src/app/modules/teams/components/actions-header/actions-header.component.spec.ts
@@ -68,7 +68,7 @@ describe('ActionsHeaderComponent', () => {
     });
 
     it('should parse out the assignees from the new message and add it to the action item', () => {
-      const newUnformattedMessage = `a new actionItem @ben @frank`;
+      const newUnformattedMessage = `a new actionItem @ben12 @frank`;
       const expectedFormattedMessage = 'a new actionItem';
 
       const expectedActionItem: ActionItem = {
@@ -76,7 +76,7 @@ describe('ActionsHeaderComponent', () => {
         teamId: teamId,
         task: expectedFormattedMessage,
         completed: false,
-        assignee: 'ben, frank',
+        assignee: 'ben12, frank',
         dateCreated: moment(mockDateString).format()
       };
 

--- a/ui/src/app/modules/teams/components/actions-header/actions-header.component.ts
+++ b/ui/src/app/modules/teams/components/actions-header/actions-header.component.ts
@@ -22,7 +22,7 @@ import * as moment from 'moment';
 import {Themes} from '../../../domain/Theme';
 
 const ASSIGNEE_PARSE_SYMBOL = '@';
-const ASSIGNEE_PARSE_REGEX = /(\@[a-zA-Z]+\b)/g;
+const ASSIGNEE_PARSE_REGEX = /(\@[a-zA-Z0-9]+\b)/g;
 
 @Component({
   selector: 'rq-actions-header',

--- a/ui/src/app/modules/teams/components/actions-header/actions-header.component.ts
+++ b/ui/src/app/modules/teams/components/actions-header/actions-header.component.ts
@@ -21,6 +21,9 @@ import {ActionItemService} from '../../services/action.service';
 import * as moment from 'moment';
 import {Themes} from '../../../domain/Theme';
 
+const ASSIGNEE_PARSE_SYMBOL = '@';
+const ASSIGNEE_PARSE_REGEX = /(\@[a-zA-Z]+\b)/g;
+
 @Component({
   selector: 'rq-actions-header',
   templateUrl: './actions-header.component.html',
@@ -42,20 +45,43 @@ export class ActionsHeaderComponent {
   public addActionItem(newMessage: string): void {
     if (newMessage && newMessage.length) {
       const todaysDate = moment().format();
-      const actionItem: ActionItem = {
-        id: null,
-        teamId: this.teamId,
-        task: newMessage,
-        completed: false,
-        assignee: null,
-        dateCreated: todaysDate
-      };
+      const assignees = this.parseAssignees(newMessage);
+      const updatedMessage = this.removeAssigneesFromMessage(newMessage, assignees);
 
-      this.actionItemService.addActionItem(actionItem);
+      if (updatedMessage && updatedMessage.length) {
+        const actionItem: ActionItem = {
+          id: null,
+          teamId: this.teamId,
+          task: updatedMessage,
+          completed: false,
+          assignee: assignees ? assignees.join(', ') : null,
+          dateCreated: todaysDate
+        };
+
+        this.actionItemService.addActionItem(actionItem);
+      }
     }
   }
 
   public onSortChanged(sortState: boolean): void {
     this.sortChanged.emit(sortState);
+  }
+
+  private parseAssignees(newMessage: string): string[] {
+    const matches = newMessage.match(ASSIGNEE_PARSE_REGEX);
+    if (matches) {
+      return matches.map(assignee => assignee.replace(ASSIGNEE_PARSE_SYMBOL, ''));
+    }
+    return null;
+  }
+
+  private removeAssigneesFromMessage(newMessage: string, assignees: string[]): string {
+    if (assignees) {
+      return newMessage
+        .replace(ASSIGNEE_PARSE_REGEX, '')
+        .replace(/\s+/g, ' ') // kill extra whitespaces in middle of message
+        .trim();
+    }
+    return newMessage;
   }
 }


### PR DESCRIPTION
## Overview
This PR allows users to assign new action items to people by mentioning their names in the new message.

It uses the **@** symbol to denote assignees.

### Demo
![capture1](https://user-images.githubusercontent.com/6293337/51435184-e448bb80-1c3f-11e9-918f-f1ad1c01f3ed.JPG)
![capture2](https://user-images.githubusercontent.com/6293337/51435185-e6127f00-1c3f-11e9-8656-eb745bde39e1.JPG)
