### PR TITLE
Re-enable SonarQube scans

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,6 +44,12 @@ jobs:
       - run: yarn lint
       - run: yarn unit-coverage
       - run: yarn build
+      - name: SonarCloud Scan
+        if: ${{ github.repository == 'FordLabs/retroquest' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_UI_TOKEN }}
+        run: ./gradlew ui:sonarqube --info
+        working-directory: ./
 
   api-checks:
     runs-on: ubuntu-latest
@@ -69,7 +75,11 @@ jobs:
         run: ./gradlew api:apiTestDockerDb
       - name: generate coverage reports
         run: ./gradlew api:jacocoTestReport
-
+      - name: SonarCloud Scan
+        if: ${{ github.repository == 'FordLabs/retroquest' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_API_TOKEN }}
+        run: ./gradlew api:sonarqube --info
       - name: cleanup gradle cache
         run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/Feedback.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/Feedback.java
@@ -44,4 +44,15 @@ public class Feedback {
     @EqualsAndHashCode.Exclude
     @Builder.Default
     private LocalDateTime dateCreated = LocalDateTime.now();
+
+    static Feedback fromDto(FeedbackDto dto) {
+        return new Feedback(
+            null,
+            dto.getStars(),
+            dto.getComment(),
+            dto.getUserEmail(),
+            dto.getTeamId(),
+            LocalDateTime.now()
+        );
+    }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackController.java
@@ -48,7 +48,8 @@ public class FeedbackController {
     @PostMapping
     @Operation(summary = "Creates a feedback entry", description = "saveFeedback")
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Created")})
-    public ResponseEntity<URI> saveFeedback(@RequestBody Feedback feedback) throws URISyntaxException {
+    public ResponseEntity<URI> saveFeedback(@RequestBody FeedbackDto feedbackDto) throws URISyntaxException {
+        var feedback = Feedback.fromDto(feedbackDto);
         log.info(
             "[FEEDBACK_SUBMITTED] stars:'{}' comment:'{}' email:'{}' teamId:'{}'",
             feedback.getStars(),
@@ -56,8 +57,7 @@ public class FeedbackController {
             feedback.getUserEmail(),
             feedback.getTeamId()
         );
-        feedback.setDateCreated(LocalDateTime.now());
-        Feedback savedFeedback = feedbackRepository.save(feedback);
-        return ResponseEntity.created(new URI("/api/feedback/" + savedFeedback.getId())).build();
+        feedback = feedbackRepository.save(feedback);
+        return ResponseEntity.created(new URI("/api/feedback/" + feedback.getId())).build();
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackDto.java
+++ b/api/src/main/java/com/ford/labs/retroquest/feedback/FeedbackDto.java
@@ -1,0 +1,11 @@
+package com.ford.labs.retroquest.feedback;
+
+import lombok.Value;
+
+@Value
+public class FeedbackDto {
+    int stars;
+    String comment;
+    String userEmail;
+    String teamId;
+}

--- a/api/src/test/java/com/ford/labs/retroquest/api/FeedbackApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/FeedbackApiTest.java
@@ -2,6 +2,7 @@ package com.ford.labs.retroquest.api;
 
 import com.ford.labs.retroquest.api.setup.ApiTest;
 import com.ford.labs.retroquest.feedback.Feedback;
+import com.ford.labs.retroquest.feedback.FeedbackDto;
 import com.ford.labs.retroquest.feedback.FeedbackRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.AfterEach;
@@ -39,13 +40,12 @@ public class FeedbackApiTest extends ApiTest {
         meterRegistry.gauge("retroquest.feedback.count", 0);
         meterRegistry.gauge("retroquest.feedback.averageRating", 0);
 
-        var feedback = Feedback.builder()
-            .stars(4)
-            .comment("This is a comment")
-            .userEmail("email@email.email")
-            .teamId("teamId")
-            .dateCreated(null)
-            .build();
+        var feedback = new FeedbackDto(
+            4,
+            "This is a comment",
+            "email@email.email",
+            "teamId"
+        );
 
         mockMvc.perform(
             post("/api/feedback/")


### PR DESCRIPTION
## Overview
Re-enable SonarQube scans on the Check pipeline.

We will now only run SonarQube scans if the current repository is `FordLabs/retroquest`. This will only allow check runs that have permissions to access the SonarQube secret token to run the SonarQube scans.