### PR TITLE
Adds stale-while-refresh to service worker API, shouldn't 404 anymore.

### DIFF
--- a/ui/src/ngsw-config.json
+++ b/ui/src/ngsw-config.json
@@ -1,5 +1,7 @@
 {
   "index": "/index.html",
+  "strategy": "freshness",
+  "timeout": "0u",
   "assetGroups": [
     {
       "name": "app",


### PR DESCRIPTION
https://angular.io/guide/service-worker-config#strategy