### PR TITLE
Publish metrics to StatsD

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/ApplicationConfig.java
+++ b/api/src/main/java/com/ford/labs/retroquest/ApplicationConfig.java
@@ -10,21 +10,13 @@ import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class ApplicationConfig {
-    private final TeamRepository teamRepository;
-    private final FeedbackRepository feedbackRepository;
-
-    public ApplicationConfig(TeamRepository teamRepository, FeedbackRepository feedbackRepository) {
-        this.teamRepository = teamRepository;
-        this.feedbackRepository = feedbackRepository;
-    }
-
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder.build();
     }
 
     @Bean
-    public Metrics metrics() {
+    public Metrics metrics(TeamRepository teamRepository, FeedbackRepository feedbackRepository) {
         return new Metrics(teamRepository, feedbackRepository);
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackRepository.java
@@ -18,8 +18,10 @@
 package com.ford.labs.retroquest.feedback;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -28,4 +30,9 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     List<Feedback> findAllByStarsIsGreaterThanEqual(int minimumValue);
 
     List<Feedback> findAllByTeamId(String teamId);
+
+    long countByDateCreatedGreaterThanEqualAndDateCreatedLessThanEqual(LocalDateTime startTime, LocalDateTime endTime);
+
+    @Query("select avg(f.stars) from Feedback f where f.stars > 0 and f.dateCreated >= ?1 and f.dateCreated <= ?2")
+    double getAverageRating(LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
@@ -25,7 +25,7 @@ public class Metrics {
 
     @ManagedAttribute
     public int getTeamCount() {
-        return teamRepository.findAll().size();
+        return (int) getTeamCount(null, null);
     }
 
     public long getTeamCount(LocalDate startDate, LocalDate endDate) {
@@ -46,9 +46,9 @@ public class Metrics {
         LocalDateTime finalEndTime = endTime == null ? LocalDateTime.now() : endTime.atStartOfDay();
         LocalDateTime finalStartTime = startTime == null ? LocalDateTime.MIN : startTime.atStartOfDay();
         List<Feedback> feedbackList = feedbackRepository.findAll().stream()
-                .filter(feedback -> !feedback.getDateCreated().isBefore(finalStartTime))
-                .filter(feedback -> !feedback.getDateCreated().isAfter(finalEndTime))
-                .collect(toList());
+            .filter(feedback -> !feedback.getDateCreated().isBefore(finalStartTime))
+            .filter(feedback -> !feedback.getDateCreated().isAfter(finalEndTime))
+            .collect(toList());
         return feedbackList.size();
     }
 
@@ -63,11 +63,11 @@ public class Metrics {
         LocalDateTime finalEndTime = endTime == null ? LocalDateTime.now() : endTime.atStartOfDay();
         LocalDateTime finalStartTime = startTime == null ? LocalDateTime.MIN : startTime.atStartOfDay();
         return feedbackRepository.findAllByStarsIsGreaterThanEqual(1).stream()
-                .filter(feedback -> !feedback.getDateCreated().isBefore(finalStartTime))
-                .filter(feedback -> !feedback.getDateCreated().isAfter(finalEndTime))
-                .mapToInt(Feedback::getStars)
-                .average()
-                .orElse(0);
+            .filter(feedback -> !feedback.getDateCreated().isBefore(finalStartTime))
+            .filter(feedback -> !feedback.getDateCreated().isAfter(finalEndTime))
+            .mapToInt(Feedback::getStars)
+            .average()
+            .orElse(0);
     }
 
     public int getTeamLogins(LocalDate startDate, LocalDate endDate) {

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsConfiguration.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsConfiguration.java
@@ -1,0 +1,33 @@
+package com.ford.labs.retroquest.metrics;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+
+@Configuration
+public class MetricsConfiguration {
+    private final Metrics metrics;
+    private final MeterRegistry meterRegistry;
+
+    public MetricsConfiguration(Metrics metrics, MeterRegistry meterRegistry) {
+        this.metrics = metrics;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    void registerMetrics() {
+        Gauge.builder("retroquest.teams.count", this.metrics, Metrics::getTeamCount)
+            .strongReference(true)
+            .register(this.meterRegistry);
+
+        Gauge.builder("retroquest.feedback.count", this.metrics, Metrics::getFeedbackCount)
+            .strongReference(true)
+            .register(this.meterRegistry);
+
+        Gauge.builder("retroquest.feedback.averageRating", this.metrics, Metrics::getAverageRating)
+            .strongReference(true)
+            .register(this.meterRegistry);
+    }
+}

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamRepository.java
@@ -33,7 +33,8 @@ import java.util.Set;
 public interface TeamRepository extends JpaRepository<Team, String> {
     Optional<Team> findTeamByNameIgnoreCase(String name);
     Optional<Team> findTeamByUri(String uri);
-    List<Team> findAllByLastLoginDateBetween(LocalDate start, LocalDate end);
+
+    long countByLastLoginDateBetween(LocalDate start, LocalDate end);
 
     long countAllByDateCreatedAfterAndDateCreatedIsNotNull(LocalDate start);
     long countAllByDateCreatedBetweenAndDateCreatedNotNull(LocalDate start, LocalDate end);

--- a/api/src/test/java/com/ford/labs/retroquest/api/FeedbackApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/FeedbackApiTest.java
@@ -9,10 +9,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -29,28 +33,47 @@ public class FeedbackApiTest extends ApiTest {
     }
 
     @Test
+    public void shouldPostFeedbackAndUpdateMetric() throws Exception {
+        var feedback = Feedback.builder()
+            .stars(4)
+            .comment("This is a comment")
+            .userEmail("email@email.email")
+            .teamId("teamId")
+            .dateCreated(null)
+            .build();
+
+        mockMvc.perform(
+            post("/api/feedback/")
+                .content(objectMapper.writeValueAsString(feedback))
+                .contentType(APPLICATION_JSON)
+        )
+            .andExpect(status().isCreated())
+            .andReturn();
+    }
+
+    @Test
     public void should_get_all_feedback_as_an_admin() throws Exception {
         feedbackRepository.save(Feedback.builder().build());
 
         mockMvc.perform(
-                get("/api/admin/feedback/all")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(1)));
+            get("/api/admin/feedback/all")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(1)));
     }
 
     @Test
     public void should_not_get_all_feedback_being_unauthorized() throws Exception {
         mockMvc.perform(get("/api/admin/feedback/all").contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic("foo", "bar")))
-                .andExpect(status().isUnauthorized());
+            .with(httpBasic("foo", "bar")))
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void should_not_get_all_feedback_without_basic_auth_token() throws Exception {
         mockMvc.perform(get("/api/admin/feedback/all")
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isUnauthorized());
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized());
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/api/MetricsApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/MetricsApiTest.java
@@ -47,23 +47,23 @@ public class MetricsApiTest extends ApiTest {
         teamRepository.save(team);
 
         MvcResult result = mockMvc.perform(get("/api/admin/metrics/team/count")
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andReturn();
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andReturn();
         assertThat(result.getResponse().getContentAsString()).isEqualTo("1");
     }
 
     @Test
     public void cannotReadTheTotalNumberOfTeamsWithInvalidAuthorization() throws Exception {
         mockMvc.perform(get("/api/admin/metrics/team/count")
-                .with(httpBasic("foo", "bar")))
-                .andExpect(status().isUnauthorized());
+            .with(httpBasic("foo", "bar")))
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void cannotReadTheTotalNumberOfTeamsWithoutAuthorization() throws Exception {
         mockMvc.perform(get("/api/admin/metrics/team/count"))
-                .andExpect(status().isUnauthorized());
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -82,14 +82,14 @@ public class MetricsApiTest extends ApiTest {
     @Test
     public void cannotGetFeedbackWithInvalidAuthorization() throws Exception {
         mockMvc.perform(get("/api/admin/metrics/feedback/count")
-                .with(httpBasic("foo", "bar")))
-                .andExpect(status().isUnauthorized());
+            .with(httpBasic("foo", "bar")))
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void cannotGetFeedbackWithoutAuthorization() throws Exception {
         mockMvc.perform(get("/api/admin/metrics/feedback/count"))
-                .andExpect(status().isUnauthorized());
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -104,10 +104,10 @@ public class MetricsApiTest extends ApiTest {
 
 
         MvcResult result = mockMvc.perform(get("/api/admin/metrics/feedback/average")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andReturn();
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andReturn();
         assertThat(result.getResponse().getContentAsString()).isEqualTo("3.0");
     }
 
@@ -123,10 +123,10 @@ public class MetricsApiTest extends ApiTest {
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
         MvcResult result = mockMvc.perform(get("/api/admin/metrics/feedback/average")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andReturn();
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andReturn();
 
         assertThat(result.getResponse().getContentAsString()).isEqualTo("4.0");
     }
@@ -134,14 +134,14 @@ public class MetricsApiTest extends ApiTest {
     @Test
     public void cannotGetAverageRatingWithInvalidAuthorization() throws Exception {
         mockMvc.perform(get("/api/admin/metrics/feedback/average")
-                .with(httpBasic("foo", "bar")))
-                .andExpect(status().isUnauthorized());
+            .with(httpBasic("foo", "bar")))
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
     public void cannotGetAverageRatingWithoutAuthorization() throws Exception {
         mockMvc.perform(get("/api/admin/metrics/feedback/average"))
-                .andExpect(status().isUnauthorized());
+            .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -155,10 +155,10 @@ public class MetricsApiTest extends ApiTest {
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
         mockMvc.perform(get("/api/admin/metrics/feedback/count?start=2018-02-02")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(1)));
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(1)));
     }
 
     @Test
@@ -172,10 +172,10 @@ public class MetricsApiTest extends ApiTest {
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
         mockMvc.perform(get("/api/admin/metrics/feedback/count?end=2018-02-02")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(1)));
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(1)));
     }
 
     @Test
@@ -191,10 +191,10 @@ public class MetricsApiTest extends ApiTest {
         feedbackRepository.saveAll(asList(feedback1, feedback2, feedback3));
 
         mockMvc.perform(get("/api/admin/metrics/feedback/count?start=2018-05-01&end=2018-12-01")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(1)));
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(1)));
     }
 
     @Test
@@ -213,10 +213,10 @@ public class MetricsApiTest extends ApiTest {
         feedbackRepository.saveAll(asList(feedback1, feedback2, feedback3));
 
         mockMvc.perform(get("/api/admin/metrics/feedback/average?start=2018-05-01&end=2018-12-01")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(2.0)));
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(2.0)));
     }
 
     @Test
