### PR TITLE
Add an unused import linter

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   root: true,
   ignorePatterns: ['projects/**/*', 'jest.config.js'],
   extends: ['prettier'],
+  plugins: ['unused-imports'],
   overrides: [
     {
       files: ['*.ts'],
@@ -40,6 +41,9 @@ module.exports = {
         'id-match': 'off',
         'no-underscore-dangle': 'off',
         'prefer-arrow/prefer-arrow-functions': 'off',
+        'no-unused-vars': 'off',
+        'unused-imports/no-unused-imports': 'error',
+        'unused-imports/no-unused-vars': ['warn'],
       },
     },
     {

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -43,7 +43,6 @@ module.exports = {
         'prefer-arrow/prefer-arrow-functions': 'off',
         'no-unused-vars': 'off',
         'unused-imports/no-unused-imports': 'error',
-        'unused-imports/no-unused-vars': ['warn'],
       },
     },
     {

--- a/ui/cypress/integration/create.e2e.spec.ts
+++ b/ui/cypress/integration/create.e2e.spec.ts
@@ -1,8 +1,4 @@
-import {
-  createTeamIfNecessaryAndLogin,
-  goToTeamBoard,
-  TeamCredentials,
-} from '../util/utils';
+import { createTeamIfNecessaryAndLogin, TeamCredentials } from '../util/utils';
 
 describe('Create Page', () => {
   const teamCredentials = {

--- a/ui/package.json
+++ b/ui/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jsdoc": "30.7.6",
     "eslint-plugin-prefer-arrow": "1.2.2",
+    "eslint-plugin-unused-imports": "^1.1.1",
     "husky": "^5.2.0",
     "jest": "^26.6.3",
     "jest-preset-angular": "^8.4.0",

--- a/ui/src/app/modules/boards/pages/login/login.page.ui.spec.ts
+++ b/ui/src/app/modules/boards/pages/login/login.page.ui.spec.ts
@@ -10,7 +10,6 @@ import { TeamService } from '../../../teams/services/team.service';
 import { RouterModule } from '@angular/router';
 import { APP_BASE_HREF } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { of } from 'rxjs/index';
 
 describe('Logging in', () => {
   let mockTeamService;

--- a/ui/src/app/modules/domain/column-response.ts
+++ b/ui/src/app/modules/domain/column-response.ts
@@ -17,8 +17,6 @@
 
 import { ItemSorter } from './column/item-sorter';
 import { Thought } from './thought';
-import { Column } from './column';
-import { ActionItem } from './action-item';
 
 export interface ColumnResponse {
   id: number;

--- a/ui/src/app/modules/teams/components/actions-column/actions-column.component.spec.ts
+++ b/ui/src/app/modules/teams/components/actions-column/actions-column.component.spec.ts
@@ -19,7 +19,6 @@ import { ActionsColumnComponent } from './actions-column.component';
 import { ActionItem } from '../../../domain/action-item';
 import { ActionItemService } from '../../services/action.service';
 import { ActionItemDialogComponent } from '../../../controls/action-item-dialog/action-item-dialog.component';
-import { Thought } from '../../../domain/thought';
 
 describe('ActionsColumnComponent', () => {
   let component: ActionsColumnComponent;

--- a/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.ts
+++ b/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.ts
@@ -32,7 +32,6 @@ import {
   ColumnResponse,
   deleteColumnResponse,
   emptyColumnResponse,
-  findThought,
 } from '../../../domain/column-response';
 import { WebsocketResponse } from '../../../domain/websocket-response';
 import { CdkDragSortEvent } from '@angular/cdk/drag-drop';

--- a/ui/src/app/modules/teams/pages/team/team.page.spec.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.spec.ts
@@ -26,13 +26,9 @@ import { emptyThought } from '../../../domain/thought';
 import { emptyColumnResponse } from '../../../domain/column-response';
 import { DataService } from '../../../data.service';
 import { SaveCheckerService } from '../../services/save-checker.service';
-import {
-  createMockRxStompService,
-  createMockSubscription,
-} from '../../../utils/testutils';
+import { createMockRxStompService } from '../../../utils/testutils';
 import { EndRetroService } from '../../services/end-retro.service';
 import { SubscriptionService } from '../../services/subscription.service';
-import { RxStompService } from '@stomp/ng2-stompjs';
 
 describe('TeamPageComponent', () => {
   let component: TeamPageComponent;

--- a/ui/src/app/modules/teams/pages/team/team.page.ts
+++ b/ui/src/app/modules/teams/pages/team/team.page.ts
@@ -36,7 +36,6 @@ import { ActionItemService } from '../../services/action.service';
 import { ActionItem } from '../../../domain/action-item';
 import { EndRetroService } from '../../services/end-retro.service';
 import { SubscriptionService } from '../../services/subscription.service';
-import { Thought } from '../../../domain/thought';
 
 @Component({
   selector: 'rq-team',

--- a/ui/src/app/modules/teams/services/action.service.spec.ts
+++ b/ui/src/app/modules/teams/services/action.service.spec.ts
@@ -16,7 +16,6 @@
  */
 
 import { ActionItemService } from './action.service';
-import { Observable } from 'rxjs/index';
 import { ActionItem } from '../../domain/action-item';
 import { HttpClient } from '@angular/common/http';
 import { RxStompService } from '@stomp/ng2-stompjs';

--- a/ui/src/app/modules/teams/services/end-retro.service.spec.ts
+++ b/ui/src/app/modules/teams/services/end-retro.service.spec.ts
@@ -15,7 +15,6 @@
  *  limitations under the License.
  */
 
-import { ThoughtService } from './thought.service';
 import { createMockRxStompService } from '../../utils/testutils';
 import { RxStompService } from '@stomp/ng2-stompjs';
 import { DataService } from '../../data.service';

--- a/ui/src/app/modules/teams/services/subscription.service.spec.ts
+++ b/ui/src/app/modules/teams/services/subscription.service.spec.ts
@@ -5,13 +5,8 @@ import {
 } from '../../utils/testutils';
 import { Subscription } from 'rxjs';
 import { DataService } from '../../data.service';
-import { instance, mock } from 'ts-mockito';
-import { ColumnAggregationService } from './column-aggregation.service';
-import { TeamService } from './team.service';
-import { BoardService } from './board.service';
+import { mock } from 'ts-mockito';
 import { SaveCheckerService } from './save-checker.service';
-import { EndRetroService } from './end-retro.service';
-import { TeamPageComponent } from '../pages/team/team.page';
 import { EventEmitter } from '@angular/core';
 import { WebsocketResponse } from '../../domain/websocket-response';
 import { Column } from '../../domain/column';

--- a/ui/src/app/modules/teams/services/subscription.service.ts
+++ b/ui/src/app/modules/teams/services/subscription.service.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Injectable, OnDestroy, OnInit } from '@angular/core';
+import { EventEmitter, Injectable, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { RxStompService } from '@stomp/ng2-stompjs';
 import { DataService } from '../../data.service';

--- a/ui/src/app/modules/teams/services/team-page-query-param-guard.spec.ts
+++ b/ui/src/app/modules/teams/services/team-page-query-param-guard.spec.ts
@@ -15,7 +15,6 @@
  *  limitations under the License.
  */
 
-import { waitForAsync } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { TeamPageQueryParamGuard } from './team-page-query-param-guard';
 import { createMockRouter } from '../../utils/testutils';

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4812,6 +4812,18 @@ eslint-plugin-prefer-arrow@1.2.2:
   resolved "https://registry.yarnpkg.com/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.2.tgz#0c6d25a6b94cb3e0110a23d129760af5860edb6e"
   integrity sha512-C8YMhL+r8RMeMdYAw/rQtE6xNdMulj+zGWud/qIGnlmomiPRaLDGLMeskZ3alN6uMBojmooRimtdrXebLN4svQ==
 
+eslint-plugin-unused-imports@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-1.1.1.tgz#a5433f8b394461201129a246d8d92d9613e69597"
+  integrity sha512-EApvRx9Q3XQI96Tg7xPPqY6OuOy95wWMXAtc8RrwdIRk9bv8vkJKwOVoE4HeWJOQhHeHcI8lUbOqmup/PxjfOw==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
## Overview
Add an eslint plugin to error on unused imports.
https://www.npmjs.com/package/eslint-plugin-unused-imports

Connects #295 

## Testing Instructions

- Open a file
- Import something into the file
- Run the linter
- You should see an error about an unused import
- Run lint-fix
- The unused import should be removed
