### PR TITLE
Correctly expose OpenAPI object as Bean

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/swagger/SwaggerConfiguration.java
+++ b/api/src/main/java/com/ford/labs/retroquest/swagger/SwaggerConfiguration.java
@@ -4,13 +4,13 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
-import org.springdoc.core.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 class SwaggerConfiguration {
-    private OpenAPI apiInfo() {
+    @Bean
+    public OpenAPI apiInfo() {
         return new OpenAPI()
             .info(
                 new Info().title("RetroQuest")


### PR DESCRIPTION
## Overview
Correctly exposes OpenAPI configuration object as a Spring Bean

## Testing Instructions
Run the application locally, and go to http://localhost:8080/swagger-ui.html.

Ensure that the metadata for the RetroQuest API is present.