### PR TITLE
Reduce JWT exception chatter

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/exception/UserUnauthenticatedException.java
+++ b/api/src/main/java/com/ford/labs/retroquest/exception/UserUnauthenticatedException.java
@@ -21,10 +21,6 @@ import org.springframework.security.core.AuthenticationException;
 
 public class UserUnauthenticatedException extends AuthenticationException {
 
-    public UserUnauthenticatedException(String msg, Throwable t) {
-        super(msg, t);
-    }
-
     public UserUnauthenticatedException(String msg) {
         super(msg);
     }

--- a/api/src/main/java/com/ford/labs/retroquest/security/JwtAuthenticationProvider.java
+++ b/api/src/main/java/com/ford/labs/retroquest/security/JwtAuthenticationProvider.java
@@ -31,7 +31,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         try {
             authentication.getPrincipal();
         } catch(Exception e) {
-            throw new UserUnauthenticatedException("Invalid Token", e);
+            throw new UserUnauthenticatedException(e.getMessage());
         }
 
         authentication.setAuthenticated(true);

--- a/api/src/main/java/com/ford/labs/retroquest/security/WebSecurityConfig.java
+++ b/api/src/main/java/com/ford/labs/retroquest/security/WebSecurityConfig.java
@@ -59,16 +59,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             httpSecurity.requiresChannel().antMatchers("/*").requiresSecure();
         }
 
-        httpSecurity.authorizeRequests().antMatchers("/api/admin/**")
-                .hasRole("ADMIN").and().httpBasic();
-
         httpSecurity
                 .authorizeRequests()
-                .antMatchers("/contributors").permitAll()
-                .antMatchers("/**")
-                .permitAll()
-                .anyRequest()
-                .authenticated()
+                .antMatchers("/**").permitAll()
+                .anyRequest().authenticated()
+                .and().httpBasic()
                 .and().addFilterAfter(jwtAuthenticationFilter, BasicAuthenticationFilter.class);
 
         httpSecurity.csrf().disable();

