### PR TITLE
Team name case and space insensitive

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItem.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItem.java
@@ -18,10 +18,7 @@
 package com.ford.labs.retroquest.actionitem;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -35,7 +32,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class ActionItem {
 
     @Id
@@ -45,6 +42,7 @@ public class ActionItem {
     private boolean completed;
     private String teamId;
     private String assignee;
+    @EqualsAndHashCode.Exclude
     private Date dateCreated;
     private boolean archived;
 

--- a/api/src/main/java/com/ford/labs/retroquest/board/Board.java
+++ b/api/src/main/java/com/ford/labs/retroquest/board/Board.java
@@ -32,7 +32,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class Board {
 
     @Id

--- a/api/src/main/java/com/ford/labs/retroquest/board/BoardRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/board/BoardRepository.java
@@ -27,6 +27,8 @@ import java.util.List;
 public interface BoardRepository extends JpaRepository<Board, Long> {
     List<Board> findAllByTeamIdOrderByDateCreatedDesc(String teamId, Pageable pageable);
 
+    List<Board> findAllByTeamId(String teamId);
+
     void deleteBoardByTeamIdAndId(String teamId, Long id);
 
     Board findByTeamIdAndId(String teamId, Long id);

--- a/api/src/main/java/com/ford/labs/retroquest/columntitle/ColumnTitle.java
+++ b/api/src/main/java/com/ford/labs/retroquest/columntitle/ColumnTitle.java
@@ -33,7 +33,7 @@ import java.io.Serializable;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder=true)
 public class ColumnTitle implements Serializable {
 
     @Id

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/Feedback.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/Feedback.java
@@ -18,17 +18,14 @@
 package com.ford.labs.retroquest.feedback;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Data
 @Entity
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class Feedback {
@@ -44,5 +41,6 @@ public class Feedback {
     private String teamId;
 
     @JsonFormat(pattern = "MM/dd/yy hh:mm:ss.SSS")
+    @EqualsAndHashCode.Exclude
     private LocalDateTime dateCreated;
 }

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackRepository.java
@@ -27,4 +27,5 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     List<Feedback> findAllByStarsIsGreaterThanEqual(int minimumValue);
 
+    List<Feedback> findAllByTeamId(String teamId);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/CaptchaService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/CaptchaService.java
@@ -21,7 +21,7 @@ public class CaptchaService {
             return false;
         }
 
-        Optional<Team> team = teamRepository.findTeamByName(teamName);
+        Optional<Team> team = teamRepository.findTeamByNameIgnoreCase(teamName.trim());
         if(team.isPresent()) {
             Integer failedAttempts = team.get().getFailedAttempts() != null ? team.get().getFailedAttempts() : 0;
             return failedAttempts > captchaProperties.getFailedLoginThreshold();

--- a/api/src/main/java/com/ford/labs/retroquest/team/CreateTeamRequest.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/CreateTeamRequest.java
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@Builder(toBuilder=true)
 public class CreateTeamRequest implements TeamRequest {
 
     @TeamNameConstraint

--- a/api/src/main/java/com/ford/labs/retroquest/team/Team.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/Team.java
@@ -32,7 +32,7 @@ import java.time.LocalDate;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class Team implements Persistable<String> {
 
     @Id

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
@@ -31,8 +31,7 @@ import javax.validation.Valid;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequestMapping(value = "/api")

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
@@ -17,12 +17,15 @@
 
 package com.ford.labs.retroquest.team;
 
+import com.ford.labs.retroquest.team.cleanup.CanonicalTeamNameAndCount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, String> {
@@ -32,4 +35,13 @@ public interface TeamRepository extends JpaRepository<Team, String> {
 
     long countAllByDateCreatedAfterAndDateCreatedIsNotNull(LocalDate start);
     long countAllByDateCreatedBetweenAndDateCreatedNotNull(LocalDate start, LocalDate end);
+
+    @Query("SELECT new com.ford.labs.retroquest.team.cleanup.CanonicalTeamNameAndCount(UPPER(TRIM(name)) as canonical_name,COUNT(*) as total) "
+            + "FROM Team "
+            + "GROUP BY canonical_name "
+            +" HAVING COUNT(*) > 1")
+    Set<CanonicalTeamNameAndCount> findAllTeamsWithConflictingCanonicalNames();
+
+    @Query("SELECT t FROM Team t WHERE UPPER(TRIM(name)) = UPPER(TRIM(:name))")
+    List<Team> findAllTeamsByNameWithTrimmingAndIgnoreCase(String name);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, String> {
-    Optional<Team> findTeamByName(String name);
+    Optional<Team> findTeamByNameIgnoreCase(String name);
     Optional<Team> findTeamByUri(String uri);
     List<Team> findAllByLastLoginDateBetween(LocalDate start, LocalDate end);
 

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
@@ -19,8 +19,10 @@ package com.ford.labs.retroquest.team;
 
 import com.ford.labs.retroquest.team.cleanup.CanonicalTeamNameAndCount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -44,4 +46,9 @@ public interface TeamRepository extends JpaRepository<Team, String> {
 
     @Query("SELECT t FROM Team t WHERE UPPER(TRIM(name)) = UPPER(TRIM(:name))")
     List<Team> findAllTeamsByNameWithTrimmingAndIgnoreCase(String name);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Team t SET t.name = TRIM(t.name)")
+    int trimAllTeamNames();
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
@@ -164,4 +164,8 @@ public class TeamService {
         }
         throw new BoardDoesNotExistException();
     }
+
+    public int trimAllTeamNames() {
+        return teamRepository.trimAllTeamNames();
+    }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
@@ -30,6 +30,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -93,9 +94,7 @@ public class TeamService {
         return teamEntity;
     }
 
-    private void generateColumns(Team teamEntity) {
-
-
+    public List<ColumnTitle> generateColumns(Team teamEntity) {
         ColumnTitle happyColumnTitle = new ColumnTitle();
         happyColumnTitle.setTeamId(teamEntity.getUri());
         happyColumnTitle.setTopic("happy");
@@ -111,9 +110,12 @@ public class TeamService {
         unhappyColumnTitle.setTopic("unhappy");
         unhappyColumnTitle.setTitle("Sad");
 
-        columnTitleRepository.save(happyColumnTitle);
-        columnTitleRepository.save(confusedColumnTitle);
-        columnTitleRepository.save(unhappyColumnTitle);
+        List<ColumnTitle> columns = new ArrayList<>();
+
+        columns.add(columnTitleRepository.save(happyColumnTitle));
+        columns.add(columnTitleRepository.save(confusedColumnTitle));
+        columns.add(columnTitleRepository.save(unhappyColumnTitle));
+        return columns;
     }
 
     public Team login(LoginRequest loginRequest) {

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
@@ -76,14 +76,15 @@ public class TeamService {
     }
 
     private Team createTeamEntity(String name, String password) {
-        String uri = convertTeamNameToURI(name);
+        String trimmedName = name.trim();
+        String uri = convertTeamNameToURI(trimmedName);
         teamRepository
                 .findTeamByUri(uri)
                 .ifPresent(s -> {
                     throw new DataIntegrityViolationException(s.getUri());
                 });
 
-        Team teamEntity = new Team(uri, name, password);
+        Team teamEntity = new Team(uri, trimmedName, password);
         teamEntity.setDateCreated(LocalDate.now());
 
         teamEntity = teamRepository.save(teamEntity);
@@ -147,7 +148,7 @@ public class TeamService {
     }
 
     public Team getTeamByName(String teamName) {
-        Optional<Team> team = teamRepository.findTeamByName(teamName);
+        Optional<Team> team = teamRepository.findTeamByNameIgnoreCase(teamName.trim());
         if (team.isPresent()) {
             return team.get();
         }

--- a/api/src/main/java/com/ford/labs/retroquest/team/cleanup/CanonicalTeamNameAndCount.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/cleanup/CanonicalTeamNameAndCount.java
@@ -1,0 +1,15 @@
+package com.ford.labs.retroquest.team.cleanup;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CanonicalTeamNameAndCount {
+    private String name;
+    private Long count;
+}

--- a/api/src/main/java/com/ford/labs/retroquest/team/cleanup/TeamNameCleanup.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/cleanup/TeamNameCleanup.java
@@ -16,6 +16,7 @@ import com.ford.labs.retroquest.thought.ThoughtRepository;
 import com.ford.labs.retroquest.users.UserTeamMapping;
 import com.ford.labs.retroquest.users.UserTeamMappingRepository;
 import lombok.extern.java.Log;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
@@ -49,6 +50,7 @@ public class TeamNameCleanup implements ApplicationListener<ApplicationReadyEven
     private final UserTeamMappingRepository userTeamMappingRepository;
     private final FeedbackRepository feedbackRepository;
     private final TeamService teamService;
+    private final boolean runCleanupJob;
 
     public TeamNameCleanup(TeamRepository teamRepository,
                            ThoughtRepository thoughtRepository,
@@ -57,7 +59,8 @@ public class TeamNameCleanup implements ApplicationListener<ApplicationReadyEven
                            ActionItemRepository actionItemRepository,
                            UserTeamMappingRepository userTeamMappingRepository,
                            FeedbackRepository feedbackRepository,
-                           TeamService teamService) {
+                           TeamService teamService,
+                           @Value("${com.retroquest.runTeamCleanupJob:false}") boolean runCleanupJob) {
         this.teamRepository = teamRepository;
         this.thoughtRepository = thoughtRepository;
         this.columnTitleRepository = columnTitleRepository;
@@ -66,12 +69,15 @@ public class TeamNameCleanup implements ApplicationListener<ApplicationReadyEven
         this.userTeamMappingRepository = userTeamMappingRepository;
         this.feedbackRepository = feedbackRepository;
         this.teamService = teamService;
+        this.runCleanupJob = runCleanupJob;
     }
 
     @Override
     public void onApplicationEvent(ApplicationReadyEvent event) {
-        fixConflictingTeamNames();
-        teamService.trimAllTeamNames();
+        if (runCleanupJob) {
+            fixConflictingTeamNames();
+            teamService.trimAllTeamNames();
+        }
     }
 
     private void fixConflictingTeamNames() {

--- a/api/src/main/java/com/ford/labs/retroquest/team/cleanup/TeamNameCleanup.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/cleanup/TeamNameCleanup.java
@@ -1,0 +1,169 @@
+package com.ford.labs.retroquest.team.cleanup;
+
+import com.ford.labs.retroquest.actionitem.ActionItem;
+import com.ford.labs.retroquest.actionitem.ActionItemRepository;
+import com.ford.labs.retroquest.board.Board;
+import com.ford.labs.retroquest.board.BoardRepository;
+import com.ford.labs.retroquest.columntitle.ColumnTitle;
+import com.ford.labs.retroquest.columntitle.ColumnTitleRepository;
+import com.ford.labs.retroquest.feedback.Feedback;
+import com.ford.labs.retroquest.feedback.FeedbackRepository;
+import com.ford.labs.retroquest.team.Team;
+import com.ford.labs.retroquest.team.TeamRepository;
+import com.ford.labs.retroquest.thought.Thought;
+import com.ford.labs.retroquest.thought.ThoughtRepository;
+import com.ford.labs.retroquest.users.UserTeamMapping;
+import com.ford.labs.retroquest.users.UserTeamMappingRepository;
+import lombok.extern.java.Log;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * There is a problem in the database.
+ * Multiple teams exist with the same Team Name.
+ * <p>
+ * This is meant to be a one-time startup job to address that.  It combines the data from
+ * multiple teams
+ * <p>
+ * It uses the most recent board name or retro to determine the winner for passwords
+ * and URIs
+ * <p>
+ * Moving forward, the Team service should prevent these kinds of collisions
+ */
+@Log
+@Component
+public class TeamNameCleanup implements ApplicationListener<ApplicationReadyEvent> {
+    private final TeamRepository teamRepository;
+    private final ThoughtRepository thoughtRepository;
+    private final ColumnTitleRepository columnTitleRepository;
+    private final BoardRepository boardRepository;
+    private final ActionItemRepository actionItemRepository;
+    private final UserTeamMappingRepository userTeamMappingRepository;
+    private final FeedbackRepository feedbackRepository;
+
+    public TeamNameCleanup(TeamRepository teamRepository,
+                           ThoughtRepository thoughtRepository,
+                           ColumnTitleRepository columnTitleRepository,
+                           BoardRepository boardRepository,
+                           ActionItemRepository actionItemRepository,
+                           UserTeamMappingRepository userTeamMappingRepository,
+                           FeedbackRepository feedbackRepository) {
+        this.teamRepository = teamRepository;
+        this.thoughtRepository = thoughtRepository;
+        this.columnTitleRepository = columnTitleRepository;
+        this.boardRepository = boardRepository;
+        this.actionItemRepository = actionItemRepository;
+        this.userTeamMappingRepository = userTeamMappingRepository;
+        this.feedbackRepository = feedbackRepository;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        fixConflictingTeamNames();
+    }
+
+    private void fixConflictingTeamNames() {
+        Set<CanonicalTeamNameAndCount> conflictTeams = teamRepository.findAllTeamsWithConflictingCanonicalNames();
+        conflictTeams.forEach(this::resolveTeamNameConflict);
+    }
+
+    private void resolveTeamNameConflict(CanonicalTeamNameAndCount teamNameRecord) {
+        List<Team> teams = teamRepository.findAllTeamsByNameWithTrimmingAndIgnoreCase(teamNameRecord.getName());
+        Team teamToKeep = getTeamToKeep(teams);
+        deleteDuplicateTeams(teams, teamToKeep);
+    }
+
+    private void deleteDuplicateTeams(List<Team> teams, Team teamToKeep) {
+        teams.stream()
+                .filter(t -> !t.getId().equals(teamToKeep.getId()))
+                .forEach(t -> deleteTeam(t, teamToKeep));
+    }
+
+    private void deleteTeam(Team oldTeam, Team newTeam) {
+        moveThoughtsToNewTeam(oldTeam, newTeam);
+        deleteColumnTitles(oldTeam);
+        moveBoardsToNewTeam(oldTeam, newTeam);
+        moveActionItemsToNewTeam(oldTeam, newTeam);
+        moveUserTeamMappingsToNewTeam(oldTeam, newTeam);
+        moveFeedbackToNewTeam(oldTeam, newTeam);
+        teamRepository.delete(oldTeam);
+    }
+
+
+    private Team getTeamToKeep(List<Team> teams) {
+        Team maxTeam = teams.get(0);
+        Long maxId = 0L;
+
+        for (Team t : teams) {
+            Long maxIdForTeam = thoughtRepository.getMaxIdByTeamId(t.getId()).orElse(0L);
+            if (maxIdForTeam > maxId) {
+                maxId = maxIdForTeam;
+                maxTeam = t;
+            }
+        }
+        return maxTeam;
+    }
+
+    private void moveThoughtsToNewTeam(Team oldTeam, Team newTeam) {
+        List<ColumnTitle> columnTitles = columnTitleRepository.findAllByTeamId(newTeam.getId());
+        Map<String, ColumnTitle> topicsToNewTitles = columnTitles.stream()
+                .collect(toMap(ColumnTitle::getTopic, columnTitle -> columnTitle));
+
+        List<Thought> oldThoughts = thoughtRepository.findAllByTeamId(oldTeam.getId());
+        for (Thought oldThought : oldThoughts) {
+            Thought newThought = oldThought.toBuilder()
+                    .teamId(newTeam.getId())
+                    .columnTitle(topicsToNewTitles.get(oldThought.getTopic()))
+                    .build();
+            thoughtRepository.save(newThought);
+        }
+    }
+
+    private void deleteColumnTitles(Team oldTeam) {
+        List<ColumnTitle> columnTitles = columnTitleRepository.findAllByTeamId(oldTeam.getId());
+        columnTitles.forEach(ct -> columnTitleRepository.delete(ct));
+    }
+
+    private void moveBoardsToNewTeam(Team oldTeam, Team newTeam) {
+        List<Board> boards = boardRepository.findAllByTeamId(oldTeam.getId());
+        boards.forEach(oldBoard -> {
+            Board newBoard = oldBoard.toBuilder().teamId(newTeam.getId()).build();
+            boardRepository.save(newBoard);
+        });
+    }
+
+    private void moveActionItemsToNewTeam(Team oldTeam, Team newTeam) {
+        List<ActionItem> actionItems = actionItemRepository.findAllByTeamId(oldTeam.getId());
+        actionItems.forEach(oldActionItem -> {
+            ActionItem newActionItem = oldActionItem.toBuilder().teamId(newTeam.getId()).build();
+            actionItemRepository.save(newActionItem);
+        });
+    }
+
+    private void moveFeedbackToNewTeam(Team oldTeam, Team newTeam) {
+        List<Feedback> feedback = feedbackRepository.findAllByTeamId(oldTeam.getId());
+        feedback.forEach(oldFeedback -> {
+            Feedback newFeedback = oldFeedback.toBuilder().teamId(newTeam.getId()).build();
+            feedbackRepository.save(newFeedback);
+        });
+    }
+
+    private void moveUserTeamMappingsToNewTeam(Team oldTeam, Team newTeam) {
+        List<UserTeamMapping> userTeamMappings = userTeamMappingRepository.findAllByTeamUri(oldTeam.getUri());
+        userTeamMappings.forEach(oldUserTeamMapping -> {
+            if (userTeamMappingRepository.findAllByTeamUriAndUserId(newTeam.getUri(), oldUserTeamMapping.getUserId()).size() == 0) {
+                UserTeamMapping newUserTeamMapping = oldUserTeamMapping.toBuilder().teamUri(newTeam.getUri()).build();
+                userTeamMappingRepository.save(newUserTeamMapping);
+            } else {
+                userTeamMappingRepository.delete(oldUserTeamMapping);
+            }
+        });
+    }
+}

--- a/api/src/main/java/com/ford/labs/retroquest/team/cleanup/TeamNameCleanup.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/cleanup/TeamNameCleanup.java
@@ -10,6 +10,7 @@ import com.ford.labs.retroquest.feedback.Feedback;
 import com.ford.labs.retroquest.feedback.FeedbackRepository;
 import com.ford.labs.retroquest.team.Team;
 import com.ford.labs.retroquest.team.TeamRepository;
+import com.ford.labs.retroquest.team.TeamService;
 import com.ford.labs.retroquest.thought.Thought;
 import com.ford.labs.retroquest.thought.ThoughtRepository;
 import com.ford.labs.retroquest.users.UserTeamMapping;
@@ -47,6 +48,7 @@ public class TeamNameCleanup implements ApplicationListener<ApplicationReadyEven
     private final ActionItemRepository actionItemRepository;
     private final UserTeamMappingRepository userTeamMappingRepository;
     private final FeedbackRepository feedbackRepository;
+    private final TeamService teamService;
 
     public TeamNameCleanup(TeamRepository teamRepository,
                            ThoughtRepository thoughtRepository,
@@ -54,7 +56,8 @@ public class TeamNameCleanup implements ApplicationListener<ApplicationReadyEven
                            BoardRepository boardRepository,
                            ActionItemRepository actionItemRepository,
                            UserTeamMappingRepository userTeamMappingRepository,
-                           FeedbackRepository feedbackRepository) {
+                           FeedbackRepository feedbackRepository,
+                           TeamService teamService) {
         this.teamRepository = teamRepository;
         this.thoughtRepository = thoughtRepository;
         this.columnTitleRepository = columnTitleRepository;
@@ -62,11 +65,13 @@ public class TeamNameCleanup implements ApplicationListener<ApplicationReadyEven
         this.actionItemRepository = actionItemRepository;
         this.userTeamMappingRepository = userTeamMappingRepository;
         this.feedbackRepository = feedbackRepository;
+        this.teamService = teamService;
     }
 
     @Override
     public void onApplicationEvent(ApplicationReadyEvent event) {
         fixConflictingTeamNames();
+        teamService.trimAllTeamNames();
     }
 
     private void fixConflictingTeamNames() {

--- a/api/src/main/java/com/ford/labs/retroquest/thought/Thought.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/Thought.java
@@ -30,7 +30,7 @@ import java.util.List;
 @Data
 @Entity
 @NoArgsConstructor
-@Builder
+@Builder(toBuilder=true)
 public class Thought {
 
     @Id

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtRepository.java
@@ -18,12 +18,16 @@
 package com.ford.labs.retroquest.thought;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ThoughtRepository extends JpaRepository<Thought, Long> {
+    List<Thought> findAllByTeamId(String teamId);
+
     List<Thought> findAllByTeamIdAndBoardIdIsNull(String teamId);
 
     List<Thought> findAllByTeamIdAndBoardIdIsNullOrderByTopic(String teamId);
@@ -31,4 +35,7 @@ public interface ThoughtRepository extends JpaRepository<Thought, Long> {
     void deleteAllByTeamId(String teamId);
 
     void deleteThoughtByTeamIdAndId(String teamId, Long id);
+
+    @Query("SELECT MAX(t.id) FROM Thought t Where t.teamId = :teamId")
+    Optional<Long> getMaxIdByTeamId(String teamId);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/users/UserController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/users/UserController.java
@@ -80,7 +80,7 @@ public class UserController {
     @Transactional
     public ResponseEntity<Void> addExistingTeamToUser(@PathVariable("name") String name, @RequestBody ExistingTeamRequest request) {
 
-        Optional<Team> teamOptional = teamRepository.findTeamByName(request.getName());
+        Optional<Team> teamOptional = teamRepository.findTeamByNameIgnoreCase(request.getName());
         if (teamOptional.isPresent() && passwordEncoder.matches(request.getPassword(), teamOptional.get().getPassword())) {
             User foundUser = userRepository.findByName(name).orElse(null);
 

--- a/api/src/main/java/com/ford/labs/retroquest/users/UserTeamMapping.java
+++ b/api/src/main/java/com/ford/labs/retroquest/users/UserTeamMapping.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 
 @Entity
 @Data
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserTeamMapping {

--- a/api/src/main/java/com/ford/labs/retroquest/users/UserTeamMappingRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/users/UserTeamMappingRepository.java
@@ -1,8 +1,14 @@
 package com.ford.labs.retroquest.users;
 
+import com.ford.labs.retroquest.board.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserTeamMappingRepository extends JpaRepository<UserTeamMapping, Long> {
+    List<UserTeamMapping> findAllByTeamUri(String teamUri);
+    List<UserTeamMapping> findAllByTeamUriAndUserId(String teamUri, Long userId);
+
 }

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/CaptchaServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/CaptchaServiceTest.java
@@ -33,7 +33,7 @@ public class CaptchaServiceTest {
         captchaProperties.setFailedLoginThreshold(4);
         CaptchaService captchaService = new CaptchaService(teamRepository, captchaProperties);
 
-        when(teamRepository.findTeamByName("some team")).thenReturn(Optional.of(team));
+        when(teamRepository.findTeamByNameIgnoreCase("some team")).thenReturn(Optional.of(team));
 
         assertTrue(captchaService.isCaptchaEnabledForTeam("some team"));
     }
@@ -47,7 +47,7 @@ public class CaptchaServiceTest {
         captchaProperties.setFailedLoginThreshold(10);
         CaptchaService captchaService = new CaptchaService(teamRepository, captchaProperties);
 
-        when(teamRepository.findTeamByName("some team")).thenReturn(Optional.of(team));
+        when(teamRepository.findTeamByNameIgnoreCase("some team")).thenReturn(Optional.of(team));
 
         assertFalse(captchaService.isCaptchaEnabledForTeam("some team"));
     }
@@ -64,11 +64,25 @@ public class CaptchaServiceTest {
     }
 
     @Test
+    public void trimsSpaceFromTramName() {
+        Team team = new Team();
+        team.setFailedAttempts(5);
+
+        captchaProperties.setEnabled(true);
+        captchaProperties.setFailedLoginThreshold(4);
+        CaptchaService captchaService = new CaptchaService(teamRepository, captchaProperties);
+
+        when(teamRepository.findTeamByNameIgnoreCase("some team")).thenReturn(Optional.of(team));
+
+        assertTrue(captchaService.isCaptchaEnabledForTeam("    some team     "));
+    }
+
+    @Test
     public void handlesNullFailedAttempts() {
         Team team = new Team();
         captchaProperties.setEnabled(true);
         captchaProperties.setFailedLoginThreshold(1);
-        when(teamRepository.findTeamByName("some team")).thenReturn(Optional.of(team));
+        when(teamRepository.findTeamByNameIgnoreCase("some team")).thenReturn(Optional.of(team));
 
         CaptchaService captchaService = new CaptchaService(teamRepository, captchaProperties);
 

--- a/api/src/test/java/com/ford/labs/retroquest/team/cleanup/TeamNameCleanupTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/team/cleanup/TeamNameCleanupTest.java
@@ -292,6 +292,22 @@ class TeamNameCleanupTest {
         assertThat(actualFeedback).isEqualTo(expectedFeedback);
     }
 
+    @Test
+    public void teamNamesRemoveExtraSpaces() {
+        createTeamToKeep(new Team("name-with-trailing", "nameWithTrailing    ", "Password1"));
+        createTeamToKeep(new Team("name-with-leading", "   nameWithLeading", "Password1"));
+        createTeamToKeep(new Team("name-with-extras", "  name   with   extras  ", "Password1"));
+        teamNameCleanup.onApplicationEvent(applicationReadyEvent);
+
+        List<Team> expectedTeams = teamsToKeep.stream()
+                .map(t -> t.toBuilder().name(t.getName().trim()).build())
+                .collect(Collectors.toList());
+        List<Team> actualTeams = teamRepository.findAll();
+        actualTeams.sort(comparing(Team::getUri));
+        expectedTeams.sort(comparing(Team::getUri));
+        assertThat(actualTeams).isEqualTo(expectedTeams);
+    }
+
     private void createConflictingTeamNames() {
         Team teamToDelete, teamToKeep;
         teamToDelete = createTeamToDelete(new Team("name0-", "name0 ", "Password1"));

--- a/api/src/test/java/com/ford/labs/retroquest/team/cleanup/TeamNameCleanupTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/team/cleanup/TeamNameCleanupTest.java
@@ -1,0 +1,417 @@
+package com.ford.labs.retroquest.team.cleanup;
+
+import com.ford.labs.retroquest.actionitem.ActionItem;
+import com.ford.labs.retroquest.actionitem.ActionItemRepository;
+import com.ford.labs.retroquest.board.Board;
+import com.ford.labs.retroquest.board.BoardRepository;
+import com.ford.labs.retroquest.columntitle.ColumnTitle;
+import com.ford.labs.retroquest.columntitle.ColumnTitleRepository;
+import com.ford.labs.retroquest.feedback.Feedback;
+import com.ford.labs.retroquest.feedback.FeedbackRepository;
+import com.ford.labs.retroquest.team.Team;
+import com.ford.labs.retroquest.team.TeamRepository;
+import com.ford.labs.retroquest.team.TeamService;
+import com.ford.labs.retroquest.thought.Thought;
+import com.ford.labs.retroquest.thought.ThoughtRepository;
+import com.ford.labs.retroquest.users.UserTeamMapping;
+import com.ford.labs.retroquest.users.UserTeamMappingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.disjoint;
+import static java.util.Collections.emptyList;
+import static java.util.Comparator.comparing;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class TeamNameCleanupTest {
+
+    @Autowired
+    private TeamNameCleanup teamNameCleanup;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private ThoughtRepository thoughtRepository;
+
+    @Autowired
+    private ColumnTitleRepository columnTitleRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private ActionItemRepository actionItemRepository;
+
+    @Autowired
+    private UserTeamMappingRepository userTeamMappingRepository;
+
+    @Autowired
+    private FeedbackRepository feedbackRepository;
+
+    @Autowired
+    private TeamService teamService;
+
+
+    @Mock
+    private ApplicationReadyEvent applicationReadyEvent;
+
+    private final List<Team> teamsToFix = new ArrayList<>();
+
+    private final List<Team> teamsToKeep = new ArrayList<>();
+
+    private final Map<Team, Team> teamsToDeleteToReplacement = new HashMap<>();
+
+    private final Map<Team, Map<String, ColumnTitle>> teamsToTopicsToColumnTitles = new HashMap<>();
+
+    private final Map<Team, Map<String, List<Thought>>> teamsToTopicsToThoughts = new HashMap<>();
+
+    private final Map<Team, List<Board>> teamsToBoards = new HashMap<>();
+
+    private final Map<Team, List<ActionItem>> teamsToActionItems = new HashMap<>();
+
+    private final Map<Team, List<Feedback>> teamsToFeedback = new HashMap<>();
+
+
+    @BeforeEach
+    public void setup() {
+        teamsToFix.clear();
+        teamsToKeep.clear();
+        teamsToDeleteToReplacement.clear();
+        teamsToTopicsToColumnTitles.clear();
+        teamsToTopicsToThoughts.clear();
+        teamsToBoards.clear();
+        teamsToActionItems.clear();
+        teamsToFeedback.clear();
+
+        feedbackRepository.deleteAll();
+        userTeamMappingRepository.deleteAll();
+        actionItemRepository.deleteAll();
+        boardRepository.deleteAll();
+        thoughtRepository.deleteAll();
+        columnTitleRepository.deleteAll();
+        teamRepository.deleteAll();
+
+        createConflictingTeamNames();
+    }
+
+    @Test
+    public void canDetectConflictingTeams() {
+        Set<CanonicalTeamNameAndCount> actual = teamRepository.findAllTeamsWithConflictingCanonicalNames();
+        Set<CanonicalTeamNameAndCount> expected = teamsToFix.stream()
+                .map(t -> new CanonicalTeamNameAndCount(t.getName().trim().toUpperCase(), 2L))
+                .collect(Collectors.toSet());
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void theTeamWithTheLeastRecentThoughtIsDeleted() {
+        teamNameCleanup.onApplicationEvent(applicationReadyEvent);
+        assertThat(teamRepository.findAllTeamsWithConflictingCanonicalNames().size()).isEqualTo(0);
+        List<Team> existingTeams = teamRepository.findAll();
+        assertThat(existingTeams).isEqualTo(teamsToKeep);
+        assertThat(disjoint(existingTeams, teamsToDeleteToReplacement.keySet())).isTrue();
+    }
+
+    @Test
+    public void thoughtsArePointedToNewTeamAndColumnsOnNewTeam() {
+        teamNameCleanup.onApplicationEvent(applicationReadyEvent);
+        List<Thought> expectedThoughts = getExpectedThoughts();
+
+        List<Thought> actualThoughts = thoughtRepository.findAll();
+        assertThat(actualThoughts).containsAll(expectedThoughts);
+        assertThat(actualThoughts.size()).isEqualTo(expectedThoughts.size());
+    }
+
+    @Test
+    public void columnTitlesAreDeletedAlongWithTeams() {
+        teamNameCleanup.onApplicationEvent(applicationReadyEvent);
+
+        List<ColumnTitle> expectedColumnTitles = new ArrayList<>();
+        for (Team t : teamsToKeep) {
+            expectedColumnTitles.addAll(teamsToTopicsToColumnTitles.get(t).values());
+        }
+
+        List<ColumnTitle> actualColumnTitles = columnTitleRepository.findAll();
+        assertThat(actualColumnTitles).containsAll(expectedColumnTitles);
+        assertThat(actualColumnTitles.size()).isEqualTo(expectedColumnTitles.size());
+    }
+
+    @Test
+    public void boardsArePointedToNewTeam() {
+        teamNameCleanup.onApplicationEvent(applicationReadyEvent);
+
+        List<Board> expectedBoards = new ArrayList<>();
+        for (Team team : teamsToKeep) {
+            expectedBoards.addAll(teamsToBoards.get(team));
+        }
+
+        List<Thought> expectedThoughts = getExpectedThoughts();
+        for (Team oldTeam : teamsToDeleteToReplacement.keySet()) {
+            Team newTeam = teamsToDeleteToReplacement.get(oldTeam);
+            for (Board oldBoard : teamsToBoards.get(oldTeam)) {
+                Board newBoard = oldBoard.toBuilder()
+                        .teamId(newTeam.getId())
+                        .thoughts(new ArrayList<>())
+                        .build();
+                for (Thought oldThought : oldBoard.getThoughts()) {
+                    Thought expectedThought = expectedThoughts.stream()
+                            .filter(t -> t.getId().equals(oldThought.getId()))
+                            .findFirst().orElseThrow();
+                    newBoard.getThoughts().add(expectedThought);
+                }
+                expectedBoards.add(newBoard);
+            }
+        }
+        List<Board> actualBoards = boardRepository.findAll();
+        actualBoards.sort(comparing(Board::getId));
+        expectedBoards.sort(comparing(Board::getId));
+
+        assertThat(expectedBoards).containsAll(actualBoards);
+        assertThat(expectedBoards.size()).isEqualTo(actualBoards.size());
+    }
+
+    @Test
+    public void actionItemsArePointedToNewTeam() {
+        teamNameCleanup.onApplicationEvent(applicationReadyEvent);
+
+        List<ActionItem> expectedActionItems = new ArrayList<>();
+        for (Team team : teamsToKeep) {
+            expectedActionItems.addAll(teamsToActionItems.get(team));
+        }
+        for (Team oldTeam : teamsToDeleteToReplacement.keySet()) {
+            Team newTeam = teamsToDeleteToReplacement.get(oldTeam);
+            for (ActionItem oldActionItem : teamsToActionItems.get(oldTeam)) {
+                ActionItem newActionItem = oldActionItem.toBuilder().teamId(newTeam.getId()).build();
+                expectedActionItems.add(newActionItem);
+            }
+        }
+
+        List<ActionItem> actualActionItems = actionItemRepository.findAll();
+        actualActionItems.sort(comparing(ActionItem::getId));
+        expectedActionItems.sort(comparing(ActionItem::getId));
+        assertThat(actualActionItems).isEqualTo(expectedActionItems);
+    }
+
+    @Test
+    public void userTeamMappingsAreRepointedToNewTeamWhenNoConflicts() {
+
+        Map<Team, List<UserTeamMapping>> existingUserTeamMappings = new HashMap<>();
+        teamsToDeleteToReplacement.keySet().forEach(oldTeam -> {
+            existingUserTeamMappings.put(oldTeam, new ArrayList<>());
+            existingUserTeamMappings.get(oldTeam)
+                    .add(userTeamMappingRepository.save(new UserTeamMapping(0L, 0L, oldTeam.getUri())));
+            existingUserTeamMappings.get(oldTeam)
+                    .add(userTeamMappingRepository.save(new UserTeamMapping(0L, 1L, oldTeam.getUri())));
+            existingUserTeamMappings.get(oldTeam)
+                    .add(userTeamMappingRepository.save(new UserTeamMapping(0L, 2L, oldTeam.getUri())));
+        });
+
+        teamNameCleanup.onApplicationEvent(applicationReadyEvent);
+
+        List<UserTeamMapping> expectedUserTeamMappings = new ArrayList<>();
+        for (Team oldTeam : teamsToDeleteToReplacement.keySet()) {
+            Team newTeam = teamsToDeleteToReplacement.get(oldTeam);
+            for (UserTeamMapping oldMapping : existingUserTeamMappings.get(oldTeam)) {
+                UserTeamMapping newMapping = oldMapping.toBuilder().teamUri(newTeam.getUri()).build();
+                expectedUserTeamMappings.add(newMapping);
+            }
+        }
+
+        List<UserTeamMapping> actualUserTeamMappings = userTeamMappingRepository.findAll();
+        actualUserTeamMappings.sort(comparing(UserTeamMapping::getId));
+        expectedUserTeamMappings.sort(comparing(UserTeamMapping::getId));
+        assertThat(actualUserTeamMappings).isEqualTo(expectedUserTeamMappings);
+    }
+
+    @Test
+    public void userTeamMappingsAreRepointedToNewTeamWhenConflicts() {
+
+        Map<Team, List<UserTeamMapping>> existingUserTeamMappings = new HashMap<>();
+        List<UserTeamMapping> expectedUserTeamMappings = new ArrayList<>();
+        teamsToKeep.forEach(newTeam -> {
+            existingUserTeamMappings.put(newTeam, new ArrayList<>());
+            existingUserTeamMappings.get(newTeam)
+                    .add(userTeamMappingRepository.save(new UserTeamMapping(0L, 0L, newTeam.getUri())));
+            existingUserTeamMappings.get(newTeam)
+                    .add(userTeamMappingRepository.save(new UserTeamMapping(0L, 1L, newTeam.getUri())));
+            existingUserTeamMappings.get(newTeam)
+                    .add(userTeamMappingRepository.save(new UserTeamMapping(0L, 2L, newTeam.getUri())));
+            expectedUserTeamMappings.addAll(existingUserTeamMappings.get(newTeam));
+        });
+
+
+        teamsToDeleteToReplacement.keySet().forEach(oldTeam -> {
+            existingUserTeamMappings.put(oldTeam, new ArrayList<>());
+            existingUserTeamMappings.get(oldTeam)
+                    .add(userTeamMappingRepository.save(new UserTeamMapping(0L, 0L, oldTeam.getUri())));
+            existingUserTeamMappings.get(oldTeam)
+                    .add(userTeamMappingRepository.save(new UserTeamMapping(0L, 1L, oldTeam.getUri())));
+            existingUserTeamMappings.get(oldTeam)
+                    .add(userTeamMappingRepository.save(new UserTeamMapping(0L, 2L, oldTeam.getUri())));
+        });
+
+        teamNameCleanup.onApplicationEvent(applicationReadyEvent);
+
+        List<UserTeamMapping> actualUserTeamMappings = userTeamMappingRepository.findAll();
+        actualUserTeamMappings.sort(comparing(UserTeamMapping::getId));
+        expectedUserTeamMappings.sort(comparing(UserTeamMapping::getId));
+        assertThat(actualUserTeamMappings).isEqualTo(expectedUserTeamMappings);
+    }
+
+    @Test
+    public void feedbackIsPointedToNewTeam() {
+        teamNameCleanup.onApplicationEvent(applicationReadyEvent);
+
+        List<Feedback> expectedFeedback = new ArrayList<>();
+        for (Team team : teamsToKeep) {
+            expectedFeedback.addAll(teamsToFeedback.get(team));
+        }
+        for (Team oldTeam : teamsToDeleteToReplacement.keySet()) {
+            Team newTeam = teamsToDeleteToReplacement.get(oldTeam);
+            for (Feedback oldFeedback : teamsToFeedback.get(oldTeam)) {
+                Feedback newFeedback = oldFeedback.toBuilder().teamId(newTeam.getId()).build();
+                expectedFeedback.add(newFeedback);
+            }
+        }
+
+        List<Feedback> actualFeedback = feedbackRepository.findAll();
+        actualFeedback.sort(comparing(Feedback::getId));
+        expectedFeedback.sort(comparing(Feedback::getId));
+        assertThat(actualFeedback).isEqualTo(expectedFeedback);
+    }
+
+    private void createConflictingTeamNames() {
+        Team teamToDelete, teamToKeep;
+        teamToDelete = createTeamToDelete(new Team("name0-", "name0 ", "Password1"));
+        teamToKeep = createTeamToKeep(new Team("name0", "name0", "Password1"));
+        teamsToDeleteToReplacement.put(teamToDelete, teamToKeep);
+
+        teamToDelete = createTeamToDelete(new Team("-name1", "name1 ", "Password1"));
+        teamToKeep = createTeamToKeep(new Team("name1", "name1", "Password1"));
+        teamsToDeleteToReplacement.put(teamToDelete, teamToKeep);
+
+        teamToDelete = createTeamToDelete(new Team("name2", "name2 ", "Password1"));
+        teamToKeep = createTeamToKeep(new Team("someonechangedthedb", "name2", "Password1"));
+        teamsToDeleteToReplacement.put(teamToDelete, teamToKeep);
+
+        teamToDelete = createTeamToDelete(new Team("mixedcase", "mixed case", "Password1"));
+        teamToKeep = createTeamToKeep(new Team("mixed-case", "Mixed Case", "Password1"));
+        teamsToDeleteToReplacement.put(teamToDelete, teamToKeep);
+    }
+
+    private Team createTeam(Team team, boolean mustHaveThoughts) {
+        Team savedTeam = teamRepository.save(team);
+        teamsToFix.add(team);
+
+        createColumnTitles(savedTeam);
+        createSomeThoughts(savedTeam, null, mustHaveThoughts);
+        createSomeBoards(savedTeam);
+        createSomeActionItems(savedTeam);
+        createSomeFeedback(savedTeam);
+        return savedTeam;
+    }
+
+    private void createColumnTitles(Team team) {
+        teamsToTopicsToColumnTitles.put(team, new HashMap<>());
+        teamsToTopicsToThoughts.put(team, new HashMap<>());
+        List<ColumnTitle> columnTitles = teamService.generateColumns(team);
+        for (ColumnTitle columnTitle : columnTitles) {
+            teamsToTopicsToColumnTitles.get(team).put(columnTitle.getTopic(), columnTitle);
+            teamsToTopicsToThoughts.get(team).put(columnTitle.getTopic(), new ArrayList<>());
+        }
+    }
+
+    private Team createTeamToKeep(Team team) {
+        Team savedTeam = createTeam(team, true);
+        teamsToKeep.add(savedTeam);
+        return savedTeam;
+    }
+
+    private Team createTeamToDelete(Team team) {
+        return createTeam(team, false);
+    }
+
+    private List<Thought> createSomeThoughts(Team team, Long boardId, boolean atLeastOne) {
+        Random rand = new Random();
+        int minThoughts = atLeastOne ? 1 : 0;
+        List<Thought> createdThoughts = new ArrayList<>();
+        teamsToTopicsToColumnTitles.get(team)
+                .values()
+                .forEach(columnTitle -> {
+                    for (int i = 0; i < (rand.nextInt(3) + minThoughts); i++) {
+                        Thought thought = new Thought(0L, "test " + columnTitle.getTopic(), 0, columnTitle.getTopic(), false, team.getId(), columnTitle, boardId);
+                        Thought savedThought = thoughtRepository.save(thought);
+                        teamsToTopicsToThoughts.get(team).get(columnTitle.getTopic()).add(savedThought);
+                        createdThoughts.add(savedThought);
+                    }
+                });
+        return createdThoughts;
+    }
+
+    private void createSomeBoards(Team team) {
+        teamsToBoards.put(team, new ArrayList<>());
+        Random rand = new Random();
+        for (int i = 0; i < rand.nextInt(3); i++) {
+            Board board = new Board(0L, team.getId(), LocalDate.now(), emptyList());
+            Board savedBoard = boardRepository.save(board);
+            savedBoard.setThoughts(createSomeThoughts(team, savedBoard.getId(), false));
+            teamsToBoards.get(team).add(savedBoard);
+        }
+    }
+
+    private void createSomeActionItems(Team team) {
+        Random rand = new Random();
+        teamsToActionItems.put(team, new ArrayList<>());
+        for (int i = 0; i < rand.nextInt(3); i++) {
+            ActionItem actionItem = new ActionItem(0L, "some task", false, team.getId(), "Someone", new Date(0L), false);
+            teamsToActionItems.get(team).add(actionItemRepository.save(actionItem));
+        }
+    }
+
+    private void createSomeFeedback(Team team) {
+        Random rand = new Random();
+        teamsToFeedback.put(team, new ArrayList<>());
+        for (int i = 0; i < rand.nextInt(3); i++) {
+            Feedback feedback = new Feedback(0L, 0, "comment", null, team.getId(), LocalDateTime.now());
+            teamsToFeedback.get(team).add(feedbackRepository.save(feedback));
+        }
+    }
+
+    private List<Thought> getExpectedThoughts() {
+        List<Thought> expectedThoughts = new ArrayList<>();
+
+        for (Team team : teamsToKeep) {
+            for (List<Thought> thoughts : teamsToTopicsToThoughts.get(team).values()) {
+                expectedThoughts.addAll(thoughts);
+            }
+        }
+
+        for (Team oldTeam : teamsToDeleteToReplacement.keySet()) {
+            Team newTeam = teamsToDeleteToReplacement.get(oldTeam);
+            for (List<Thought> oldThoughts : teamsToTopicsToThoughts.get(oldTeam).values()) {
+                for (Thought oldThought : oldThoughts) {
+                    Thought newThought = oldThought.toBuilder()
+                            .teamId(newTeam.getId())
+                            .columnTitle(teamsToTopicsToColumnTitles.get(newTeam).get(oldThought.getTopic()))
+                            .build();
+                    expectedThoughts.add(newThought);
+                }
+            }
+        }
+        return expectedThoughts;
+    }
+
+
+}


### PR DESCRIPTION
Related to issue 261: https://github.com/FordLabs/retroquest/issues/261

## Overview
Trims board names during board creation and login so that boards will not be created with leading and trailing spaces and 
Makes board name comparison case insensitive so that logins will ignore case on team name
 and will not create duplicate boards with different cases or with 

Additionally, it has a startup job that merges teams in the case where multiple teams exist with the same name (ignoring case and trimmed whitespace)

