### PR TITLE
Fixes ActionItems not being saved

### DIFF
--- a/ui/src/app/modules/components/task-dialog/task-dialog.component.spec.ts
+++ b/ui/src/app/modules/components/task-dialog/task-dialog.component.spec.ts
@@ -22,6 +22,7 @@ import moment from 'moment';
 import { createMockEventEmitter } from '../../utils/testutils';
 import MockDate from 'mockdate';
 import { ActionItemTaskComponent } from '../action-item-task/action-item-task.component';
+import { emptyThought } from '../../domain/thought';
 
 describe('TaskDialogComponent', () => {
   let component: TaskDialogComponent;
@@ -38,6 +39,7 @@ describe('TaskDialogComponent', () => {
 
     component = new TaskDialogComponent(mockActionItemService);
     component.myWindow = myWindow;
+    component.task = emptyThought();
   });
 
   it('should create', () => {
@@ -156,16 +158,17 @@ describe('TaskDialogComponent', () => {
           focusInput: jest.fn(),
         } as ActionItemTaskComponent;
         component.actionItemTaskComponent = mockActionItemTaskComponent;
-        component.createLinking();
       });
 
       it('should not do anything but start an animation for the user', () => {
+        component.createLinking();
         expect(component.assignedActionItem.state).toEqual('active');
         expect(component.visible).toBeTruthy();
         expect(component.actionItemIsVisible).toBeTruthy();
       });
 
       it('should refocus the action item', () => {
+        component.createLinking();
         expect(mockActionItemTaskComponent.focusInput).toHaveBeenCalled();
       });
     });
@@ -178,6 +181,8 @@ describe('TaskDialogComponent', () => {
         MockDate.set(fakeDate.toDate());
         component.assignedActionItem.task = fakeTaskMessage;
         component.actionItemIsVisible = true;
+        component.task = emptyThought();
+        component.task.teamId = '1';
         component.createLinking();
       });
 
@@ -197,6 +202,7 @@ describe('TaskDialogComponent', () => {
       it('should call the backend to add the assigned action item', () => {
         const expectedActionItem = emptyActionItem();
         expectedActionItem.task = fakeTaskMessage;
+        expectedActionItem.teamId = '1';
         expectedActionItem.dateCreated = fakeDate.format();
         expect(mockActionItemService.addActionItem).toHaveBeenCalledWith(
           expectedActionItem

--- a/ui/src/app/modules/components/task-dialog/task-dialog.component.ts
+++ b/ui/src/app/modules/components/task-dialog/task-dialog.component.ts
@@ -121,6 +121,7 @@ export class TaskDialogComponent implements AfterContentChecked {
   public createLinking() {
     if (this.assignedActionItem.task.length > 0) {
       this.assignedActionItem.dateCreated = moment().format();
+      this.assignedActionItem.teamId = this.task.teamId;
       this.actionItemService.addActionItem(this.assignedActionItem);
       this.assignedActionItem = emptyActionItem();
       this.actionItemIsVisible = false;


### PR DESCRIPTION
## Overview
ActionItems created from the task-dialog were not having their teamId set and so would not be created. This fixes that and adds a test check.