### PR TITLE
Replace springfox library with springdoc-openapi

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jacocoOutputDirectory = "${project.buildDir}/jacoco"
         jacocoHtmlDirectory = "${project.buildDir}/jacoco-html"
         jacocoXml = "${project.buildDir}/jacoco-xml/jacoco.xml"
-        swaggerVersion = '2.9.2'
+        springdocVersion = '1.5.9'
     }
     repositories {
         mavenCentral()
@@ -70,8 +70,8 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.12'
     implementation 'commons-io:commons-io:2.7'
     implementation 'org.liquibase:liquibase-core:4.3.1'
-    implementation "io.springfox:springfox-swagger2:${swaggerVersion}"
-    implementation "io.springfox:springfox-swagger-ui:${swaggerVersion}"
+
+    implementation "org.springdoc:springdoc-openapi-ui:$springdocVersion"
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-statsd'

--- a/api/src/main/java/com/ford/labs/retroquest/MainApplication.java
+++ b/api/src/main/java/com/ford/labs/retroquest/MainApplication.java
@@ -21,12 +21,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableCaching
 @EnableScheduling
 @SpringBootApplication
-@EnableSwagger2
 public class MainApplication {
     public static void main(String[] args) {
         SpringApplication.run(MainApplication.class, args);

--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
@@ -21,10 +21,10 @@ package com.ford.labs.retroquest.actionitem;
 import com.ford.labs.retroquest.api.authorization.ApiAuthorization;
 import com.ford.labs.retroquest.websocket.WebsocketDeleteResponse;
 import com.ford.labs.retroquest.websocket.WebsocketPutResponse;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -39,7 +39,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 
 @RestController
-@Api(tags = {"Action Item Controller"}, description = "The controller that manages action items to a board given a team id")
+@Tag(name = "Action Item Controller", description = "The controller that manages action items to a board given a team id")
 public class ActionItemController {
 
     private final ActionItemRepository actionItemRepository;
@@ -53,8 +53,8 @@ public class ActionItemController {
 
     @PutMapping("/api/team/{teamId}/action-item/{thoughtId}/complete")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Marks a thought as complete for a given team id", notes = "completeActionItem")
-    @ApiResponses(value = {@ApiResponse(code = 204, message = "No Content")})
+    @Operation(summary = "Marks a thought as complete for a given team id", description = "completeActionItem")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
     public void completeActionItem(@PathVariable("thoughtId") Long id, @PathVariable("teamId") String teamId) {
         final ActionItem actionItem = actionItemRepository.findById(id).orElseThrow();
         actionItem.toggleCompleted();
@@ -63,8 +63,8 @@ public class ActionItemController {
 
     @PutMapping("/api/team/{teamId}/action-item/{thoughtId}/task")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Updates an action item given a thought id and a team id", notes = "updateActionItemTask")
-    @ApiResponses(value = {@ApiResponse(code = 204, message = "No Content")})
+    @Operation(summary = "Updates an action item given a thought id and a team id", description = "updateActionItemTask")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
     public void updateActionItemTask(@PathVariable("thoughtId") Long actionItemId, @PathVariable("teamId") String teamId, @RequestBody ActionItem updatedActionItem) {
         ActionItem savedActionItem = actionItemRepository.findById(actionItemId).orElseThrow();
         savedActionItem.setTask(updatedActionItem.getTask());
@@ -73,8 +73,8 @@ public class ActionItemController {
 
     @PutMapping("/api/team/{teamId}/action-item/{thoughtId}/assignee")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Updates an action item assignee a thought id and a team id", notes = "updateActionItemAssignee")
-    @ApiResponses(value = {@ApiResponse(code = 204, message = "No Content")})
+    @Operation(summary = "Updates an action item assignee a thought id and a team id", description = "updateActionItemAssignee")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
     public void updateActionItemAssignee(@PathVariable("thoughtId") Long actionItemId, @PathVariable("teamId") String teamId, @RequestBody ActionItem updatedActionItem) {
         ActionItem savedActionItem = actionItemRepository.findById(actionItemId).orElseThrow();
         savedActionItem.setAssignee(updatedActionItem.getAssignee());
@@ -83,25 +83,25 @@ public class ActionItemController {
 
     @GetMapping("/api/team/{teamId}/action-items")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Retrieves all action items given a team id", notes = "getActionItemsForTeam")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = ActionItem.class, responseContainer = "List")})
+    @Operation(summary = "Retrieves all action items given a team id", description = "getActionItemsForTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public List<ActionItem> getActionItemsForTeam(@PathVariable("teamId") String teamId) {
         return actionItemRepository.findAllByTeamId(teamId);
     }
 
     @GetMapping("/api/team/{teamId}/action-items/archived")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Retrieves all archived action items given a team id", notes = "getArchivedActionItemsForTeam")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = ActionItem.class, responseContainer = "List")})
+    @Operation(summary = "Retrieves all archived action items given a team id", description = "getArchivedActionItemsForTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public List<ActionItem> getArchivedActionItemsForTeam(@PathVariable("teamId") String teamId) {
         return actionItemRepository.findAllByTeamIdAndArchivedIsTrue(teamId);
     }
 
     @PostMapping("/api/team/{teamId}/action-item")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Creates an action item given a team id", notes = "createActionItemForTeam")
-    @ApiResponses(value = {@ApiResponse(code = 201, message = "Created", response = ResponseEntity.class)})
-    public ResponseEntity createActionItemForTeam(@PathVariable("teamId") String teamId, @RequestBody ActionItem actionItem) throws URISyntaxException {
+    @Operation(summary = "Creates an action item given a team id", description = "createActionItemForTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Created")})
+    public ResponseEntity<URI> createActionItemForTeam(@PathVariable("teamId") String teamId, @RequestBody ActionItem actionItem) throws URISyntaxException {
         actionItem.setTeamId(teamId);
         ActionItem savedActionItem = actionItemRepository.save(actionItem);
         URI savedActionItemUri = new URI("/api/team/" + teamId + "/action-item/" + savedActionItem.getId());

--- a/api/src/main/java/com/ford/labs/retroquest/board/BoardController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/board/BoardController.java
@@ -21,10 +21,10 @@ package com.ford.labs.retroquest.board;
 import com.ford.labs.retroquest.api.authorization.ApiAuthorization;
 import com.ford.labs.retroquest.thought.Thought;
 import com.ford.labs.retroquest.websocket.WebsocketPutResponse;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
@@ -38,7 +38,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping(value = "/api")
-@Api(tags = {"Board Controller"}, description = "The controller that manages the retro board")
+@Tag(name = "Board Controller", description = "The controller that manages the retro board")
 public class BoardController {
 
     private final BoardService boardService;
@@ -51,8 +51,8 @@ public class BoardController {
 
     @GetMapping("/team/{teamId}/boards")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Gets a retro board given a team id and page index", notes = "getBoardsForTeamId")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Board.class, responseContainer = "List")})
+    @Operation(summary = "Gets a retro board given a team id and page index", description = "getBoardsForTeamId")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public List<Board> getBoardsForTeamId(@PathVariable("teamId") String teamId,
                                           @RequestParam(value = "pageIndex", defaultValue = "0") Integer pageIndex) {
         return this.boardService.getBoardsForTeamId(teamId, pageIndex);
@@ -60,8 +60,8 @@ public class BoardController {
 
     @PostMapping("/team/{teamId}/board")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Saves a board given a team id", notes = "saveBoard")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Board.class)})
+    @Operation(summary = "Saves a board given a team id", description = "saveBoard")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public Board saveBoard(@PathVariable("teamId") String teamId, @RequestBody @Valid Board board) {
         return this.boardService.saveBoard(board);
     }
@@ -69,16 +69,16 @@ public class BoardController {
     @Transactional
     @DeleteMapping("/team/{teamId}/board/{boardId}")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "deletes a board for a team id", notes = "deleteBoard")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
+    @Operation(summary = "deletes a board for a team id", description = "deleteBoard")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public void deleteBoard(@PathVariable("teamId") String teamId, @PathVariable("boardId") Long boardId) {
         this.boardService.deleteBoard(teamId, boardId);
     }
 
     @GetMapping("/team/{teamId}/board/{boardId}/thoughts")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Gets all thoughts for a team id and board id", notes = "getThoughtsForBoard")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Thought.class, responseContainer = "List")})
+    @Operation(summary = "Gets all thoughts for a team id and board id", description = "getThoughtsForBoard")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public List<Thought> getThoughtsForBoard(@PathVariable("teamId") String teamId, @PathVariable("boardId") Long boardId) {
         return this.boardService.getThoughtsForTeamIdAndBoardId(teamId, boardId);
     }

--- a/api/src/main/java/com/ford/labs/retroquest/columntitle/ColumnTitleController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/columntitle/ColumnTitleController.java
@@ -19,10 +19,10 @@ package com.ford.labs.retroquest.columntitle;
 
 import com.ford.labs.retroquest.api.authorization.ApiAuthorization;
 import com.ford.labs.retroquest.websocket.WebsocketPutResponse;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
@@ -34,7 +34,7 @@ import javax.transaction.Transactional;
 import java.util.List;
 
 @RestController
-@Api(tags = {"Column Title Controller"}, description = "The controller that manages the titles of each column on a retro board")
+@Tag(name = "Column Title Controller", description = "The controller that manages the titles of each column on a retro board")
 public class ColumnTitleController {
 
     private ColumnTitleRepository columnTitleRepository;
@@ -48,8 +48,8 @@ public class ColumnTitleController {
 
     @GetMapping("/api/team/{teamId}/columns")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Gets a the column titles on a retro board for a given team id", notes = "getColumnTitlesForTeam")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = ColumnTitle.class, responseContainer = "List")})
+    @Operation(summary = "Gets a the column titles on a retro board for a given team id", description = "getColumnTitlesForTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public List<ColumnTitle> getColumnTitlesForTeam(@PathVariable("teamId") String teamId) {
         return columnTitleRepository.findAllByTeamId(teamId);
     }
@@ -57,8 +57,8 @@ public class ColumnTitleController {
     @Transactional
     @PutMapping("/api/team/{teamId}/column/{columnId}/title")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Updates the title of a column of a retro board given a team id and column id", notes = "updateTitleOfColumn")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
+    @Operation(summary = "Updates the title of a column of a retro board given a team id and column id", description = "updateTitleOfColumn")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public void updateTitleOfColumn(@PathVariable("teamId") String teamId, @RequestBody ColumnTitle columnTitle, @PathVariable("columnId") Long columnId) {
         ColumnTitle returnedColumnTitle = columnTitleRepository.findById(columnId).orElseThrow();
         returnedColumnTitle.setTitle(columnTitle.getTitle());
@@ -68,7 +68,6 @@ public class ColumnTitleController {
     @MessageMapping("/{teamId}/column-title/{columnId}/edit")
     @SendTo("/topic/{teamId}/column-titles")
     public WebsocketPutResponse<ColumnTitle> editColumnTitleWebsocket(@DestinationVariable("teamId") String teamId, @DestinationVariable("columnId") Long columnId, ColumnTitle columnTitle, Authentication authentication) {
-
         if (apiAuthorization.requestIsAuthorized(authentication, teamId)) {
             ColumnTitle savedColumnTitle = columnTitleRepository.findById(columnId).orElseThrow();
             savedColumnTitle.setTitle(columnTitle.getTitle());

--- a/api/src/main/java/com/ford/labs/retroquest/contributors/ContributorController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/contributors/ContributorController.java
@@ -17,17 +17,17 @@
 
 package com.ford.labs.retroquest.contributors;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
-@Api(tags = {"Contributor Controller"}, description = "The controller that manages the contributors to Retroquest")
+@Tag(name = "Contributor Controller", description = "The controller that manages the contributors to Retroquest")
 public class ContributorController {
 
     private final ContributorsService contributorService;
@@ -37,8 +37,8 @@ public class ContributorController {
     }
 
     @GetMapping("/api/contributors")
-    @ApiOperation(value = "Gets the all of the contributors to Retroquest", notes = "getColumnTitlesForTeam")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Contributor.class, responseContainer = "List")})
+    @Operation(summary = "Gets the all of the contributors to Retroquest", description = "getColumnTitlesForTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public List<Contributor> getContributors() {
         return contributorService.getContributors();
     }

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/AdminFeedbackController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/AdminFeedbackController.java
@@ -17,10 +17,10 @@
 
 package com.ford.labs.retroquest.feedback;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,7 +30,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/admin/feedback")
-@Api(tags = {"Admin Feedback Controller"}, description = "The controller that manages all feedback")
+@Tag(name = "Admin Feedback Controller", description = "The controller that manages all feedback")
 public class AdminFeedbackController {
 
     private FeedbackRepository feedbackRepository;
@@ -41,8 +41,8 @@ public class AdminFeedbackController {
     }
 
     @GetMapping("/all")
-    @ApiOperation(value = "Gets all feedback", notes = "getAllFeedBack")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Feedback.class, responseContainer = "List")})
+    @Operation(summary = "Gets all feedback", description = "getAllFeedBack")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public List<Feedback> getAllFeedBack() {
         return feedbackRepository.findAll();
     }

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackController.java
@@ -17,10 +17,10 @@
 
 package com.ford.labs.retroquest.feedback;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,7 +33,7 @@ import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/feedback")
-@Api(tags = {"Feedback Controller"}, description = "The controller that manages feedback for Retroquest")
+@Tag(name = "Feedback Controller", description = "The controller that manages feedback for Retroquest")
 public class FeedbackController {
 
     private FeedbackRepository feedbackRepository;
@@ -43,9 +43,9 @@ public class FeedbackController {
     }
 
     @PostMapping
-    @ApiOperation(value = "Creates a feedback entry", notes = "saveFeedback")
-    @ApiResponses(value = {@ApiResponse(code = 201, message = "Created", response = ResponseEntity.class)})
-    public ResponseEntity saveFeedback(@RequestBody Feedback feedback) throws URISyntaxException {
+    @Operation(summary = "Creates a feedback entry", description = "saveFeedback")
+    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Created")})
+    public ResponseEntity<URI> saveFeedback(@RequestBody Feedback feedback) throws URISyntaxException {
         feedback.setDateCreated(LocalDateTime.now());
         Feedback savedFeedback = feedbackRepository.save(feedback);
         return ResponseEntity.created(new URI("/api/feedback/" + savedFeedback.getId())).build();

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsController.java
@@ -1,9 +1,9 @@
 package com.ford.labs.retroquest.metrics;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/admin/metrics")
-@Api(tags = {"Metrics Controller"}, description = "The controller that manages metrics")
+@Tag(name = "Metrics Controller", description = "The controller that manages metrics")
 public class MetricsController {
 
     private final Metrics metrics;
@@ -25,57 +25,57 @@ public class MetricsController {
     }
 
     @GetMapping("/team/count")
-    @ApiOperation(value = "Gets the number of teams between a start and end date", notes = "getTeamCount")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Long.class)})
+    @Operation(summary = "Gets the number of teams between a start and end date", description = "getTeamCount")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public ResponseEntity<Long> getTeamCount(
-            @RequestParam(name = "start", required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-                    LocalDate startDate,
-            @RequestParam(name = "end", required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-                    LocalDate endDate
+        @RequestParam(name = "start", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate startDate,
+        @RequestParam(name = "end", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate endDate
     ) {
         return ResponseEntity.ok(metrics.getTeamCount(startDate, endDate));
     }
 
     @GetMapping("/feedback/count")
-    @ApiOperation(value = "Gets the number of feedback entries between a start and end date", notes = "saveFeedback")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Long.class)})
+    @Operation(summary = "Gets the number of feedback entries between a start and end date", description = "saveFeedback")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public ResponseEntity<Integer> getFeedbackCount(
-            @RequestParam(name = "start", required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-                    LocalDate startDate,
-            @RequestParam(name = "end", required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-                    LocalDate endDate
+        @RequestParam(name = "start", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate startDate,
+        @RequestParam(name = "end", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate endDate
     ) {
         return ResponseEntity.ok(metrics.getFeedbackCount(startDate, endDate));
     }
 
     @GetMapping("/feedback/average")
-    @ApiOperation(value = "Returns the average app rating between a start and end date", notes = "saveFeedback")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Double.class)})
+    @Operation(summary = "Returns the average app rating between a start and end date", description = "saveFeedback")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public ResponseEntity<Double> getAverageRating(
-            @RequestParam(name = "start", required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-                    LocalDate startDate,
-            @RequestParam(name = "end", required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-                    LocalDate endDate
+        @RequestParam(name = "start", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate startDate,
+        @RequestParam(name = "end", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate endDate
     ) {
         return ResponseEntity.ok(metrics.getAverageRating(startDate, endDate));
     }
 
     @GetMapping("/team/logins")
-    @ApiOperation(value = "Returns the number of logins given a start and end date", notes = "saveFeedback")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Integer.class)})
+    @Operation(summary = "Returns the number of logins given a start and end date", description = "saveFeedback")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public int getLogins(
-            @RequestParam(name = "start", required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-                    LocalDate startDate,
-            @RequestParam(name = "end", required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-                    LocalDate endDate
+        @RequestParam(name = "start", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate startDate,
+        @RequestParam(name = "end", required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate endDate
     ) {
         return metrics.getTeamLogins(startDate, endDate);
     }

--- a/api/src/main/java/com/ford/labs/retroquest/swagger/SwaggerConfiguration.java
+++ b/api/src/main/java/com/ford/labs/retroquest/swagger/SwaggerConfiguration.java
@@ -1,39 +1,25 @@
 package com.ford.labs.retroquest.swagger;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springdoc.core.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 class SwaggerConfiguration {
-
-    @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .apiInfo(apiInfo())
-                .host("retroquest.ford.com")
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("com.ford.labs.retroquest"))
-                .paths(PathSelectors.any())
-                .build()
-                .useDefaultResponseMessages(false);
-    }
-
-    private ApiInfo apiInfo() {
-        return new ApiInfoBuilder().title("Retroquest")
-                .description("The Swagger API for Retroquest")
-                .contact(new Contact("tdcs", "https://dcs.ford.com/", "tdcs@ford.com"))
-                .version("1.0.0")
-                .license("Apache 2.0")
-                .licenseUrl("http://www.apache.org/licenses/LICENSE-2.0")
-                .termsOfServiceUrl("http://tos.ford.com")
-                .build();
+    private OpenAPI apiInfo() {
+        return new OpenAPI()
+            .info(
+                new Info().title("RetroQuest")
+                    .description("The Swagger API for Retroquest")
+                    .version("1.0.0")
+                    .contact(new Contact().name("FordLabs").url("https://fordlabs.com/"))
+                    .license(new License().name("Apache 2.0").url("http://www.apache.org/licenses/LICENSE-2.0"))
+                    .termsOfService("http://tos.ford.com")
+            );
     }
 }
 

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
@@ -19,10 +19,10 @@ package com.ford.labs.retroquest.team;
 
 import com.ford.labs.retroquest.api.authorization.ApiAuthorization;
 import com.ford.labs.retroquest.security.JwtBuilder;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -40,7 +40,7 @@ import static org.springframework.http.HttpStatus.OK;
 
 @RestController
 @RequestMapping(value = "/api")
-@Api(tags = {"Team Controller"}, description = "The controller that manages team boards")
+@Tag(name = "Team Controller", description = "The controller that manages team boards")
 public class TeamController {
 
     private final TeamService teamService;
@@ -60,8 +60,8 @@ public class TeamController {
 
     @PostMapping("/team")
     @Transactional(rollbackOn = URISyntaxException.class)
-    @ApiOperation(value = "Creates a new team", notes = "createTeam")
-    @ApiResponses(value = {@ApiResponse(code = 201, message = "Created", response = String.class)})
+    @Operation(summary = "Creates a new team", description = "createTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Created")})
     public ResponseEntity<String> createTeam(@RequestBody @Valid CreateTeamRequest createTeamRequest) {
         Team team = teamService.createNewTeam(createTeamRequest);
 
@@ -76,24 +76,24 @@ public class TeamController {
     @PostMapping("/update-password")
     @Transactional(rollbackOn = URISyntaxException.class)
     @PreAuthorize("#updatePasswordRequest.teamId == authentication.principal")
-    @ApiOperation(value = "Resets a password for a team id", notes = "updatePasswords")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = String.class)})
+    @Operation(summary = "Resets a password for a team id", description = "updatePasswords")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public ResponseEntity<String> updatePassword(@RequestBody @Valid UpdatePasswordRequest updatePasswordRequest) {
         teamService.updatePassword(updatePasswordRequest);
         return ResponseEntity.ok().body("Password Reset Successfully");
     }
 
     @GetMapping("/team/{teamUri}/name")
-    @ApiOperation(value = "Gets a team name given the team uri", notes = "getTeamName")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = String.class)})
+    @Operation(summary = "Gets a team name given the team uri", description = "getTeamName")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public String getTeamName(@PathVariable("teamUri") String teamUri) {
         return teamService.getTeamByUri(teamUri).getName();
     }
 
     @GetMapping(value = "/team/{teamId}/csv", produces = "application/board.csv")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "downloads a team board", notes = "downloadTeamBoard")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Byte.class)})
+    @Operation(summary = "downloads a team board", description = "downloadTeamBoard")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public ResponseEntity<byte[]> downloadTeamBoard(@PathVariable("teamId") String teamId) throws IOException {
         CsvFile file = teamService.buildCsvFileFromTeam(teamId);
         return ResponseEntity.ok()
@@ -104,14 +104,14 @@ public class TeamController {
 
     @GetMapping(value = "team/{teamId}/validate")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Validates a team id", notes = "deprecated")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
+    @Operation(summary = "Validates a team id", description = "deprecated")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public void validateTeamId(@PathVariable("teamId") String teamId) {
     }
 
     @PostMapping("/team/login")
-    @ApiOperation(value = "Logs in a user given a login request", notes = "deprecated")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = String.class)})
+    @Operation(summary = "Logs in a user given a login request", description = "deprecated")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public ResponseEntity<String> login(@RequestBody @Valid LoginRequest team) {
         Team savedTeamEntity = teamService.login(team);
         String jwt = jwtBuilder.buildJwt(savedTeamEntity.getUri());
@@ -123,15 +123,15 @@ public class TeamController {
     }
 
     @GetMapping("/team/{teamName}/captcha")
-    @ApiOperation(value = "returns whether captcha is enabled given a team name", notes = "isCaptchaEnabledForTeam")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = CaptchaResponse.class)})
+    @Operation(summary = "returns whether captcha is enabled given a team name", description = "isCaptchaEnabledForTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public CaptchaResponse isCaptchaEnabledForTeam(@PathVariable("teamName") String teamName) {
         return new CaptchaResponse(captchaService.isCaptchaEnabledForTeam(teamName));
     }
 
     @GetMapping("/captcha")
-    @ApiOperation(value = "Determines whether captcha is enabled globally for Retroquest", notes = "isCaptchaEnabled")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = CaptchaResponse.class)})
+    @Operation(summary = "Determines whether captcha is enabled globally for Retroquest", description = "isCaptchaEnabled")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public CaptchaResponse isCaptchaEnabled() {
         return new CaptchaResponse(captchaService.isCaptchaEnabled());
     }

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtController.java
@@ -20,10 +20,10 @@ package com.ford.labs.retroquest.thought;
 import com.ford.labs.retroquest.api.authorization.ApiAuthorization;
 import com.ford.labs.retroquest.websocket.WebsocketDeleteResponse;
 import com.ford.labs.retroquest.websocket.WebsocketPutResponse;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -38,7 +38,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 
 @RestController
-@Api(tags = {"Thought Controller"}, description = "The controller that manages thoughts on a team board")
+@Tag(name = "Thought Controller", description = "The controller that manages thoughts on a team board")
 public class ThoughtController {
 
     private ThoughtService thoughtService;
@@ -55,16 +55,16 @@ public class ThoughtController {
 
     @PutMapping("/api/team/{teamId}/thought/{thoughtId}/heart")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "adds a like to a thought given a thought and team id", notes = "likeThought")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "Created", response = Integer.class)})
+    @Operation(summary = "adds a like to a thought given a thought and team id", description = "likeThought")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Created")})
     public int likeThought(@PathVariable("thoughtId") String thoughtId, @PathVariable("teamId") String teamId) {
         return thoughtService.likeThought(thoughtId);
     }
 
     @PutMapping("/api/team/{teamId}/thought/{thoughtId}/discuss")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "toggles between a thought being discussed or not discussed", notes = "discussThought")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
+    @Operation(summary = "toggles between a thought being discussed or not discussed", description = "discussThought")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public ResponseEntity<Void> discussThought(@PathVariable("thoughtId") String thoughtId, @PathVariable("teamId") String teamId) {
         thoughtService.discussThought(thoughtId);
 
@@ -74,16 +74,16 @@ public class ThoughtController {
     @Transactional
     @PutMapping("/api/team/{teamId}/thought/{id}/message")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Updates the content of a thought given a thought and team id", notes = "updateThoughtMessage")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
+    @Operation(summary = "Updates the content of a thought given a thought and team id", description = "updateThoughtMessage")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public void updateThoughtMessage(@PathVariable("id") Long id, @RequestBody Thought thought, @PathVariable("teamId") String teamId) {
         thoughtService.updateThoughtMessage(String.valueOf(id), thought.getMessage());
     }
 
     @GetMapping("/api/team/{teamId}/thoughts")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Returns all thoughts given a team id", notes = "getThoughtsForTeam")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = Thought.class, responseContainer = "List")})
+    @Operation(summary = "Returns all thoughts given a team id", description = "getThoughtsForTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public List<Thought> getThoughtsForTeam(@PathVariable("teamId") String teamId) {
         return thoughtService.fetchAllThoughtsByTeam(teamId);
     }
@@ -91,8 +91,8 @@ public class ThoughtController {
     @Transactional
     @DeleteMapping("/api/team/{teamId}/thoughts")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Removes all thoughts given a team id", notes = "clearThoughtsForTeam")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
+    @Operation(summary = "Removes all thoughts given a team id", description = "clearThoughtsForTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public void clearThoughtsForTeam(@PathVariable("teamId") String teamId) {
         thoughtService.deleteAllThoughtsByTeamId(teamId);
     }
@@ -100,18 +100,18 @@ public class ThoughtController {
     @Transactional
     @DeleteMapping("/api/team/{teamId}/thought/{thoughtId}")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Removes a thought given a team id and thought id", notes = "clearIndividualThoughtForTeam")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "OK")})
+    @Operation(summary = "Removes a thought given a team id and thought id", description = "clearIndividualThoughtForTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public void clearIndividualThoughtForTeam(@PathVariable("teamId") String teamId, @PathVariable("thoughtId") Long id) {
         thoughtService.deleteThought(teamId, id);
     }
 
     @PostMapping("/api/team/{teamId}/thought")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Creates a thought given a team id and thought", notes = "createThoughtForTeam")
+    @Operation(summary = "Creates a thought given a team id and thought", description = "createThoughtForTeam")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Created"),
-            @ApiResponse(code = 400, message = "Path to saved thought is not a valid URI")
+            @ApiResponse(responseCode = "201", description = "Created"),
+            @ApiResponse(responseCode = "400", description = "Path to saved thought is not a valid URI")
     })
     public ResponseEntity<Void> createThoughtForTeam(@PathVariable("teamId") String teamId, @RequestBody Thought thought) throws URISyntaxException {
         URI savedThoughtUri = new URI(thoughtService.createThoughtAndReturnURI(teamId, thought));

--- a/api/src/main/java/com/ford/labs/retroquest/users/UserController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/users/UserController.java
@@ -5,10 +5,10 @@ import com.ford.labs.retroquest.statuscodeexceptions.BadRequestException;
 import com.ford.labs.retroquest.team.Team;
 import com.ford.labs.retroquest.team.TeamRepository;
 import com.ford.labs.retroquest.team.TeamService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +28,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
 @RequestMapping(value = "/api")
-@Api(tags = {"User Controller"}, description = "The controller that manages a user")
+@Tag(name = "User Controller", description = "The controller that manages a user")
 public class UserController {
 
     private final UserRepository userRepository;
@@ -52,10 +52,10 @@ public class UserController {
 
     @PostMapping(value = "user")
     @Transactional
-    @ApiOperation(value = "Creates a new user", notes = "requires a non-blank name and password")
+    @Operation(summary = "Creates a new user", description = "requires a non-blank name and password")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Created", response = String.class),
-            @ApiResponse(code = 400, message = "Bad Request", response = String.class)
+            @ApiResponse(responseCode = "201", description = "Created"),
+            @ApiResponse(responseCode = "400", description = "Bad Request")
     })
     public ResponseEntity<String> createNewUser(@RequestBody NewUserRequest newUserRequest) {
 
@@ -83,9 +83,9 @@ public class UserController {
 
     @GetMapping(value = "user/{name}")
     @PreAuthorize("#name.toLowerCase() == authentication.principal")
-    @ApiOperation(value = "validates a user given a name", notes = "this has no implementation")
+    @Operation(summary = "validates a user given a name", description = "this has no implementation")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK")
+            @ApiResponse(responseCode = "200", description = "OK")
     })
     public void validateUser(@PathVariable("name") String name) {
         // For Sonarqube
@@ -94,11 +94,11 @@ public class UserController {
     @PutMapping(value = "user/{name}/team")
     @PreAuthorize("#name.toLowerCase() == authentication.principal")
     @Transactional
-    @ApiOperation(value = "adds a given user to an existing team", notes = "addUserToExistingTeam")
+    @Operation(summary = "adds a given user to an existing team", description = "addUserToExistingTeam")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 400, message = "Team does not exist or the password for the team in the request is invalid"),
-            @ApiResponse(code = 409, message = "The user already belongs to the existing team")
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Team does not exist or the password for the team in the request is invalid"),
+            @ApiResponse(responseCode = "409", description = "The user already belongs to the existing team")
     })
     public ResponseEntity<Void> addUserToExistingTeam(@PathVariable("name") String name, @RequestBody ExistingTeamRequest request) {
 
@@ -125,10 +125,10 @@ public class UserController {
     @PostMapping(value = "user/{name}/team")
     @PreAuthorize("#name.toLowerCase() == authentication.principal")
     @Transactional
-    @ApiOperation(value = "Adds a given user to a new team", notes = "requires a non-blank name")
+    @Operation(summary = "Adds a given user to a new team", description = "requires a non-blank name")
     @ApiResponses(value = {
-            @ApiResponse(code = 201, message = "Created"),
-            @ApiResponse(code = 400, message = "Bad Request")
+            @ApiResponse(responseCode = "201", description = "Created"),
+            @ApiResponse(responseCode = "400", description = "Bad Request")
     })
     public ResponseEntity<Void> addUserToNewTeam(@PathVariable("name") String name, @RequestBody NewTeamRequest request) {
 
@@ -151,9 +151,9 @@ public class UserController {
     @GetMapping(value = "user/{name}/team")
     @PreAuthorize("#name.toLowerCase() == authentication.principal")
     @Transactional
-    @ApiOperation(value = "Returns all of teams assigned to a given user", notes = "getTeamsAssignedToUser")
+    @Operation(summary = "Returns all of teams assigned to a given user", description = "getTeamsAssignedToUser")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "Created", response = Team.class, responseContainer = "Set")
+            @ApiResponse(responseCode = "200", description = "Created")
     })
     public ResponseEntity<Set<Team>> getTeamsAssignedToUser(@PathVariable("name") String name) {
 
@@ -164,10 +164,10 @@ public class UserController {
 
     @PostMapping(value = "user/login")
     @Transactional
-    @ApiOperation(value = "Returns a token for a new user", notes = "getUserToken")
+    @Operation(summary = "Returns a token for a new user", description = "getUserToken")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = String.class),
-            @ApiResponse(code = 404, message = "User Not Found", response = String.class)
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "404", description = "User Not Found")
     })
     public ResponseEntity<String> getUserToken(@RequestBody NewUserRequest newUserRequest) {
 

--- a/api/src/main/java/com/ford/labs/retroquest/v2/columns/ColumnController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/v2/columns/ColumnController.java
@@ -17,10 +17,10 @@
 
 package com.ford.labs.retroquest.v2.columns;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/api/v2/team")
-@Api(tags = {"Column Controller"}, description = "The controller that aggregates all of the items given a team id")
+@Tag(name = "Column Controller", description = "The controller that aggregates all of the items given a team id")
 public class ColumnController {
 
     private final ColumnCombinerService columnCombinerService;
@@ -41,8 +41,8 @@ public class ColumnController {
 
     @GetMapping("/{teamId}/columns")
     @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @ApiOperation(value = "Gets all thoughts for a given team id", notes = "getThoughtsForTeam")
-    @ApiResponses(value = {@ApiResponse(code = 200, message = "All the thoughts for a team id", response = ColumnCombinerResponse.class)})
+    @Operation(summary = "Gets all thoughts for a given team id", description = "getThoughtsForTeam")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "All the thoughts for a team id")})
     public ColumnCombinerResponse getThoughtsForTeam(@PathVariable("teamId") String teamId, Authentication authentication) {
         return columnCombinerService.aggregateResponse(teamId);
     }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -36,3 +36,5 @@ com.retroquest.captcha.secret=${random.value}
 com.retroquest.captcha.enabled=false
 com.retroquest.captcha.failedLoginThreshold=5
 app.archive.thought.pageSize=30
+
+springdoc.packages-to-scan=com.ford.labs.retroquest


### PR DESCRIPTION
## Overview
This PR replaces the older Springfox library with springdoc-openapi. This library provides a modern implementation of the OpenAPI v3 specification. 

### Demo
![image](https://user-images.githubusercontent.com/22086580/119844092-23edd500-bed6-11eb-9394-9c78405d4ffb.png)


## Testing Instructions
You can access the Swagger UI page by going to `$BASE_URL/swagger.ui.html` in the browser. You can access the OpenAPI JSON documentation by going to `$BASE_URL/v3/api-docs`. The old Springfox implementation hosted the Swagger UI at the same location, and the documentation was hosted at `$BASE_URL/v2/api-docs`. 