### PR TITLE
Fix websocket timeout

### DIFF
--- a/ui/src/app/modules/teams/pages/team/team.page.spec.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.spec.ts
@@ -245,12 +245,24 @@ describe('TeamPageComponent', () => {
 
   describe('ngOnInit', () => {
 
+    let mockTimeOutValue = -1;
+
     const mockWindow = {
-      setInterval: (fn) => fn()
+      setInterval: (fn, timeout) => {
+        mockTimeOutValue = timeout;
+        fn()
+      }
     };
 
     beforeEach(() => {
       component.globalWindowRef = mockWindow;
+    });
+
+    fit('websocket should send heartbeat to backend every 1s', () => {
+      component.ngOnInit();
+      mockActiveRoute.params.next({teamId: 1});
+
+      expect(mockTimeOutValue).toEqual(1 * 1000);
     });
 
     it('should call open websocket', () => {

--- a/ui/src/app/modules/teams/pages/team/team.page.spec.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.spec.ts
@@ -258,7 +258,7 @@ describe('TeamPageComponent', () => {
       component.globalWindowRef = mockWindow;
     });
 
-    fit('websocket should send heartbeat to backend every 1s', () => {
+    it('websocket should send heartbeat to backend every 1s', () => {
       component.ngOnInit();
       mockActiveRoute.params.next({teamId: 1});
 

--- a/ui/src/app/modules/teams/pages/team/team.page.spec.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.spec.ts
@@ -250,7 +250,7 @@ describe('TeamPageComponent', () => {
     const mockWindow = {
       setInterval: (fn, timeout) => {
         mockTimeOutValue = timeout;
-        fn()
+        fn();
       }
     };
 

--- a/ui/src/app/modules/teams/pages/team/team.page.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.ts
@@ -129,6 +129,7 @@ export class TeamPageComponent implements OnInit {
         this.websocketInit();
       }
 
+
       this.websocketService.intervalId = this.globalWindowRef.setInterval(() => {
         if (this.websocketService.getWebsocketState() === WebSocket.CLOSED) {
           this.websocketService.closeWebsocket();
@@ -136,8 +137,10 @@ export class TeamPageComponent implements OnInit {
         } else if (this.websocketService.getWebsocketState() === WebSocket.OPEN) {
           this.websocketService.sendHeartbeat();
         }
-      }, 1000 * 60);
+      }, 1000 * 1);
+
     });
+
   }
 
   public getColumnThoughtCount(column: Column): number {

--- a/ui/src/app/modules/teams/pages/team/team.page.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.ts
@@ -357,7 +357,11 @@ export class TeamPageComponent implements OnInit {
     const teamPage = document.getElementById('page');
     const pageGestures = new Hammer(teamPage);
 
-    pageGestures.on('swipeleft', () => { this.incrementSelectedIndex(); });
-    pageGestures.on('swiperight', () => { this.decrementSelectedIndex(); });
+    pageGestures.on('swipeleft', () => {
+      this.incrementSelectedIndex();
+    });
+    pageGestures.on('swiperight', () => {
+      this.decrementSelectedIndex();
+    });
   }
 }


### PR DESCRIPTION
## Overview
Decreases the websocket state checking interval from once a minute to once a second, so 60s -> 1s.

We tested this on the computer by manually shutting down the websocket in chrome and watching it restart itself automatically.