--- a/api/src/test/java/com/ford/labs/retroquest/security/JwtAuthenticationProviderTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/security/JwtAuthenticationProviderTest.java
@@ -17,23 +17,29 @@
 
 package com.ford.labs.retroquest.security;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.AuthenticationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class JwtAuthenticationProviderTest {
 
+    public static final String INVALID_JWT = "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2MjY4ODA4NzYsInN1YiI6InRlc3QiLCJpc3MiOiJSZXRyb1F1ZXN0In0.AJgA5Bhr-MZgBFyQV64BphMKJ7ScK5roBLBL7K2KSyGMl5snrhQ6yxmIwMFffC7m3aZ1kCA-y_QvaGIqru37LQ";
     private final JwtAuthenticationProvider jwtAuthenticationProvider = new JwtAuthenticationProvider();
 
     @Test
     void jwtWithInvalidFormatThrowsException() {
-        var invalidJwt = new JwtAuthentication("", false, "SOSECRET");
-        Assertions.assertThrows(
-            AuthenticationException.class,
-            () -> jwtAuthenticationProvider.authenticate(invalidJwt)
-        );
+        var invalidJwt = new JwtAuthentication(INVALID_JWT, false, "SOSECRET");
+
+        try {
+            jwtAuthenticationProvider.authenticate(invalidJwt);
+            fail();
+        } catch(AuthenticationException exception) {
+            assertThat(exception.getMessage()).isEqualTo("JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.");
+        } catch (Exception exception) {
+            fail();
+        }
     }
 
     @Test

--- a/api/src/test/java/com/ford/labs/retroquest/security/JwtAuthenticationProviderTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/security/JwtAuthenticationProviderTest.java
@@ -17,29 +17,26 @@
 
 package com.ford.labs.retroquest.security;
 
+import com.ford.labs.retroquest.exception.UserUnauthenticatedException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.core.AuthenticationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class JwtAuthenticationProviderTest {
 
-    public static final String INVALID_JWT = "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2MjY4ODA4NzYsInN1YiI6InRlc3QiLCJpc3MiOiJSZXRyb1F1ZXN0In0.AJgA5Bhr-MZgBFyQV64BphMKJ7ScK5roBLBL7K2KSyGMl5snrhQ6yxmIwMFffC7m3aZ1kCA-y_QvaGIqru37LQ";
+    private static final String INVALID_JWT = "eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2MjY4ODA4NzYsInN1YiI6InRlc3QiLCJpc3MiOiJSZXRyb1F1ZXN0In0.AJgA5Bhr-MZgBFyQV64BphMKJ7ScK5roBLBL7K2KSyGMl5snrhQ6yxmIwMFffC7m3aZ1kCA-y_QvaGIqru37LQ";
+    private static final String INVALID_JWT_SIGNATURE_STRING = "JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.";
     private final JwtAuthenticationProvider jwtAuthenticationProvider = new JwtAuthenticationProvider();
 
     @Test
-    void jwtWithInvalidFormatThrowsException() {
+    void jwtWithInvalidFormatThrowsUserUnauthenticatedException() {
         var invalidJwt = new JwtAuthentication(INVALID_JWT, false, "SOSECRET");
-
-        try {
-            jwtAuthenticationProvider.authenticate(invalidJwt);
-            fail("Test did not throw an exception");
-        } catch(AuthenticationException exception) {
-            assertThat(exception.getMessage()).isEqualTo("JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.");
-        } catch (Exception exception) {
-            fail("Test threw an exception other than an AuthenticationException");
-        }
+        var exception = Assertions.assertThrows(
+                UserUnauthenticatedException.class,
+                () -> jwtAuthenticationProvider.authenticate(invalidJwt)
+        );
+        assertThat(exception.getMessage()).isEqualTo(INVALID_JWT_SIGNATURE_STRING);
     }
 
     @Test

--- a/api/src/test/java/com/ford/labs/retroquest/security/JwtAuthenticationProviderTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/security/JwtAuthenticationProviderTest.java
@@ -34,11 +34,11 @@ class JwtAuthenticationProviderTest {
 
         try {
             jwtAuthenticationProvider.authenticate(invalidJwt);
-            fail();
+            fail("Test did not throw an exception");
         } catch(AuthenticationException exception) {
             assertThat(exception.getMessage()).isEqualTo("JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted.");
         } catch (Exception exception) {
-            fail();
+            fail("Test threw an exception other than an AuthenticationException");
         }
     }
 

--- a/ui/src/app/modules/teams/services/team.service.ts
+++ b/ui/src/app/modules/teams/services/team.service.ts
@@ -15,19 +15,21 @@
  * limitations under the License.
  */
 
-import {Injectable} from '@angular/core';
-import {HttpClient, HttpResponse} from '@angular/common/http';
-import {Observable} from 'rxjs/index';
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { Observable } from 'rxjs';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class TeamService {
+  constructor(private http: HttpClient) {}
 
-  constructor(private http: HttpClient) {
-  }
-
-  create(name: string, password: string, captchaResponse: string): Observable<HttpResponse<string>> {
+  create(
+    name: string,
+    password: string,
+    captchaResponse: string
+  ): Observable<HttpResponse<string>> {
     return this.doPostRequest('/api/team', name, password, captchaResponse);
   }
 
@@ -35,56 +37,66 @@ export class TeamService {
     return this.doPostRequest('/api/user', name, password);
   }
 
-  login(name: string, password: string, captchaResponse: string): Observable<HttpResponse<string>> {
+  login(
+    name: string,
+    password: string,
+    captchaResponse: string
+  ): Observable<HttpResponse<string>> {
     return this.http.post(
       '/api/team/login',
-      {name, password, captchaResponse},
-      {observe: 'response', responseType: 'text'}
+      { name, password, captchaResponse },
+      { observe: 'response', responseType: 'text' }
     );
   }
 
-  updatePassword(teamId: string, previousPassword: string, newPassword: string): Observable<HttpResponse<string>> {
+  updatePassword(
+    teamId: string,
+    previousPassword: string,
+    newPassword: string
+  ): Observable<HttpResponse<string>> {
     return this.http.post(
       '/api/update-password',
-      {teamId, previousPassword, newPassword},
-      {observe: 'response', responseType: 'text'}
+      { teamId, previousPassword, newPassword },
+      { observe: 'response', responseType: 'text' }
     );
   }
 
   fetchTeamName(teamId: string): Observable<string> {
-    return this.http.get(
-      `/api/team/${teamId}/name`,
-      {responseType: 'text'}
-    );
+    return this.http.get(`/api/team/${teamId}/name`, { responseType: 'text' });
   }
 
   validateTeamId(teamId: string): Observable<HttpResponse<Object>> {
-    return this.http.get(
-      `/api/team/${teamId}/validate`,
-      {observe: 'response'}
-    );
+    return this.http.get(`/api/team/${teamId}/validate`, {
+      observe: 'response',
+    });
   }
 
   isCaptchaEnabledForTeam(teamName: string): Observable<HttpResponse<string>> {
-    return this.http.get(
-      `/api/team/${teamName}/captcha`,
-      {observe: 'response', responseType: 'text'}
-    );
+    return this.http.get(`/api/team/${teamName}/captcha`, {
+      observe: 'response',
+      responseType: 'text',
+    });
   }
 
   isCaptchaEnabled(): Observable<HttpResponse<string>> {
-    return this.http.get(
-      `/api/captcha`,
-      {observe: 'response', responseType: 'text'}
-    );
+    return this.http.get(`/api/captcha`, {
+      observe: 'response',
+      responseType: 'text',
+    });
   }
 
-  private doPostRequest(endpoint: string, name: string, password: string, captchaResponse?: string) {
-    const payload = captchaResponse ? {name, password, captchaResponse} : {name, password};
-    return this.http.post(
-      endpoint,
-      payload,
-      {observe: 'response', responseType: 'text'}
-    );
+  private doPostRequest(
+    endpoint: string,
+    name: string,
+    password: string,
+    captchaResponse?: string
+  ) {
+    const payload = captchaResponse
+      ? { name, password, captchaResponse }
+      : { name, password };
+    return this.http.post(endpoint, payload, {
+      observe: 'response',
+      responseType: 'text',
+    });
   }
 }


### PR DESCRIPTION
## Overview
We were getting our logs flooded with JWT token expiration stack traces. This commit removes the exception cascade that was leading to the traces. The AuthenticationException that gets thrown when a principal can't be read on a JWT is expected so we shouldn't be seeing that much information and be cluttering out important events.

Connects #255 

## Testing Instructions
1. Start the app
2. Create / log into a board
3. Modify the token in the cookies
4. Make sure network calls still 401
5. Make sure there is no stacktrace in the logs