### PR TITLE
Removes the End Retro button from techtrek board.

### DIFF
--- a/ui/src/app/modules/teams/components/header/header.component.html
+++ b/ui/src/app/modules/teams/components/header/header.component.html
@@ -48,11 +48,12 @@
       </button>
 
       <rq-button
+        *ngIf="boardIsOpenToEveryone"
         id="endRetro"
         (click)="showEndRetroDialog()"
         [ngClass]="{
-            'hide': actionsRadiatorViewEnabled
-         }"
+          'hide': actionsRadiatorViewEnabled
+        }"
         [theme]="theme"
         text="end retro"
         type="primary"

--- a/ui/src/app/modules/teams/components/header/header.component.ts
+++ b/ui/src/app/modules/teams/components/header/header.component.ts
@@ -56,6 +56,10 @@ export class HeaderComponent implements OnInit {
   public ngOnInit(): void {
   }
 
+  get boardIsOpenToEveryone(): boolean {
+    return this.teamName.toLowerCase() === 'techtrek';
+  }
+
   get darkThemeIsEnabled(): boolean {
     return this.theme === Themes.Dark;
   }


### PR DESCRIPTION
## Overview
This feature is being done only for the TechTrek retro board that will be used.

I was asked for this feature because we don't want users ending the retro, we've been told it's a little confusing.

This will be revoked after the tech trek