### PR TITLE
Fix styles for action item assignees on iOS

### DIFF
--- a/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
+++ b/ui/src/app/modules/controls/action-item-task/action-item-task.component.scss
@@ -210,13 +210,15 @@
         background-color: inherit;
         border: 0;
         border-bottom: 2px solid $action-yellow;
+        border-radius: 0;
         box-sizing: border-box;
         color: inherit;
         display: inline-block;
         font-size: .8rem;
         font-weight: bold;
-        height: 18px;
+        height: 22px;
         outline: none;
+        padding-left: 0;
         padding-right: $right-side-padding;
 
         text-overflow: ellipsis;


### PR DESCRIPTION
## Overview
This fixes a visual bug in iOS where the assignees on action items used to look like this:
![Simulator Screen Shot - iPhone Xʀ - 2019-07-25 at 16 11 01](https://user-images.githubusercontent.com/11194200/61905356-e2192f80-aef6-11e9-8b4b-f82d6de64bde.png)

### Demo
The assignees now look like this:
![Simulator Screen Shot - iPhone Xʀ - 2019-07-25 at 16 11 58](https://user-images.githubusercontent.com/11194200/61905408-007f2b00-aef7-11e9-9c4c-0e9d0743799a.png)
