### PR TITLE
Removes transparency from completed thoughts on Archived Boards

### DIFF
--- a/ui/src/app/modules/controls/task/task.component.html
+++ b/ui/src/app/modules/controls/task/task.component.html
@@ -33,7 +33,10 @@
     #content_value
     [(ngModel)]="taskMessage"
     class="content-message edit-input"
-    [ngClass]="{'disable opacify': task.discussed }"
+    [ngClass]="{
+      'disable': task.discussed,
+      'opacify': task.discussed && !archived
+    }"
     [readonly]="!taskEditModeEnabled"
     (blur)="editModeOff()"
     (keydown.enter)="forceBlur(); $event.preventDefault()"
@@ -74,7 +77,7 @@
     <div
       class="star-background"
       [ngClass]="{
-        'opacify': task.discussed || taskEditModeEnabled,
+        'opacify': (task.discussed || taskEditModeEnabled) && !archived,
         'dark-theme': darkThemeIsEnabled
       }"
     >
@@ -86,7 +89,7 @@
       ></i>
     </div>
     <div class="star-count"
-         [ngClass]="{'opacify': task.discussed || taskEditModeEnabled}"
+         [ngClass]="{'opacify': (task.discussed || taskEditModeEnabled) && !archived}"
     >{{task.hearts}}
     </div>
   </div>
@@ -140,7 +143,7 @@
   <div
     class="complete-container"
     [ngClass]="{
-      'opacify': taskEditModeEnabled || readOnly,
+      'opacify': (taskEditModeEnabled || readOnly) && !archived,
       'dark-theme': darkThemeIsEnabled,
       'disable': taskEditModeEnabled
     }"

--- a/ui/src/app/modules/controls/task/task.component.ts
+++ b/ui/src/app/modules/controls/task/task.component.ts
@@ -43,6 +43,7 @@ export class TaskComponent implements AfterViewChecked {
   @Input() enableOverlayBorder = false;
   @Input() readOnly = false;
   @Input() theme = Themes.Light;
+  @Input() archived = false;
 
   @Output() messageChanged: EventEmitter<string> = new EventEmitter<string>();
   @Output() deleted: EventEmitter<Thought> = new EventEmitter<Thought>();

--- a/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.html
+++ b/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.html
@@ -28,6 +28,7 @@
     [@fadeInOutAnimation]="thought.state"
     [readOnly]="readOnly"
     [theme]="theme"
+    [archived]="archived"
   >
   </rq-task>
 </div>

--- a/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.ts
+++ b/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.ts
@@ -36,6 +36,7 @@ export class ThoughtsColumnComponent {
   @Input() column: Column;
   @Input() thoughts: Array<Thought> = [];
   @Input() readOnly = false;
+  @Input() archived = false;
 
   @Input() theme: Themes = Themes.Light;
 

--- a/ui/src/app/modules/teams/pages/archived-board/archived-board.page.html
+++ b/ui/src/app/modules/teams/pages/archived-board/archived-board.page.html
@@ -51,7 +51,7 @@
     >
       <rq-thoughts-header [column]="column" [thoughtCount]="getColumnThoughtCount(column)" [hideNewThought]="true"
       ></rq-thoughts-header>
-      <rq-thoughts-column [column]="column" [thoughts]="getThoughtsInColumn(column)" [readOnly]="true"
+      <rq-thoughts-column [column]="column" [thoughts]="getThoughtsInColumn(column)" [readOnly]="true" [archived]="true"
       ></rq-thoughts-column>
     </div>
   </div>


### PR DESCRIPTION
- Adds an Archived input property to Task components, which is set to true on Archived Boards. 
- Removes 'opacify' styling from Task component content, star count, and completed checkbox, if the Archived input property is true.

Resolves Issue #177, regarding completed task transparency being unnecessary on archived boards and making thoughts hard to read.

### Demo
<img width="510" alt="archiveoverlays-after" src="https://user-images.githubusercontent.com/8216389/52077474-14a52980-255f-11e9-81fe-9e62d12db536.png">
