### PR TITLE
Use local FontAwesome CSS instead of CDN

### DIFF
--- a/ui/angular.json
+++ b/ui/angular.json
@@ -24,7 +24,8 @@
               "src/manifest.json"
             ],
             "styles": [
-              "src/styles.scss"
+              "src/styles.scss",
+              "./node_modules/@fortawesome/fontawesome-free/css/all.css"
             ],
             "scripts": [],
             "stylePreprocessorOptions": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -31,6 +31,7 @@
     "@angular/service-worker": "^7.2.3",
     "@elderbyte/ts-logger": "^0.1.0",
     "@elderbyte/ts-stomp": "^2.1.2",
+    "@fortawesome/fontawesome-free": "^5.9.0",
     "core-js": "^2.5.4",
     "file-saver": "^2.0.0",
     "hammerjs": "^2.0.8",

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -50,7 +50,6 @@
   <link rel="shortcut icon" type="image/x-icon" href="assets/icons/icon-72x72.png">
 
   <link href="https://fonts.googleapis.com/css?family=Quicksand:400,500,700" rel="stylesheet">
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
   <link rel="manifest" href="manifest.json">
   <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/icon-180x180.png">
   <meta name="theme-color" content="#1976d2">


### PR DESCRIPTION
## Overview
This PR changes RetroQuest's dependnency on FontAwesome to use an NPM Package instead of the CDN. This allows RetroQuest to continue to load icons in cases where the icons are blocked or unavailable.