### PR TITLE
Fixed population of the team name field on the login page from the URL

### DIFF
--- a/ui/src/app/modules/boards/pages/login/login.page.ts
+++ b/ui/src/app/modules/boards/pages/login/login.page.ts
@@ -48,7 +48,12 @@ export class LoginComponent implements OnInit {
   ngOnInit() {
     const teamId = this.route.snapshot.params['teamId'] as string;
     if (teamId) {
-      this.teamName = teamId.replace(/-/g, ' ');
+      this.teamService.fetchTeamName(teamId).subscribe(
+        (teamName) => {
+          this.teamName = teamName;
+        },
+        (error) => {
+        });
     }
   }
 


### PR DESCRIPTION
## Overview
Related to [issue 259](https://github.com/FordLabs/retroquest/issues/259): 
this retrieves the team name to populate into the login screen based on the URL rather than assume it's just the url without dashes.

This is an issue because the current solution merely replaces dashes with spaces.  Users who put caps into their team names will find the URI strings are lower case so a board with the name `Issue Number 259` becomes uri `issue-number-259` and populates the login page with `issue number 259` which fails login.

## Testing Instructions
Create a board with a mix of capital and lower letters in the team name like:
`Issue Number 259`

This will give you a board with a URL login of 

`http://localhost:8080/team/issue-number-259`

or

`http://localhost:8080/login/issue-number-259`


The team name in the login screen will be populated in a case sensitive manner with `Issue Number 259` 
rather than `issue number 259`