### PR TITLE
Adds ability to archive action items and displays them on the archive…

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItem.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItem.java
@@ -46,6 +46,7 @@ public class ActionItem {
     private String teamId;
     private String assignee;
     private Date dateCreated;
+    private boolean archived;
 
     private String getCompletedString() {
         return completed ? "yes" : "no";

--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
@@ -72,6 +72,12 @@ public class ActionItemController {
         return actionItemRepository.findAllByTeamId(teamId);
     }
 
+    @GetMapping("/api/team/{teamId}/action-items/archived")
+    @PreAuthorize("#teamId == authentication.principal")
+    public List<ActionItem> getArchivedActionItemsForTeam(@PathVariable("teamId") String teamId) {
+        return actionItemRepository.findAllByTeamIdAndArchivedIsTrue(teamId);
+    }
+
     @PostMapping("/api/team/{teamId}/action-item")
     @PreAuthorize("#teamId == authentication.principal")
     public ResponseEntity createActionItemForTeam(@PathVariable("teamId") String teamId, @RequestBody ActionItem actionItem) throws URISyntaxException {
@@ -103,6 +109,7 @@ public class ActionItemController {
         savedActionItem.setTask(updatedActionItem.getTask());
         savedActionItem.setAssignee(updatedActionItem.getAssignee());
         savedActionItem.setCompleted(updatedActionItem.isCompleted());
+        savedActionItem.setArchived(updatedActionItem.isArchived());
         actionItemRepository.save(savedActionItem);
         return new WebsocketPutResponse<>(savedActionItem);
     }

--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemRepository.java
@@ -25,5 +25,9 @@ import java.util.List;
 @Repository
 public interface ActionItemRepository extends JpaRepository<ActionItem, Long>{
     List<ActionItem> findAllByTeamId(String teamId);
+    List<ActionItem> findAllByTeamIdAndArchivedIsFalse(String teamId);
+    List<ActionItem> findAllByTeamIdAndArchivedIsTrue(String teamId);
+
     void deleteActionItemByTeamIdAndId(String teamId, Long id);
+
 }

--- a/api/src/main/java/com/ford/labs/retroquest/v2/columns/ColumnCombinerService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/v2/columns/ColumnCombinerService.java
@@ -48,7 +48,7 @@ public class ColumnCombinerService {
 
     public ColumnCombinerResponse aggregateResponse(String teamId) {
         List<Thought> thoughts = thoughtRepository.findAllByTeamIdAndBoardIdIsNull(teamId);
-        List<ActionItem> actionItems = actionItemRepository.findAllByTeamId(teamId);
+        List<ActionItem> actionItems = actionItemRepository.findAllByTeamIdAndArchivedIsFalse(teamId);
         List<ColumnTitle> columnTitles = columnTitleRepository.findAllByTeamId(teamId);
 
         Map<ColumnTitle, List<Thought>> columnTitleListMap = columnTitles.stream().collect(

--- a/api/src/main/resources/db/h2/V004__add_archive_column_to_action_item_table.sql
+++ b/api/src/main/resources/db/h2/V004__add_archive_column_to_action_item_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `action_item`
+  ADD `archived` bit(1) NOT NULL DEFAULT 0;

--- a/api/src/main/resources/db/migration/V012__add_archive_column_to_action_item_table.sql
+++ b/api/src/main/resources/db/migration/V012__add_archive_column_to_action_item_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `action_item`
+    ADD `archived` bit(1) NOT NULL DEFAULT 0;

--- a/api/src/test/java/com/ford/labs/retroquest/v2/columns/ColumnCombinerServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/v2/columns/ColumnCombinerServiceTest.java
@@ -69,7 +69,7 @@ public class ColumnCombinerServiceTest {
                 )
         );
 
-        when(actionItemRepository.findAllByTeamId(fakeTeamId)).thenReturn(
+        when(actionItemRepository.findAllByTeamIdAndArchivedIsFalse(fakeTeamId)).thenReturn(
                 Arrays.asList(
                         expectedActiveActionItems,
                         expectedCompletedActionItems

--- a/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.html
+++ b/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.html
@@ -17,6 +17,8 @@
 
 <rq-action-item-task
   #action_item_component
+  [readOnly]="readonly"
+  [archived]="readonly"
   [theme]="theme"
   *ngIf="visible"
   [enableOverlayBorder]="true"

--- a/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.ts
+++ b/ui/src/app/modules/controls/action-item-dialog/action-item-dialog.component.ts
@@ -36,8 +36,9 @@ const ESC_KEY = 27;
 export class ActionItemDialogComponent implements AfterContentChecked {
 
   @Input() actionItem: ActionItem = emptyActionItem();
-  @Input() visible = true;
+  @Input() visible = false;
   @Input() theme: Themes = Themes.Light;
+  @Input() readonly = false;
 
   @Output() visibilityChanged: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() messageChanged: EventEmitter<string> = new EventEmitter<string>();

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.html
@@ -27,8 +27,8 @@
 <div
   class="content-area"
   [ngClass]="{
-    'disable': actionItem.completed,
-    'opacify': actionItem.completed
+    'disable': actionItem.completed && !actionItem.archived,
+    'opacify': actionItem.completed && !actionItem.archived
   }"
 >
 
@@ -62,8 +62,8 @@
 
 <div class="assigned-to-section"
      [ngClass]="{
-       'disable': taskEditModeEnabled || actionItem.completed,
-       'opacify': !displayAsLinkable && (taskEditModeEnabled || actionItem.completed)
+       'disable': taskEditModeEnabled || (actionItem.completed && !actionItem.archived),
+       'opacify': !displayAsLinkable && (taskEditModeEnabled || (actionItem.completed && !actionItem.archived))
      }">
   <div class="label">assigned to</div>
 
@@ -81,6 +81,7 @@
       }"
       [maxLength]="maxAssigneeLength"
       (focus)="assigneeCharacterCountdownIsVisible = true"
+      [disabled]="archived"
     >
     <rq-floating-character-countdown
       #assigneeCharacterCountdown
@@ -130,11 +131,11 @@
     }"
   >
     <div class="date-created-header"
-         [ngClass]="{'opacify': actionItem.completed || taskEditModeEnabled}"
+         [ngClass]="{'opacify': (actionItem.completed  && !actionItem.archived) || taskEditModeEnabled}"
     >created
     </div>
     <div class="date-created-value"
-         [ngClass]="{'opacify': actionItem.completed || taskEditModeEnabled}"
+         [ngClass]="{'opacify': (actionItem.completed  && !actionItem.archived) || taskEditModeEnabled}"
     >{{getDateCreated()}}
     </div>
   </div>
@@ -170,11 +171,15 @@
   <div
     class="container delete-container"
     [ngClass]="{
-      'dark-theme': darkThemeIsEnabled
+      'dark-theme': darkThemeIsEnabled,
+      'disable': actionItem.archived || taskEditModeEnabled
     }"
     (click)="emitDeleteItem()">
-    <i class="fas fa-trash-alt"
-       [ngClass]="{'opacify': readOnly}"
+    <i
+      class="fas fa-trash-alt"
+      [ngClass]="{
+        'opacify': readOnly || taskEditModeEnabled
+       }"
     ></i>
     <rq-tooltip text="Delete" [theme]="theme"></rq-tooltip>
   </div>
@@ -182,8 +187,8 @@
   <div
     class="complete-container"
     [ngClass]="{
-      'opacify': taskEditModeEnabled || readOnly,
-      'disable': taskEditModeEnabled
+      'opacify': taskEditModeEnabled || (readOnly && !actionItem.archived),
+      'disable': taskEditModeEnabled || readOnly
     }"
     (click)="toggleTaskComplete()"
   >

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -1,4 +1,4 @@
-/*!
+/*!archives-sub-heading
  *  Copyright (c) 2018 Ford Motor Company
  *  All rights reserved.
  *

--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.ts
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.ts
@@ -26,7 +26,7 @@ import {Themes} from '../../domain/Theme';
   templateUrl: './action-item-task.component.html',
   styleUrls: ['./action-item-task.component.scss'],
   host: {
-    '[class.push-order-to-bottom]': 'actionItem.completed',
+    '[class.push-order-to-bottom]': 'actionItem.completed && !actionItem.archived',
     '[class.edit-mode]': '!displayAsLinkable && taskEditModeEnabled',
     '[class.dialog-overlay-border]': 'enableOverlayBorder',
     '[class.dark-theme]': 'darkThemeIsEnabled'
@@ -39,6 +39,7 @@ export class ActionItemTaskComponent implements AfterViewChecked {
   @Input() enableOverlayBorder = false;
   @Input() theme = Themes.Light;
   @Input() taskEditModeEnabled = false;
+  @Input() archived = false;
 
   @Output() messageChanged: EventEmitter<string> = new EventEmitter<string>();
   @Output() deleted: EventEmitter<ActionItem> = new EventEmitter<ActionItem>();

--- a/ui/src/app/modules/controls/task/task.component.html
+++ b/ui/src/app/modules/controls/task/task.component.html
@@ -127,16 +127,16 @@
   <div
     class="container delete-container"
     [ngClass]="{
-      'dark-theme': darkThemeIsEnabled
+      'dark-theme': darkThemeIsEnabled,
+      'disable': readOnly || taskEditModeEnabled
     }"
     (click)="emitDeleteItem()"
-    [ngClass]="{'disable': readOnly}"
   >
     <rq-tooltip text="Delete" [theme]="theme"></rq-tooltip>
 
 
     <i class="fas fa-trash-alt"
-       [ngClass]="{'opacify': readOnly}"
+       [ngClass]="{'opacify': readOnly || taskEditModeEnabled}"
     ></i>
   </div>
 

--- a/ui/src/app/modules/domain/action-item.ts
+++ b/ui/src/app/modules/domain/action-item.ts
@@ -24,6 +24,7 @@ export interface ActionItem {
   expanded?: boolean;
   dateCreated: string;
   state?: string;
+  archived: boolean;
 }
 
 export function emptyActionItem(): ActionItem {
@@ -33,6 +34,7 @@ export function emptyActionItem(): ActionItem {
     completed: false,
     teamId: null,
     assignee: null,
-    dateCreated: null
+    dateCreated: null,
+    archived: false
   };
 }

--- a/ui/src/app/modules/teams/components/actions-column/actions-column.component.spec.ts
+++ b/ui/src/app/modules/teams/components/actions-column/actions-column.component.spec.ts
@@ -39,7 +39,8 @@ describe('ActionsColumnComponent', () => {
       task: '',
       completed: false,
       assignee: null,
-      dateCreated: null
+      dateCreated: null,
+      archived: false
     };
 
     component.actionItemAggregation = {

--- a/ui/src/app/modules/teams/components/actions-column/actions-column.component.ts
+++ b/ui/src/app/modules/teams/components/actions-column/actions-column.component.ts
@@ -24,6 +24,7 @@ import {Themes} from '../../../domain/Theme';
 import * as moment from 'moment';
 import {ColumnResponse} from '../../../domain/column-response';
 import {WebsocketResponse} from '../../../domain/websocket-response';
+import {Column} from '../../../domain/column';
 
 @Component({
   selector: 'rq-actions-column',
@@ -40,6 +41,7 @@ export class ActionsColumnComponent implements OnInit {
   @Input() theme: Themes = Themes.Light;
   @Input() teamId: string;
   @Input() actionItemChanged: EventEmitter<WebsocketResponse> = new EventEmitter();
+  @Input() retroEnded: EventEmitter<Column> = new EventEmitter();
 
   sorted = false;
 
@@ -50,6 +52,10 @@ export class ActionsColumnComponent implements OnInit {
 
   ngOnInit(): void {
 
+    this.retroEnded.subscribe(() => {
+      this.actionItemAggregation.items.completed.splice(0, this.actionItemAggregation.items.completed.length);
+    });
+
     this.actionItemChanged.subscribe(
       response => {
 
@@ -58,7 +64,9 @@ export class ActionsColumnComponent implements OnInit {
         if (response.type === 'delete') {
           this.deleteActionItem(actionItem);
         } else {
-          this.updateActionItems(actionItem);
+          if (!actionItem.archived) {
+            this.updateActionItems(actionItem);
+          }
         }
       }
     );

--- a/ui/src/app/modules/teams/components/actions-header/actions-header.component.spec.ts
+++ b/ui/src/app/modules/teams/components/actions-header/actions-header.component.spec.ts
@@ -59,7 +59,8 @@ describe('ActionsHeaderComponent', () => {
         task: newMessage,
         completed: false,
         assignee: null,
-        dateCreated: moment(mockDateString).format()
+        dateCreated: moment(mockDateString).format(),
+        archived: false
       };
 
       component.addActionItem(newMessage);
@@ -77,7 +78,8 @@ describe('ActionsHeaderComponent', () => {
         task: expectedFormattedMessage,
         completed: false,
         assignee: 'ben12, frank',
-        dateCreated: moment(mockDateString).format()
+        dateCreated: moment(mockDateString).format(),
+        archived: false
       };
 
       component.addActionItem(newUnformattedMessage);
@@ -95,7 +97,8 @@ describe('ActionsHeaderComponent', () => {
           task: newMessage,
           completed: false,
           assignee: null,
-          dateCreated: moment(mockDateString).format()
+          dateCreated: moment(mockDateString).format(),
+          archived: false
         };
 
         component.addActionItem(newMessage);
@@ -114,7 +117,8 @@ describe('ActionsHeaderComponent', () => {
         task: expectedFormattedMessage,
         completed: false,
         assignee: expectedAssignee,
-        dateCreated: moment(mockDateString).format()
+        dateCreated: moment(mockDateString).format(),
+        archived: false
       };
 
       component.addActionItem(newMessage);

--- a/ui/src/app/modules/teams/components/actions-header/actions-header.component.ts
+++ b/ui/src/app/modules/teams/components/actions-header/actions-header.component.ts
@@ -56,7 +56,8 @@ export class ActionsHeaderComponent {
           task: updatedMessage,
           completed: false,
           assignee: assignees ? assignees.join(', ').substring(0, this.maxAssigneeLength) : null,
-          dateCreated: todaysDate
+          dateCreated: todaysDate,
+          archived: false
         };
 
         this.actionItemService.addActionItem(actionItem);

--- a/ui/src/app/modules/teams/pages/archives/archives.page.html
+++ b/ui/src/app/modules/teams/pages/archives/archives.page.html
@@ -107,23 +107,44 @@
 
   <div class="archives" *ngIf="actionItemArchivesAreSelected">
 
-    <div class="heading-container">
-      <div
-        class="archives-heading"
-        [ngClass]="{'dark-theme': darkThemeIsEnabled}"
-      >Action Item Archives
+    <div class="grid-wrapper">
+
+      <div class="heading-container">
+        <div
+          class="archives-heading"
+          [ngClass]="{'dark-theme': darkThemeIsEnabled}"
+        >Action Item Archives
+        </div>
+
+        <div
+          class="archives-sub-heading"
+          [ngClass]="{'dark-theme': darkThemeIsEnabled}"
+        >Examine completed action items from times gone by
+        </div>
       </div>
 
-      <div
-        class="archives-sub-heading"
-        [ngClass]="{'dark-theme': darkThemeIsEnabled}"
-      >Examine completed action items
+      <div class="action-item-container">
+        <rq-action-item-task
+          *ngFor="let actionItem of archivedActionItems"
+          [actionItem]="actionItem"
+          [theme]="theme"
+          [readOnly]="true"
+          [archived]="true"
+          (click)="showDialog(actionItem); actionItemDialog.show()"
+        ></rq-action-item-task>
       </div>
 
-      <div class="coming-soon-message" [ngClass]="{'dark-theme': darkThemeIsEnabled}">
-        This feature is coming soon. Stay tuned!
-      </div>
     </div>
 
   </div>
 </div>
+
+<rq-action-item-dialog
+  #actionItemDialog
+  [theme]="theme"
+  [actionItem]="selectedActionItem"
+  (visibilityChanged)="dialogIsVisible = $event"
+  [readonly]="true"
+>
+
+</rq-action-item-dialog>

--- a/ui/src/app/modules/teams/pages/archives/archives.page.scss
+++ b/ui/src/app/modules/teams/pages/archives/archives.page.scss
@@ -106,10 +106,10 @@
 
     .heading-container {
       margin-bottom: 24px;
-      width: $archives-content-base-width;
 
       .archives-heading {
         font-size: 1.5rem;
+        font-weight: 500;
 
         &.dark-theme {
           color: $clouds;
@@ -118,25 +118,14 @@
       }
 
       .archives-sub-heading {
+        font-size: 1.1rem;
         opacity: .6;
 
         &.dark-theme {
           color: $clouds;
         }
       }
-
-      .coming-soon-message {
-        font-size: 1.7rem;
-        font-weight: bold;
-        margin-top: 12px;
-        width: 800px;
-
-        &.dark-theme {
-          color: $clouds;
-        }
-      }
     }
-
 
     .archives-sort-section {
       align-items: center;
@@ -178,6 +167,19 @@
         }
       }
     }
+
+    .action-item-container {
+      display: grid;
+      grid-gap: 48px;
+      grid-template-columns: 350px 350px 350px;
+
+      rq-action-item-task {
+        font-size: .9rem;
+        height: auto;
+        width: inherit;
+      }
+    }
+
 
     .no-archives-info {
       text-align: center;

--- a/ui/src/app/modules/teams/pages/archives/archives.page.spec.ts
+++ b/ui/src/app/modules/teams/pages/archives/archives.page.spec.ts
@@ -17,12 +17,12 @@
 
 import {ArchivesPageComponent} from './archives.page';
 import {Subject} from 'rxjs';
-import {ActivatedRoute, Params} from '@angular/router';
 import {TeamService} from '../../services/team.service';
 import {BoardService} from '../../services/board.service';
 import {Board, emptyBoardWithThought} from '../../../domain/board';
 import {WebsocketService} from '../../services/websocket.service';
 import {DataService} from '../../../data.service';
+import {ActionItemService} from '../../services/action.service';
 
 describe('ArchivesPageComponent', () => {
   let paramsSubject: Subject<Object>;
@@ -34,6 +34,7 @@ describe('ArchivesPageComponent', () => {
   let mockWebSocketService: WebsocketService;
   let mockWindow: Window;
   let mockDataService: DataService;
+  let mockActionItemService: ActionItemService;
 
   let component: ArchivesPageComponent;
 
@@ -50,8 +51,9 @@ describe('ArchivesPageComponent', () => {
     mockWebSocketService = jasmine.createSpyObj({closeWebsocket: new Subject()});
     mockWindow = jasmine.createSpyObj({clearInterval: null});
     mockDataService = new DataService();
+    mockActionItemService = jasmine.createSpyObj({fetchArchivedActionItems: new Subject()});
 
-    component = new ArchivesPageComponent(mockDataService, mockTeamService, mockBoardService, mockWebSocketService);
+    component = new ArchivesPageComponent(mockDataService, mockTeamService, mockBoardService, mockWebSocketService, mockActionItemService);
     component.globalWindowRef = mockWindow;
 
     paramsObj = {
@@ -97,6 +99,11 @@ describe('ArchivesPageComponent', () => {
       mockWebSocketService.intervalId = 1;
       component.ngOnInit();
       expect(mockWindow.clearInterval).toHaveBeenCalledWith(1);
+    });
+
+    it('should get all of the archived action items', () => {
+      component.ngOnInit();
+      expect(mockActionItemService.fetchArchivedActionItems).toHaveBeenCalled();
     });
   });
 

--- a/ui/src/app/modules/teams/pages/archives/archives.page.ts
+++ b/ui/src/app/modules/teams/pages/archives/archives.page.ts
@@ -22,6 +22,8 @@ import {BoardService} from '../../services/board.service';
 import {WebsocketService} from '../../services/websocket.service';
 import {Themes} from '../../../domain/Theme';
 import {DataService} from '../../../data.service';
+import {ActionItemService} from '../../services/action.service';
+import {ActionItem} from '../../../domain/action-item';
 
 @Component({
   selector: 'rq-archives',
@@ -39,11 +41,16 @@ export class ArchivesPageComponent implements OnInit {
   countSortEnabled = false;
   archivesAreLoading = true;
   selectedArchives = 'thoughts';
+  archivedActionItems: Array<ActionItem> = [];
+  selectedActionItem: ActionItem;
+  dialogIsVisible = false;
 
   constructor(private dataService: DataService,
               private teamsService: TeamService,
               private boardService: BoardService,
-              private websocketService: WebsocketService) {
+              private websocketService: WebsocketService,
+              private actionItemService: ActionItemService
+  ) {
   }
 
   ngOnInit() {
@@ -63,6 +70,12 @@ export class ArchivesPageComponent implements OnInit {
       () => {
         this.archivesAreLoading = false;
       });
+
+    this.actionItemService.fetchArchivedActionItems(this.teamId).subscribe(
+      actionItems => {
+        this.archivedActionItems = actionItems;
+      }
+    );
   }
 
   get thoughtArchivesAreSelected(): boolean {
@@ -94,4 +107,8 @@ export class ArchivesPageComponent implements OnInit {
     return this.boards;
   }
 
+  showDialog(actionItem: ActionItem) {
+    this.selectedActionItem = actionItem;
+    this.dialogIsVisible = true;
+  }
 }

--- a/ui/src/app/modules/teams/pages/team/team.page.html
+++ b/ui/src/app/modules/teams/pages/team/team.page.html
@@ -50,6 +50,7 @@
       <rq-actions-column
         *ngIf="aggregation.topic === 'action'"
         [theme]="theme"
+        [retroEnded]="retroEnded"
         [actionItemAggregation]="aggregation"
         [actionItemChanged]="actionItemChanged"
         [teamId]="teamId"

--- a/ui/src/app/modules/teams/pages/team/team.page.spec.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.spec.ts
@@ -54,7 +54,8 @@ describe('TeamPageComponent', () => {
       instance(websocketService),
       null,
       instance(boardService),
-      instance(columnAggregationService)
+      instance(columnAggregationService),
+      null
     );
 
   });

--- a/ui/src/app/modules/teams/pages/team/team.page.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.ts
@@ -29,6 +29,8 @@ import {ColumnAggregationService} from '../../services/column-aggregation.servic
 import {ColumnResponse} from '../../../domain/column-response';
 import {Column} from '../../../domain/column';
 import {DataService} from '../../../data.service';
+import {ActionItemService} from '../../services/action.service';
+import {ActionItem} from '../../../domain/action-item';
 
 @Component({
   selector: 'rq-team',
@@ -44,7 +46,8 @@ export class TeamPageComponent implements OnInit {
               private websocketService: WebsocketService,
               private saveCheckerService: SaveCheckerService,
               private boardService: BoardService,
-              private columnAggregationService: ColumnAggregationService
+              private columnAggregationService: ColumnAggregationService,
+              private actionItemService: ActionItemService
   ) {
   }
 
@@ -140,18 +143,33 @@ export class TeamPageComponent implements OnInit {
   public onEndRetro(): void {
 
     const thoughts = [];
+    const archivedActionItems: Array<ActionItem> = [];
 
     this.columnsAggregation.map((column) => {
       if (column.topic !== 'action') {
         thoughts.push(...column.items.active);
         thoughts.push(...column.items.completed);
+      } else {
+        archivedActionItems.push(...column.items.completed as Array<ActionItem>);
+        for (let i = 0; i < archivedActionItems.length; ++i) {
+          archivedActionItems[i].archived = true;
+        }
       }
     });
 
-    if (thoughts.length > 0) {
-      this.boardService.createBoard(this.teamId, thoughts).subscribe();
+    if (thoughts.length > 0 || archivedActionItems.length > 0) {
+      if (thoughts.length > 0) {
+        this.boardService.createBoard(this.teamId, thoughts).subscribe();
+      }
+
+      if (archivedActionItems.length > 0) {
+        this.actionItemService.archiveActionItems(archivedActionItems);
+      }
+
       this.websocketService.endRetro();
     }
+
+
   }
 
   public isSelectedIndex(index: number): boolean {

--- a/ui/src/app/modules/teams/services/action.service.spec.ts
+++ b/ui/src/app/modules/teams/services/action.service.spec.ts
@@ -20,6 +20,9 @@ import {Observable} from 'rxjs/index';
 import {ActionItem} from '../../domain/action-item';
 import {HttpClient} from '@angular/common/http';
 import {WebsocketService} from './websocket.service';
+import {compareLogSummaries} from '@angular/core/src/render3/styling/class_and_style_bindings';
+import {componentFactoryName} from '@angular/compiler';
+import {mock} from 'ts-mockito';
 
 describe('ActionItemService', () => {
   let service: ActionItemService;
@@ -32,7 +35,8 @@ describe('ActionItemService', () => {
     task: 'action actionItem',
     completed: false,
     assignee: null,
-    dateCreated: null
+    dateCreated: null,
+    archived: false
   };
 
   beforeEach(() => {
@@ -77,6 +81,15 @@ describe('ActionItemService', () => {
     it('should send an update command to the ActionItem api via websocket', () => {
       service.updateActionItem(actionItem);
       expect(mockWebSocket.updateActionItem).toHaveBeenCalledWith(actionItem);
+    });
+  });
+
+  describe('fetchArchivedActionItems', () => {
+    const fakeTeamId = 'fake-team-id';
+
+    it('should call the backend api with the correct url', () => {
+      service.fetchArchivedActionItems(fakeTeamId);
+      expect(mockHttpClient.get).toHaveBeenCalledWith(`/api/team/${fakeTeamId}/action-items/archived`);
     });
   });
 

--- a/ui/src/app/modules/teams/services/action.service.ts
+++ b/ui/src/app/modules/teams/services/action.service.ts
@@ -21,6 +21,7 @@ import {Observable} from 'rxjs/index';
 
 import {ActionItem} from '../../domain/action-item';
 import {WebsocketService} from './websocket.service';
+import {Action} from 'rxjs/internal/scheduler/Action';
 
 @Injectable()
 export class ActionItemService {
@@ -30,6 +31,10 @@ export class ActionItemService {
 
   fetchActionItems(teamId): Observable<Array<ActionItem>> {
     return this.http.get<Array<ActionItem>>(`/api/team/${teamId}/action-items`);
+  }
+
+  fetchArchivedActionItems(teamId): Observable<Array<ActionItem>> {
+    return this.http.get<Array<ActionItem>>(`/api/team/${teamId}/action-items/archived`);
   }
 
   addActionItem(actionItem: ActionItem): void {
@@ -44,4 +49,9 @@ export class ActionItemService {
     this.webSocketService.updateActionItem(actionItem);
   }
 
+  archiveActionItems(archivedActionItems: Array<ActionItem>) {
+    archivedActionItems.map(actionItem => {
+      this.webSocketService.updateActionItem(actionItem);
+    });
+  }
 }

--- a/ui/src/app/modules/teams/services/websocket.service.spec.ts
+++ b/ui/src/app/modules/teams/services/websocket.service.spec.ts
@@ -237,7 +237,8 @@ describe('WebsocketService', () => {
         completed: false,
         teamId: '',
         assignee: '',
-        dateCreated: null
+        dateCreated: null,
+        archived: false
       };
 
       service.openWebsocket(teamId).subscribe();
@@ -277,7 +278,8 @@ describe('WebsocketService', () => {
         completed: false,
         teamId: '',
         assignee: '',
-        dateCreated: null
+        dateCreated: null,
+        archived: false
       };
 
       service.openWebsocket(teamId).subscribe();
@@ -298,7 +300,8 @@ describe('WebsocketService', () => {
         completed: false,
         teamId: '',
         assignee: '',
-        dateCreated: null
+        dateCreated: null,
+        archived: false
       };
 
       service.openWebsocket(teamId).subscribe();


### PR DESCRIPTION
…s page.

## Overview
Action items are now being archived and can be viewed on the archives page. The reason for this is your action items list can get quite big and users want the ability to see past retro items without having to resort to deleting them and losing them forever.

Also it redesigns the thought archives page a bit to accomodate being able to select archived action items.

### Screenshots
![image](https://user-images.githubusercontent.com/6293337/57261382-91034900-7035-11e9-97a7-8a281a7fe183.png)

![image](https://user-images.githubusercontent.com/6293337/57261301-45e93600-7035-11e9-9b4e-fa78aab256ef.png)

![image](https://user-images.githubusercontent.com/6293337/57261342-631e0480-7035-11e9-8f6e-ed1accd3b1bf.png)

![image](https://user-images.githubusercontent.com/6293337/57261316-51d4f800-7035-11e9-8373-3fd59ad5ba8c.png)

![image](https://user-images.githubusercontent.com/6293337/57261328-59949c80-7035-11e9-8589-15c45ffc9f6b.png)
