### PR TITLE
Fixes EndRetro Button not clearing archived thoughts

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
@@ -26,12 +26,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.transaction.Transactional;
 import javax.validation.Valid;

--- a/api/src/main/java/com/ford/labs/retroquest/thought/CreateThoughtRequest.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/CreateThoughtRequest.java
@@ -24,6 +24,7 @@ import lombok.Value;
 @Value
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreateThoughtRequest {
+    Long id;
     String message;
     int hearts;
     String topic;

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
@@ -21,7 +21,6 @@ import com.ford.labs.retroquest.columntitle.ColumnTitleRepository;
 import com.ford.labs.retroquest.exception.ThoughtNotFoundException;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
 import java.util.List;
 
 @Service

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
@@ -21,6 +21,7 @@ import com.ford.labs.retroquest.columntitle.ColumnTitleRepository;
 import com.ford.labs.retroquest.exception.ThoughtNotFoundException;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 @Service
@@ -80,6 +81,7 @@ public class ThoughtService {
 
     public Thought createThought(String teamId, Long boardId, CreateThoughtRequest request) {
         var thought = new Thought();
+        thought.setId(request.getId());
         thought.setMessage(request.getMessage());
         thought.setHearts(request.getHearts());
         thought.setTopic(request.getTopic());

--- a/api/src/main/resources/db/changelog.xml
+++ b/api/src/main/resources/db/changelog.xml
@@ -16,7 +16,9 @@
   ~ limitations under the License.
   -->
 
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
     <changeSet author="rkennel (generated)" id="1615067156888-1">
         <preConditions onFail="MARK_RAN">
             <not>

--- a/api/src/test/java/com/ford/labs/retroquest/api/BoardApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/BoardApiTest.java
@@ -32,10 +32,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/com/ford/labs/retroquest/api/BoardApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/BoardApiTest.java
@@ -20,17 +20,27 @@ package com.ford.labs.retroquest.api;
 import com.ford.labs.retroquest.api.setup.ApiTestBase;
 import com.ford.labs.retroquest.board.Board;
 import com.ford.labs.retroquest.board.BoardRepository;
+import com.ford.labs.retroquest.board.CreateBoardRequest;
+import com.ford.labs.retroquest.thought.CreateThoughtRequest;
+import com.ford.labs.retroquest.thought.Thought;
+import com.ford.labs.retroquest.thought.ThoughtRepository;
+import com.ford.labs.retroquest.thought.ThoughtService;
+import org.assertj.core.util.Lists;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -40,11 +50,19 @@ class BoardApiTest extends ApiTestBase {
     @Autowired
     private BoardRepository boardRepository;
 
+    @Autowired
+    private ThoughtRepository thoughtRepository;
+
+    @Autowired
+    private ThoughtService thoughtService;
+
     @AfterEach
     void teardown() {
         boardRepository.deleteAllInBatch();
+        thoughtRepository.deleteAllInBatch();
 
         assertThat(boardRepository.count()).isZero();
+        assertThat(thoughtRepository.count()).isZero();
     }
 
     @Test
@@ -69,5 +87,63 @@ class BoardApiTest extends ApiTestBase {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].dateCreated", Matchers.is("2018-02-02")))
                 .andExpect(jsonPath("$[1].dateCreated", Matchers.is("2018-01-01")));
+    }
+
+    @Test
+    void should_save_a_board_with_thoughts() throws Exception {
+
+        Thought savedThought = thoughtService.createThought(teamId, new CreateThoughtRequest(-1L, "TEST_MESSAGE", 0, "happy", false, teamId, -1L));
+        CreateBoardRequest request = new CreateBoardRequest(teamId, Lists.emptyList());
+
+        mockMvc.perform(post("/api/team/" + teamId + "/board")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", getBearerAuthToken()))
+                .andExpect(status().isOk());
+
+        assertThat(boardRepository.count()).isEqualTo(1);
+        assertThat(thoughtService.fetchAllThoughtsByTeam(teamId)).containsExactly(savedThought);
+    }
+
+    @Test
+    void should_save_a_board_with_thoughts_and_clear_away_the_thoughts_without_a_board_id() throws Exception {
+
+        Thought savedThought = thoughtService.createThought(teamId, new CreateThoughtRequest(
+                -1L,
+                "TEST_MESSAGE",
+                0,
+                "happy",
+                false,
+                teamId,
+                -1L)
+        );
+
+        CreateBoardRequest request = new CreateBoardRequest(teamId, Collections.singletonList(
+                new CreateThoughtRequest(
+                        savedThought.getId(),
+                        savedThought.getMessage(),
+                        savedThought.getHearts(),
+                        savedThought.getTopic(),
+                        savedThought.isDiscussed(),
+                        savedThought.getTeamId(),
+                        -1L
+                )
+        ));
+
+        mockMvc.perform(post("/api/team/" + teamId + "/board")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", getBearerAuthToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.thoughts[0].id", Matchers.notNullValue()))
+                .andExpect(jsonPath("$.thoughts[0].message", Matchers.is(savedThought.getMessage())))
+                .andExpect(jsonPath("$.thoughts[0].hearts", Matchers.is(savedThought.getHearts())))
+                .andExpect(jsonPath("$.thoughts[0].discussed", Matchers.is(savedThought.isDiscussed())))
+                .andExpect(jsonPath("$.thoughts[0].teamId", Matchers.is(savedThought.getTeamId())))
+                .andExpect(jsonPath("$.thoughts[0].boardId", Matchers.notNullValue()));
+
+
+        assertThat(boardRepository.count()).isEqualTo(1);
+        assertThat(thoughtService.fetchAllThoughtsByTeam(teamId)).isEmpty();
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/api/TeamApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/TeamApiTest.java
@@ -19,11 +19,7 @@ package com.ford.labs.retroquest.api;
 
 import com.ford.labs.retroquest.api.setup.ApiTestBase;
 import com.ford.labs.retroquest.columntitle.ColumnTitleRepository;
-import com.ford.labs.retroquest.team.CreateTeamRequest;
-import com.ford.labs.retroquest.team.LoginRequest;
-import com.ford.labs.retroquest.team.Team;
-import com.ford.labs.retroquest.team.TeamRepository;
-import com.ford.labs.retroquest.team.UpdatePasswordRequest;
+import com.ford.labs.retroquest.team.*;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/BoardControllerTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/BoardControllerTest.java
@@ -65,6 +65,7 @@ class BoardControllerTest {
             "team-id",
             List.of(
                 new CreateThoughtRequest(
+                        -1L,
                     "hello",
                     0,
                     null,

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/BoardServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/BoardServiceTest.java
@@ -114,6 +114,7 @@ class BoardServiceTest {
             expectedTeamId,
             List.of(
                 new CreateThoughtRequest(
+                        0L,
                     expectedMessage,
                     0,
                     null,

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/BoardServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/BoardServiceTest.java
@@ -38,9 +38,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
@@ -137,6 +137,7 @@ class ThoughtServiceTest {
         var topic = "topic";
         var columnTitle = ColumnTitle.builder().title("Happy").build();
         var request = new CreateThoughtRequest(
+                -1L,
             null,
             0,
             topic,


### PR DESCRIPTION
## Overview
Fixes issue #332 

The issue was that the CreateThoughRequest class on the backend wasn't including the `id` of the Thought, causing a duplicate Thought to be archived without deleting the old entry.