@@ -232,10 +232,10 @@ public class MetricsApiTest extends ApiTest {
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
         mockMvc.perform(get("/api/admin/metrics/feedback/average?start=2018-02-02")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(3.0)));
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(3.0)));
     }
 
     @Test
@@ -251,10 +251,10 @@ public class MetricsApiTest extends ApiTest {
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
         mockMvc.perform(get("/api/admin/metrics/feedback/average?end=2018-02-02")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(3.0)));
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(3.0)));
     }
 
     @Test
@@ -269,10 +269,10 @@ public class MetricsApiTest extends ApiTest {
         teamRepository.saveAll(asList(team1, team2));
 
         mockMvc.perform(get("/api/admin/metrics/team/count?start=2018-03-03")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(1)));
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(1)));
     }
 
     @Test
@@ -286,9 +286,9 @@ public class MetricsApiTest extends ApiTest {
         teamRepository.saveAll(asList(team1, team2));
 
         mockMvc.perform(get("/api/admin/metrics/team/logins?start=2018-02-02")
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(1)));
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(1)));
     }
 
     @Test
@@ -302,9 +302,9 @@ public class MetricsApiTest extends ApiTest {
         teamRepository.saveAll(asList(team1, team2));
 
         mockMvc.perform(get("/api/admin/metrics/team/logins?end=2018-02-02")
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(1)));
+            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(1)));
     }
 
     @Test
