### PR TITLE
Disable the ability to drag thoughts when on mobile layout

### DIFF
--- a/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.html
+++ b/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.html
@@ -44,6 +44,7 @@
         [theme]="theme"
         [archived]="archived"
         cdkDrag
+        [cdkDragDisabled]="isMobileView()"
         [cdkDragData]="thought.id"
     >
     </rq-task>

--- a/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.ts
+++ b/ui/src/app/modules/teams/components/thoughts-column/thoughts-column.component.ts
@@ -63,6 +63,8 @@ export class ThoughtsColumnComponent implements OnInit {
   dialogIsVisible = false;
   thoughtsAreSorted = false;
 
+  isMobileView = (): boolean => window.innerWidth <= 610;
+
   ngOnInit(): void {
     this.retroEnded.subscribe(() => {
       this.thoughtAggregation.items.active.splice(


### PR DESCRIPTION
## Overview
Disables the ability to drag thoughts when using the mobile layout.

This is a quick fix for #331 

### Notes
If the ability to drag thoughts on mobile is still desired, we would need to modify the mobile layout to facilitate this. Perhaps we can introduce alternative UI for both mobile and desktop layouts to allow a user to change which column a thought is in without having to drag. 

There were no tests present for the drag and drop functionality, so I did not modify any tests. If such a test is added in the future (probably a Cypress test), then a duplicate test should also be present that runs the application in the mobile layout and ensures that dragging a thought is not possible.

## Testing Instructions
- Verify that the ability to drag thoughts is still present on desktop
- Verify that the ability to drag thoughts is no longer present on mobile and the user is able to drag to scroll