### PR TITLE
Made H2 Default database for ./gradlew bootRun closes #277

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Running the application locally can be done with either an H2 in-memory database
 ### In-Memory
 The simplest way to get the application spun up is by using the in-memory database via Gradle:
 ```
-./gradlew runLocal
+./gradlew bootRun
 ```
 or
 ```
@@ -61,7 +61,7 @@ cd ./api && docker-compose up
 
 Start the backend with Gradle:  
 ```
-./gradlew runDockerDb
+./gradlew bootRunDockerDb
 ```
 or
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -97,25 +97,42 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
+def noProfileOrDbDefined(tasks) {
+
+    def envProfile = System.getenv("SPRING_PROFILES_ACTIVE")
+    def systemProfile = System.getProperty("spring.profiles.active")
+
+    if(envProfile !=null || systemProfile!=null){
+        return false;
+    }
+
+    boolean dbDeclared = false;
+    tasks.forEach { task ->
+        if(task.name.contains('with')){
+            dbDeclared=true;
+        }
+    }
+
+    if(dbDeclared){
+        return false;
+    }
+
+    return true;
+
+}
+
 bootRun {
     sourceResources sourceSets.main
 
     gradle.taskGraph.whenReady { graph ->
-        boolean dbDeclared = false;
 
-        graph.getAllTasks().forEach { task->
-            if(task.name.contains('with')){
-                dbDeclared=true;
-            }
-        }
-
-        if(!dbDeclared){
+        if(noProfileOrDbDefined(graph.getAllTasks())){
             logger.lifecycle('>>> Setting spring.profiles.active == "local" <<<')
             bootRun {
                 dependencies {
                     implementation 'com.h2database:h2:1.4.200'
                 }
-                args = ['--spring.profiles.active=local']
+                System.setProperty("spring.profiles.active","local")
                 systemProperties System.properties
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -99,17 +99,22 @@ dependencies {
 
 bootRun {
     sourceResources sourceSets.main
-}
 
-task runLocal {
-    dependsOn 'withH2'
-    dependsOn 'bootRun'
-    group 'application'
-    description 'Runs this project as a Spring Boot application using in-memory (H2) database'
     gradle.taskGraph.whenReady { graph ->
-        if (graph.hasTask(runLocal)) {
+        boolean dbDeclared = false;
+
+        graph.getAllTasks().forEach { task->
+            if(task.name.contains('with')){
+                dbDeclared=true;
+            }
+        }
+
+        if(!dbDeclared){
             logger.lifecycle('>>> Setting spring.profiles.active == "local" <<<')
             bootRun {
+                dependencies {
+                    implementation 'com.h2database:h2:1.4.200'
+                }
                 args = ['--spring.profiles.active=local']
                 systemProperties System.properties
             }
@@ -117,7 +122,7 @@ task runLocal {
     }
 }
 
-task runDockerDb(type: Exec){
+task bootRunDockerDb(type: Exec){
     dependsOn 'withPostgres'
     dependsOn 'bootRun'
 
@@ -127,7 +132,7 @@ task runDockerDb(type: Exec){
     description 'Runs this project as a Spring Boot application using containerized database'
 
     gradle.taskGraph.whenReady { graph ->
-        if (graph.hasTask(runDockerDb)) {
+        if (graph.hasTask(bootRunDockerDb)) {
             logger.lifecycle('>>> Setting spring.profiles.active == "dockerdb" <<<')
             bootRun {
                 systemProperty "spring.profiles.active", "dockerdb"


### PR DESCRIPTION
- Updated build.gradle file for bootRun and bootRunDockerDb
- Updated README.MD

Note:
- ./gradlew runLocal is now just ./gradlew bootRun
- ./gradlew runDockerDb is now ./gradlew bootRunDockerDb
- closes #277