### PR TITLE
Changed link to FordLabs from Home Page

### DIFF
--- a/ui/src/app/modules/boards/components/brand-footer/brand-footer.component.html
+++ b/ui/src/app/modules/boards/components/brand-footer/brand-footer.component.html
@@ -18,7 +18,7 @@
 <div class="rq-brand-footer">
   <a class="labs-text">Powered By <a
     class="labs-link"
-    href="https://thehubat.ford.com/groups/fordlabs"
+    href="https://www.linkedin.com/company/ford-motor-company/life/?targetId=3fe3a44f-2dd2-4853-92d0-8b5d6ff7934d"
     target="_blank"
   >FordLabs</a>
   </a>


### PR DESCRIPTION
## Overview
The current link on the front page to FordLabs linked to an internal corporate website not
accessible from the public internet.  The link now points to the LinkedIn landing page.

## Testing Instructions
- Start application
- Navigate to home page
- click on "Powered by FordLabs" link

Expected Result: Navigate to FordLabs Life on LinkedIn
