### PR TITLE
Enable csrf protection

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/security/WebSecurityConfig.java
+++ b/api/src/main/java/com/ford/labs/retroquest/security/WebSecurityConfig.java
@@ -30,6 +30,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 @Configuration
 @EnableWebSecurity
@@ -75,9 +76,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .permitAll()
                 .anyRequest()
                 .authenticated()
-                .and().addFilterAfter(jwtAuthenticationFilter, BasicAuthenticationFilter.class);
+                .and().addFilterAfter(jwtAuthenticationFilter, BasicAuthenticationFilter.class)
+                .csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
 
-        httpSecurity.csrf().disable();
         displayH2ConsoleToDevs(httpSecurity);
     }
 

--- a/api/src/test/java/com/ford/labs/retroquest/api/ColumnApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ColumnApiTest.java
@@ -49,33 +49,36 @@ class ColumnApiTest extends ApiTestBase {
     @BeforeEach
     void setup() {
         expectedBody = ColumnCombinerResponse.builder()
-                .columns(
-                        Collections.singletonList(ColumnResponse.builder().topic("happy").build())
-                ).build();
+            .columns(Collections.singletonList(ColumnResponse.builder().topic("happy").build()))
+            .build();
 
         when(columnCombinerService.aggregateResponse(teamId)).thenReturn(expectedBody);
     }
 
     @Test
     void should_return_unauthorized_if_no_bearer_token_is_sent() throws Exception {
-        mockMvc.perform(get("/api/v2/team/" + teamId + "/columns"))
-                .andExpect(status().isUnauthorized());
+        mockMvc.perform(
+            get("/api/v2/team/{team}/columns", teamId)
+        ).andExpect(status().isUnauthorized());
     }
 
     @Test
     void should_return_ok_since_user_is_authorized() throws Exception {
-        mockMvc.perform(get("/api/v2/team/" + teamId + "/columns")
-                .header("Authorization", getBearerAuthToken()))
-                .andExpect(status().isOk());
+        mockMvc.perform(
+            get("/api/v2/team/{team}/columns", teamId)
+                .header("Authorization", getBearerAuthToken())
+        ).andExpect(status().isOk());
     }
 
     @Test
     void should_get_a_filled_out_aggregated_response_with_a_200() throws Exception {
-        String body = mockMvc.perform(get("/api/v2/team/" + teamId + "/columns")
-                .header("Authorization", getBearerAuthToken()))
-                .andReturn().getResponse().getContentAsString();
+        String body = mockMvc.perform(
+            get("/api/v2/team/{team}/columns", teamId)
+                .header("Authorization", getBearerAuthToken())
+        ).andReturn().getResponse().getContentAsString();
 
         assertThat(objectMapper.readValue(body, ColumnCombinerResponse.class))
-                .isEqualToComparingFieldByField(expectedBody);
+            .usingRecursiveComparison()
+            .isEqualTo(expectedBody);
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/api/FeedbackApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/FeedbackApiTest.java
@@ -31,6 +31,7 @@ import org.springframework.http.MediaType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -68,6 +69,7 @@ class FeedbackApiTest extends ApiTestBase {
             post("/api/feedback/")
                 .content(objectMapper.writeValueAsString(feedback))
                 .contentType(APPLICATION_JSON)
+                .with(csrf())
         )
             .andExpect(status().isCreated())
             .andReturn();
@@ -85,22 +87,26 @@ class FeedbackApiTest extends ApiTestBase {
         mockMvc.perform(
             get("/api/admin/feedback/all")
                 .contentType(MediaType.APPLICATION_JSON)
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", hasSize(1)));
     }
 
     @Test
     void should_not_get_all_feedback_being_unauthorized() throws Exception {
-        mockMvc.perform(get("/api/admin/feedback/all").contentType(MediaType.APPLICATION_JSON)
-            .with(httpBasic("foo", "bar")))
-            .andExpect(status().isUnauthorized());
+        mockMvc.perform(
+            get("/api/admin/feedback/all")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic("foo", "bar"))
+        ).andExpect(status().isUnauthorized());
     }
 
     @Test
     void should_not_get_all_feedback_without_basic_auth_token() throws Exception {
-        mockMvc.perform(get("/api/admin/feedback/all")
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isUnauthorized());
+        mockMvc.perform(
+            get("/api/admin/feedback/all")
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isUnauthorized());
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/api/MetricsApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/MetricsApiTest.java
@@ -63,18 +63,20 @@ class MetricsApiTest extends ApiTestBase {
         team.setDateCreated(LocalDate.now());
         teamRepository.save(team);
 
-        MvcResult result = mockMvc.perform(get("/api/admin/metrics/team/count")
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
-            .andExpect(status().isOk())
-            .andReturn();
+        MvcResult result = mockMvc.perform(
+            get("/api/admin/metrics/team/count")
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        ).andExpect(status().isOk()).andReturn();
+
         assertThat(result.getResponse().getContentAsString()).isEqualTo("1");
     }
 
     @Test
     void cannotReadTheTotalNumberOfTeamsWithInvalidAuthorization() throws Exception {
-        mockMvc.perform(get("/api/admin/metrics/team/count")
-            .with(httpBasic("foo", "bar")))
-            .andExpect(status().isUnauthorized());
+        mockMvc.perform(
+            get("/api/admin/metrics/team/count")
+                .with(httpBasic("foo", "bar"))
+        ).andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -89,18 +91,20 @@ class MetricsApiTest extends ApiTestBase {
         feedback.setDateCreated(LocalDateTime.now());
         feedbackRepository.save(feedback);
 
-        MvcResult result = mockMvc.perform(get("/api/admin/metrics/feedback/count")
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
-                .andExpect(status().isOk())
-                .andReturn();
+        MvcResult result = mockMvc.perform(
+            get("/api/admin/metrics/feedback/count")
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        ).andExpect(status().isOk()).andReturn();
+
         assertThat(result.getResponse().getContentAsString()).isEqualTo("1");
     }
 
     @Test
     void cannotGetFeedbackWithInvalidAuthorization() throws Exception {
-        mockMvc.perform(get("/api/admin/metrics/feedback/count")
-            .with(httpBasic("foo", "bar")))
-            .andExpect(status().isUnauthorized());
+        mockMvc.perform(
+            get("/api/admin/metrics/feedback/count")
+                .with(httpBasic("foo", "bar"))
+        ).andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -120,11 +124,12 @@ class MetricsApiTest extends ApiTestBase {
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
 
-        MvcResult result = mockMvc.perform(get("/api/admin/metrics/feedback/average")
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
-            .andExpect(status().isOk())
-            .andReturn();
+        MvcResult result = mockMvc.perform(
+            get("/api/admin/metrics/feedback/average")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        ).andExpect(status().isOk()).andReturn();
+
         assertThat(result.getResponse().getContentAsString()).isEqualTo("3.0");
     }
 
@@ -139,11 +144,11 @@ class MetricsApiTest extends ApiTestBase {
         feedback2.setDateCreated(LocalDateTime.now());
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
-        MvcResult result = mockMvc.perform(get("/api/admin/metrics/feedback/average")
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
-            .andExpect(status().isOk())
-            .andReturn();
+        MvcResult result = mockMvc.perform(
+            get("/api/admin/metrics/feedback/average")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        ).andExpect(status().isOk()).andReturn();
 
         assertThat(result.getResponse().getContentAsString()).isEqualTo("4.0");
     }
@@ -163,7 +168,6 @@ class MetricsApiTest extends ApiTestBase {
 
     @Test
     void whenGettingTheTotalNumberOfReviews_providingOnlyAStartDate_getsAllFromThatDateUntilNow() throws Exception {
-
         Feedback feedback1 = new Feedback();
         feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
         Feedback feedback2 = new Feedback();
@@ -171,16 +175,17 @@ class MetricsApiTest extends ApiTestBase {
 
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/count?start=2018-02-02")
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+        mockMvc.perform(
+            get("/api/admin/metrics/feedback/count?start=2018-02-02")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", Matchers.is(1)));
     }
 
     @Test
     void whenGettingTheTotalNumberOfReviews_providingOnlyAnEndDate_getsAllFromNowToThatDate() throws Exception {
-
         Feedback feedback1 = new Feedback();
         feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
         Feedback feedback2 = new Feedback();
@@ -188,16 +193,17 @@ class MetricsApiTest extends ApiTestBase {
 
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/count?end=2018-02-02")
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+        mockMvc.perform(
+            get("/api/admin/metrics/feedback/count?end=2018-02-02")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", Matchers.is(1)));
     }
 
     @Test
     void whenGettingTheTotalNumberOfReviews_providingOnlyStartAndEndDate_getsAllBetweenThoseDates() throws Exception {
-
         Feedback feedback1 = new Feedback();
         feedback1.setDateCreated(LocalDateTime.of(2018, 4, 1, 1, 1));
         Feedback feedback2 = new Feedback();
@@ -207,16 +213,17 @@ class MetricsApiTest extends ApiTestBase {
 
         feedbackRepository.saveAll(asList(feedback1, feedback2, feedback3));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/count?start=2018-05-01&end=2018-12-01")
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+        mockMvc.perform(
+            get("/api/admin/metrics/feedback/count?start=2018-05-01&end=2018-12-01")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", Matchers.is(1)));
     }
 
     @Test
     void whenGettingTheAverageRating_providingAStartAndEndDate_getsTheBetweenDates() throws Exception {
-
         Feedback feedback1 = new Feedback();
         feedback1.setDateCreated(LocalDateTime.of(2018, 4, 1, 1, 1));
         feedback1.setStars(1);
@@ -229,16 +236,17 @@ class MetricsApiTest extends ApiTestBase {
 
         feedbackRepository.saveAll(asList(feedback1, feedback2, feedback3));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/average?start=2018-05-01&end=2018-12-01")
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+        mockMvc.perform(
+            get("/api/admin/metrics/feedback/average?start=2018-05-01&end=2018-12-01")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", Matchers.is(2.0)));
     }
 
     @Test
     void whenGettingTheAverageRating_providingOnlyAStartDate_getsAllFromThatDateUntilNow() throws Exception {
-
         Feedback feedback1 = new Feedback();
         feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
         feedback1.setStars(1);
@@ -248,16 +256,17 @@ class MetricsApiTest extends ApiTestBase {
 
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/average?start=2018-02-02")
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+        mockMvc.perform(
+            get("/api/admin/metrics/feedback/average?start=2018-02-02")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", Matchers.is(3.0)));
     }
 
     @Test
     void whenGettingTheAverageRating_providingOnlyAnEndDate_getsAllFromNowToThatDate() throws Exception {
-
         Feedback feedback1 = new Feedback();
         feedback1.setStars(3);
         feedback1.setDateCreated(LocalDateTime.of(2018, 1, 1, 1, 1));
@@ -267,16 +276,17 @@ class MetricsApiTest extends ApiTestBase {
 
         feedbackRepository.saveAll(asList(feedback1, feedback2));
 
-        mockMvc.perform(get("/api/admin/metrics/feedback/average?end=2018-02-02")
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+        mockMvc.perform(
+            get("/api/admin/metrics/feedback/average?end=2018-02-02")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", Matchers.is(3.0)));
     }
 
     @Test
     void whenGettingTeamCount_providingOnlyAStartDate_getsAllFromNowToThatDate() throws Exception {
-
         Team team1 = new Team();
         team1.setUri("team" + LocalDate.now().toEpochDay());
         team1.setDateCreated(LocalDate.of(2018, 2, 2));
@@ -285,9 +295,11 @@ class MetricsApiTest extends ApiTestBase {
         team2.setDateCreated(LocalDate.of(2018, 4, 4));
         teamRepository.saveAll(asList(team1, team2));
 
-        mockMvc.perform(get("/api/admin/metrics/team/count?start=2018-03-03")
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+        mockMvc.perform(
+            get("/api/admin/metrics/team/count?start=2018-03-03")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", Matchers.is(1)));
     }
@@ -302,8 +314,10 @@ class MetricsApiTest extends ApiTestBase {
         team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
         teamRepository.saveAll(asList(team1, team2));
 
-        mockMvc.perform(get("/api/admin/metrics/team/logins?start=2018-02-02")
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+        mockMvc.perform(
+            get("/api/admin/metrics/team/logins?start=2018-02-02")
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", Matchers.is(1)));
     }
@@ -318,8 +332,10 @@ class MetricsApiTest extends ApiTestBase {
         team2.setLastLoginDate(LocalDate.of(2018, 3, 3));
         teamRepository.saveAll(asList(team1, team2));
 
-        mockMvc.perform(get("/api/admin/metrics/team/logins?end=2018-02-02")
-            .with(httpBasic(getAdminUsername(), getAdminPassword())))
+        mockMvc.perform(
+            get("/api/admin/metrics/team/logins?end=2018-02-02")
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", Matchers.is(1)));
     }
@@ -342,7 +358,8 @@ class MetricsApiTest extends ApiTestBase {
 
         mockMvc.perform(
             get("/api/admin/metrics/team/logins?start=2018-02-02&end=2018-04-04")
-                .with(httpBasic(getAdminUsername(), getAdminPassword())))
+                .with(httpBasic(getAdminUsername(), getAdminPassword()))
+        )
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", Matchers.is(1)));
     }

--- a/ui/local-proxy.config.json
+++ b/ui/local-proxy.config.json
@@ -2,14 +2,12 @@
   "/api/*": {
     "target": "http://localhost:8080",
     "secure": false,
-    "logLevel": "debug",
-    "changeOrigin": true
+    "logLevel": "debug"
   },
   "/websocket/*": {
     "target": "http://localhost:8080",
     "secure": false,
     "logLevel": "debug",
-    "changeOrigin": true,
     "ws": true
   }
 }


### PR DESCRIPTION
## Overview
Enables CSRF protections on the backend

## Testing Instructions
- Run the backend and frontend locally and ensure all API calls still behave as expected
- Run the application in a deployed environment and ensure all API calls still behave as expected