### PR TITLE
Action item radiator is now moved into the top view header

### DIFF
--- a/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.html
+++ b/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.html
@@ -14,13 +14,6 @@
   ~  See the License for the specific language governing permissions and
   ~  limitations under the License.
   -->
-<div
-  class="heading"
-  [ngClass]="{'dark-theme': 'darkThemeIsEnabled'}"
->
-  actions radiator
-</div>
-
 <rq-action-item-task
   *ngFor="let actionItem of actionItems"
   (click)="$event.stopPropagation()"

--- a/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.html
+++ b/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.html
@@ -34,6 +34,6 @@
   [text]="pageIsAutoScrolling ? 'stop autoscroll': 'start autoscroll'"
   (click)="toggleAutoScroll()"
   [ngClass]="{
-      'stop': pageIsAutoScrolling
-    }"
+    'stop': pageIsAutoScrolling
+  }"
 ></rq-button>

--- a/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.scss
+++ b/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.scss
@@ -28,18 +28,6 @@
   position: relative;
   width: 500px;
 
-  .heading {
-    color: inherit;
-    font-size: 2rem;
-    font-weight: bold;
-    margin-bottom: 36px;
-    text-transform: capitalize;
-
-    &.dark-theme {
-      color: $clouds;
-    }
-  }
-
   rq-action-item-task {
     height: auto;
     margin-bottom: 150px;

--- a/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.scss
+++ b/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.scss
@@ -22,8 +22,8 @@
   display: flex;
   flex-direction: column;
 
-  height: 500px;
   justify-content: flex-start;
+  margin: 0 auto;
   padding: 24px;
   position: relative;
   width: 500px;

--- a/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.scss
+++ b/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.scss
@@ -24,7 +24,6 @@
 
   justify-content: flex-start;
   margin: 0 auto;
-  padding: 24px;
   position: relative;
   width: 500px;
 

--- a/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.spec.ts
+++ b/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.spec.ts
@@ -19,18 +19,22 @@
 import {ActionsRadiatorViewComponent} from './actions-radiator-view.component';
 import {ActionItemService} from '../../teams/services/action.service';
 import {of} from 'rxjs';
+import {DataService} from '../../data.service';
 
 describe('ActionsRadiatorViewComponent', () => {
 
   let component: ActionsRadiatorViewComponent;
   let mockActionItemService: ActionItemService;
+  let dataService: DataService;
 
   beforeEach(() => {
     mockActionItemService = jasmine.createSpyObj({
       fetchActionItems: of([])
     });
 
-    component = new ActionsRadiatorViewComponent(mockActionItemService);
+    dataService = new DataService();
+
+    component = new ActionsRadiatorViewComponent(mockActionItemService, dataService);
   });
 
   it('should create', () => {

--- a/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.ts
+++ b/ui/src/app/modules/controls/actions-radiator-view/actions-radiator-view.component.ts
@@ -15,11 +15,12 @@
  *  limitations under the License.
  */
 
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
 import {ActionItem} from '../../domain/action-item';
 import * as $ from 'jquery';
 import {Themes} from '../../domain/Theme';
 import {ActionItemService} from '../../teams/services/action.service';
+import {DataService} from '../../data.service';
 
 const ESC_KEY = 27;
 
@@ -31,10 +32,10 @@ const ESC_KEY = 27;
     '[style.display]': 'visible ? "flex": "none"'
   }
 })
-export class ActionsRadiatorViewComponent implements OnInit {
+export class ActionsRadiatorViewComponent implements OnInit, OnDestroy {
 
-  @Input() visible = false;
-  @Input() theme: Themes = Themes.Light;
+  @Input() visible = true;
+  @Input() theme;
   @Input() teamId: string;
 
   @Output() visibilityChanged: EventEmitter<boolean> = new EventEmitter<boolean>();
@@ -46,15 +47,25 @@ export class ActionsRadiatorViewComponent implements OnInit {
   pageIsAutoScrolling = false;
   scrollingIntervalId: any = null;
 
-  constructor(private actionItemService: ActionItemService) {
+  constructor(private actionItemService: ActionItemService,
+              private dataService: DataService) {
 
   }
 
   ngOnInit(): void {
+    this.teamId = this.dataService.team.id;
+    this.theme = this.dataService.theme;
+
+    this.dataService.themeChanged.subscribe(theme => this.theme = theme);
 
     this.actionItemService.fetchActionItems(this.teamId).subscribe(actionItems => {
       this.actionItems = actionItems;
     });
+  }
+
+  ngOnDestroy(): void {
+    this.toggleAutoScroll();
+    this.resetScroll();
   }
 
   get darkThemeIsEnabled(): boolean {

--- a/ui/src/app/modules/controls/top-header/top-header.component.html
+++ b/ui/src/app/modules/controls/top-header/top-header.component.html
@@ -46,20 +46,29 @@
   <div class="center-content">
     <rq-button
       class="retro-view-button"
-      [type]="isSelected('retro') ? 'primary' : 'secondary'"
+      [type]="retroViewIsSelected ? 'primary' : 'secondary'"
       text="retro"
       [theme]="theme"
-      [ngClass]="{'selected': isSelected('retro')}"
+      [ngClass]="{'selected': retroViewIsSelected}"
       (click)="changeView('retro')"
     ></rq-button>
 
     <rq-button
       class="archives-view-button"
-      [type]="isSelected('archives') ? 'primary' : 'secondary'"
+      [type]="archivesViewIsSelected ? 'primary' : 'secondary'"
       text="archives"
       [theme]="theme"
-      [ngClass]="{'selected': isSelected('archives')}"
+      [ngClass]="{'selected': archivesViewIsSelected}"
       (click)="changeView('archives')"
+    ></rq-button>
+
+    <rq-button
+      class="radiator-view-button"
+      [type]="radiatorViewIsSelected ? 'primary' : 'secondary'"
+      text="radiator"
+      [theme]="theme"
+      [ngClass]="{'selected': radiatorViewIsSelected}"
+      (click)="changeView('radiator')"
     ></rq-button>
 
   </div>

--- a/ui/src/app/modules/controls/top-header/top-header.component.spec.ts
+++ b/ui/src/app/modules/controls/top-header/top-header.component.spec.ts
@@ -54,6 +54,12 @@ describe('TopHeaderComponent', () => {
       component.ngOnInit();
       expect(component.selectedView).toEqual('archives');
     });
+
+    it('should change the view to radiator if the window url ends with radiator string', () => {
+      Object.defineProperty(router, 'url', {value: `/url/${fakeId}/radiator`});
+      component.ngOnInit();
+      expect(component.selectedView).toEqual('radiator');
+    });
   });
 
   describe('isSelected', () => {

--- a/ui/src/app/modules/controls/top-header/top-header.component.ts
+++ b/ui/src/app/modules/controls/top-header/top-header.component.ts
@@ -46,7 +46,21 @@ export class TopHeaderComponent implements OnInit {
       this.changeView('retro');
     } else if (this.router.url.includes('archives')) {
       this.changeView('archives');
+    } else if (this.router.url.endsWith('radiator')) {
+      this.changeView('radiator');
     }
+  }
+
+  get retroViewIsSelected(): boolean {
+    return this.selectedView === 'retro';
+  }
+
+  get radiatorViewIsSelected(): boolean {
+    return this.selectedView === 'radiator';
+  }
+
+  get archivesViewIsSelected(): boolean {
+    return this.selectedView === 'archives';
   }
 
   get darkThemeIsEnabled(): boolean {
@@ -76,6 +90,10 @@ export class TopHeaderComponent implements OnInit {
       }
       case 'archives': {
         this.router.navigateByUrl(`/team/${this.teamId}/archives`);
+        break;
+      }
+      case 'radiator': {
+        this.router.navigateByUrl(`/team/${this.teamId}/radiator`);
         break;
       }
       default:

--- a/ui/src/app/modules/sub-app/sub-app.component.scss
+++ b/ui/src/app/modules/sub-app/sub-app.component.scss
@@ -16,12 +16,15 @@
  */
 @import 'color-vars';
 
+// sass-lint:disable no-vendor-prefixes
+
 :host {
+  -webkit-overflow-scrolling: touch;
   background-color: $background-color-light;
   display: block;
   height: 100%;
-
-  width: 100%;
+  overflow: auto;
+  width: 100%;   // Enables smooth scrolling for IOS devices.
 
   &.dark-theme {
     background-color: $background-color-dark;

--- a/ui/src/app/modules/teams/components/header/header.component.html
+++ b/ui/src/app/modules/teams/components/header/header.component.html
@@ -25,18 +25,7 @@
   >
     <div
       class="header-bottom-content"
-      [ngClass]="{
-          'center-content': actionsRadiatorViewEnabled
-      }"
     >
-      <rq-button
-        class="actions-radiator-button"
-        type="secondary"
-        [text]="actionsRadiatorViewEnabled ? 'view retro' : 'actions radiator'"
-        (click)="onActionsRadiatorViewClicked()"
-        [theme]="theme"
-      ></rq-button>
-
       <button
         id="giveFeedback"
         class="rq-button-secondary"
@@ -53,9 +42,7 @@
       <button
         class="rq-button-secondary download-button"
         (click)="giveZipDownloadToUser()"
-        [ngClass]="{
-            'hide': actionsRadiatorViewEnabled
-         }">
+      >
         <span class="button-text">Download CSV</span>
         <i class="fas fa-download button-icon"></i>
       </button>

--- a/ui/src/app/modules/teams/components/header/header.component.scss
+++ b/ui/src/app/modules/teams/components/header/header.component.scss
@@ -92,56 +92,9 @@
         }
       }
 
-      .change-theme-button {
-
-        @media only screen and (max-width: 610px) {
-          display: none;
-        }
-
-      }
-
-      .change-theme-icon-container {
-        box-sizing: border-box;
-        display: none;
-        height: 100%;
-        padding-right: 18px;
-
-        @media only screen and (max-width: 610px) {
-          align-items: center;
-          display: flex;
-          justify-content: center;
-          text-align: center;
-        }
-
-      }
-
       rq-button {
         height: 100%;
         width: auto;
-      }
-
-      .actions-radiator-button {
-        @media only screen and (max-width: 610px) {
-          display: none;
-        }
-      }
-
-      .archived-boards-link {
-        color: inherit;
-
-        @media only screen and (max-width: 610px) {
-          rq-button {
-            display: none;
-          }
-
-          & {
-            align-items: center;
-            display: flex;
-            height: 100%;
-            padding: 0 18px;
-          }
-        }
-
       }
 
       #giveFeedback {

--- a/ui/src/app/modules/teams/components/header/header.component.spec.ts
+++ b/ui/src/app/modules/teams/components/header/header.component.spec.ts
@@ -92,19 +92,4 @@ describe('HeaderComponent', () => {
     });
 
   });
-
-  describe('onActionsRadiatorViewClicked', () => {
-
-    beforeEach(() => {
-      component.actionsRadiatorViewClicked = jasmine.createSpyObj({
-        emit: null
-      });
-      component.onActionsRadiatorViewClicked();
-    });
-
-    it('should emit the actions radiator view signal', () => {
-      expect(component.actionsRadiatorViewClicked.emit).toHaveBeenCalled();
-    });
-  });
-
 });

--- a/ui/src/app/modules/teams/components/header/header.component.ts
+++ b/ui/src/app/modules/teams/components/header/header.component.ts
@@ -39,7 +39,6 @@ export class HeaderComponent implements OnInit {
   @Input() theme = Themes.Light;
 
   @Output() endRetro: EventEmitter<void> = new EventEmitter<void>();
-  @Output() actionsRadiatorViewClicked: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   @ViewChild(FeedbackDialogComponent) feedbackDialog: FeedbackDialogComponent;
   @ViewChild(EndRetroDialogComponent) endRetroDialog: EndRetroDialogComponent;
@@ -78,14 +77,9 @@ export class HeaderComponent implements OnInit {
     this.feedbackService.addFeedback(feedback).subscribe();
   }
 
-  public onActionsRadiatorViewClicked(): void {
-    this.actionsRadiatorViewEnabled = !this.actionsRadiatorViewEnabled;
-    this.actionsRadiatorViewClicked.emit(this.actionsRadiatorViewEnabled);
-  }
-
   giveZipDownloadToUser() {
     this.http.get(this.getCsvUrl(), {responseType: 'blob'}).subscribe(csvData => {
-      saveAs(csvData,  `${this.teamId}-board.csv`);
+      saveAs(csvData, `${this.teamId}-board.csv`);
     });
   }
 }

--- a/ui/src/app/modules/teams/pages/archives/archives.page.ts
+++ b/ui/src/app/modules/teams/pages/archives/archives.page.ts
@@ -52,7 +52,6 @@ export class ArchivesPageComponent implements OnInit {
     this.teamId = this.dataService.team.id;
     this.teamName = this.dataService.team.name;
     this.theme = this.dataService.theme;
-    console.log(this.theme, Themes.Light);
 
     this.dataService.themeChanged.subscribe(theme => this.theme = theme);
 

--- a/ui/src/app/modules/teams/pages/team/team.page.html
+++ b/ui/src/app/modules/teams/pages/team/team.page.html
@@ -26,15 +26,6 @@
   >
   </rq-header>
 
-  <rq-actions-radiator-view
-    #radiatorView
-    *ngIf="actionsRadiatorViewIsSelected"
-    [visible]="actionsRadiatorViewIsSelected"
-    [theme]="theme"
-    [teamId]="teamId"
-  >
-  </rq-actions-radiator-view>
-
   <div
     id="team-content"
     [ngClass]="{

--- a/ui/src/app/modules/teams/teams.module.ts
+++ b/ui/src/app/modules/teams/teams.module.ts
@@ -41,6 +41,7 @@ import {BoardSummaryComponent} from './components/board-summary/board-summary.co
 import {ArchivedBoardPageComponent} from './pages/archived-board/archived-board.page';
 import {SubAppComponent} from '../sub-app/sub-app.component';
 import {DataService} from '../data.service';
+import {ActionsRadiatorViewComponent} from '../controls/actions-radiator-view/actions-radiator-view.component';
 
 @NgModule({
   imports: [
@@ -51,6 +52,7 @@ import {DataService} from '../data.service';
         path: 'team/:teamId', canActivate: [TeamPageQueryParamGuard], component: SubAppComponent
         , children: [
           {path: '', component: TeamPageComponent, pathMatch: 'full'},
+          {path: 'radiator', component: ActionsRadiatorViewComponent},
           {path: 'archives', component: ArchivesPageComponent, data: {teamId: ':teamId'}, canActivate: [AuthGuard]},
           {path: 'archives/:boardId', component: ArchivedBoardPageComponent, canActivate: [AuthGuard]}
         ]

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -17,12 +17,8 @@
 
 @import 'color-vars';
 
-// sass-lint:disable no-vendor-prefixes
-
 html {
-  -webkit-overflow-scrolling: touch;   // Enables smooth scrolling for IOS devices.
   height: 100%;
-  overflow: auto;
   padding: 0;
 }
 


### PR DESCRIPTION
## Overview
This was done in order to keep the radiator navigation consistent with the archive and retro nav buttons.

Another added benefit of this is that users are able to bookmark the radiator view directly.


### Demo
![image](https://user-images.githubusercontent.com/6293337/54892568-634cb100-4e88-11e9-9139-4f9dc9576f6d.png)

![image](https://user-images.githubusercontent.com/6293337/54892850-92afed80-4e89-11e9-97ba-e3b897e36389.png)