@@ -324,9 +324,9 @@ public class MetricsApiTest extends ApiTest {
         teamRepository.saveAll(asList(team1, team2, team3));
 
         mockMvc.perform(
-                get("/api/admin/metrics/team/logins?start=2018-02-02&end=2018-04-04")
-                        .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$", Matchers.is(1)));
+            get("/api/admin/metrics/team/logins?start=2018-02-02&end=2018-04-04")
+                .with(httpBasic(getAdminUsername(), getAdminPassword())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", Matchers.is(1)));
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/MetricsTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/MetricsTest.java
@@ -38,7 +38,7 @@ public class MetricsTest {
 
     @Test
     public void returnsTheTotalNumberOfTeamsCreated() {
-        given(mockTeamRepository.findAll()).willReturn(asList(new Team(), new Team()));
+        given(mockTeamRepository.count()).willReturn(2L);
         assertEquals(2, metrics.getTeamCount());
     }
 

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/MetricsTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/MetricsTest.java
@@ -1,9 +1,7 @@
 package com.ford.labs.retroquest.deprecated_tests;
 
-import com.ford.labs.retroquest.feedback.Feedback;
 import com.ford.labs.retroquest.feedback.FeedbackRepository;
 import com.ford.labs.retroquest.metrics.Metrics;
-import com.ford.labs.retroquest.team.Team;
 import com.ford.labs.retroquest.team.TeamRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,16 +10,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Collections;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class MetricsTest {
@@ -66,114 +60,13 @@ public class MetricsTest {
 
     @Test
     public void returnsTheFeedbackCount() {
-        given(mockFeedbackRepository.findAll()).willReturn(asList(new Feedback(), new Feedback()));
+        given(mockFeedbackRepository.countByDateCreatedGreaterThanEqualAndDateCreatedLessThanEqual(any(), any())).willReturn(2L);
         assertEquals(2, metrics.getFeedbackCount());
     }
 
     @Test
     public void returnsTheAverageFeedback() {
-        Feedback twoStarFeeback = new Feedback();
-        twoStarFeeback.setStars(2);
-        Feedback threeStarFeedback = new Feedback();
-        threeStarFeedback.setStars(3);
-
-        given(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).willReturn(asList(twoStarFeeback, threeStarFeedback));
+        given(mockFeedbackRepository.getAverageRating(any(), any())).willReturn(2.5);
         assertEquals(2.5, metrics.getAverageRating(), 0);
-    }
-
-    @Test
-    public void returnsZeroWhenNoFeedbackIsPresent() {
-        given(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).willReturn(Collections.emptyList());
-        assertEquals(0.0, metrics.getAverageRating(), 0);
-    }
-
-    @Test
-    public void returnsAppropriateFeedbackCount_whenOnlyStartDateIsProvided() {
-        Feedback feedback1 = new Feedback();
-        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
-        Feedback feedback2 = new Feedback();
-        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3 ,3, 3));
-        given(mockFeedbackRepository.findAll()).willReturn(asList(feedback1, feedback2));
-
-        assertEquals(1, metrics.getFeedbackCount(LocalDate.of(2018, 2, 2), null));
-    }
-
-    @Test
-    public void returnsAppropriateFeedbackCount_whenGivenAStartAndEndDate() {
-
-        Feedback feedback1 = new Feedback();
-        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
-        Feedback feedback2 = new Feedback();
-        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
-        Feedback feedback3 = new Feedback();
-        feedback3.setDateCreated(LocalDateTime.of(2018, 5, 5, 5, 5));
-        given(mockFeedbackRepository.findAll()).willReturn(asList(feedback1, feedback2));
-
-        assertEquals(1, metrics.getFeedbackCount(LocalDate.of(2018, 2, 2), LocalDate.of(2018, 4, 4)));
-    }
-
-    @Test
-    public void returnsAppropriateFeedbackCount_whenOnlyGivenAndEndDate() {
-        Feedback feedback1 = new Feedback();
-        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
-        Feedback feedback2 = new Feedback();
-        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3 ,3, 3));
-        given(mockFeedbackRepository.findAll()).willReturn(asList(feedback1, feedback2));
-
-        assertEquals(1, metrics.getFeedbackCount(null, LocalDate.of(2018, 2, 2)));
-    }
-
-    @Test
-    public void returnsAppropriateFeedbackAverage_whenOnlyGivenAStartTime() {
-        Feedback feedback1 = new Feedback();
-        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
-        feedback1.setStars(1);
-        Feedback feedback2 = new Feedback();
-        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
-        feedback2.setStars(1);
-        given(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).willReturn(asList(feedback1, feedback2));
-
-        assertEquals(1.0, metrics.getAverageRating(LocalDate.of(2018, 1, 1), null), .001);
-    }
-
-    @Test
-    public void returnsAppropriateFeedbackAverage_whenOnlyGivenBothAStartAndEndTime() {
-        Feedback feedback1 = new Feedback();
-        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
-        feedback1.setStars(1);
-        Feedback feedback2 = new Feedback();
-        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
-        feedback2.setStars(1);
-        Feedback feedback3 = new Feedback();
-        feedback3.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
-        feedback3.setStars(1);
-        given(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).willReturn(asList(feedback1, feedback2));
-
-        assertEquals(1.0, metrics.getAverageRating(LocalDate.of(2018, 2, 2), LocalDate.of(2018, 4, 4)), .001);
-    }
-
-    @Test
-    public void returnsAppropriateFeedbackAverage_whenOnlyGivenAnEndTime() {
-        Feedback feedback1 = new Feedback();
-        feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
-        feedback1.setStars(1);
-        Feedback feedback2 = new Feedback();
-        feedback2.setDateCreated(LocalDateTime.of(2018, 3, 3, 3, 3));
-        feedback2.setStars(1);
-        given(mockFeedbackRepository.findAllByStarsIsGreaterThanEqual(1)).willReturn(asList(feedback1, feedback2));
-
-        assertEquals(1.0, metrics.getAverageRating(null, LocalDate.of(2018, 4, 4)), .001);
-    }
-
-    @Test
-    public void nullStartDate_becomesDefaultStatDate() {
-        metrics.getTeamLogins(null, LocalDate.of(2018, 1, 1));
-        then(mockTeamRepository).should().findAllByLastLoginDateBetween(LocalDate.of(1900, 1, 1), LocalDate.of(2018, 1, 1));
-    }
-
-    @Test
-    public void nullEndDate_becomesDefaulEndDate() {
-        metrics.getTeamLogins(LocalDate.of(2018, 1, 1), null);
-        verify(mockTeamRepository).findAllByLastLoginDateBetween(LocalDate.of(2018, 1, 1), LocalDate.now());
     }
 }


### PR DESCRIPTION
## Overview
Publishes RetroQuest's current metrics to StatsD.

Currently, RetroQuest's metrics can only be obtained by making an admin-authenticated request to the metrics endpoint.

This PR will add custom Micrometer metrics tracking for these metrics so that RetroQuest will publish them to StatsD. 

### Notes
I made some fairly substantial refactors to the Metrics service to push calculations to the database in order to facilitate more frequent polling. 

## Testing Instructions
The existing tests should continue to pass, and no behavioral changes are expected as a result of this change. Assertions on metrics values were added to existing API tests that would cause a change in those values. 