### PR TITLE
Remove old SonarQube scanner configuration

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -19,7 +19,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.5.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-    id 'org.sonarqube'
     id 'jacoco'
     id 'org.gradle.test-retry' version '1.2.1'
     id 'com.avast.gradle.docker-compose' version '0.14.3'
@@ -190,18 +189,6 @@ jacocoTestReport {
         html.destination file("${project.buildDir}/jacoco-html")
     }
 }
-
-sonarqube {
-    properties {
-        property "sonar.projectName", "RetroQuest API"
-        property "sonar.projectKey", "retroquest_api"
-        property "sonar.organization", "fordlabs"
-        property "sonar.host.url", "https://sonarcloud.io"
-    }
-}
-
-tasks['sonarqube'].dependsOn 'build', 'apiTest'
-tasks['sonarqube'].group = 'verification'
 
 tasks.withType(Test) {
     retry {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,5 @@
  */
 
 plugins {
-    id 'org.sonarqube' version '3.2.0' apply false
     id 'com.github.ben-manes.versions' version '0.39.0' apply false
 }

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -17,7 +17,6 @@
 
 plugins {
     id 'com.github.node-gradle.node' version '3.1.0'
-    id 'org.sonarqube'
     id 'com.github.ben-manes.versions'
 }
 
@@ -49,20 +48,4 @@ task build(type: YarnTask) {
 
 build.configure {
     dependsOn yarn_install
-}
-
-sonarqube {
-    properties {
-        property "sonar.projectName", "RetroQuest UI"
-        property "sonar.projectKey", "retroquest_ui"
-        property "sonar.organization", "fordlabs"
-        property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.sources", "./src/app"
-        property "sonar.exclusions", "**/*.spec.ts, src/testing/*, e2e/*"
-        property "sonar.tests", "./src/app"
-        property "sonar.test.inclusions", "**/*.spec.ts, src/testing/*, e2e/*"
-
-        property "sonar.testExecutionReportPaths", "test-report.xml"
-        property "sonar.javascript.lcov.reportPaths", "./coverage/lcov.info"
-    }
 }

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -30,5 +30,4 @@ module.exports = {
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths || {}, {
     prefix: './',
   }),
-  testResultsProcessor: 'jest-sonar-reporter',
 };

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,6 @@
     "ng-recaptcha": "^8.0.0",
     "ngx-infinite-scroll": "^10.0.0",
     "rxjs": "^6.5.4",
-    "sonar-scanner": "^3.1.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.4"
   },
@@ -81,7 +80,6 @@
     "husky": "^5.2.0",
     "jest": "^26.6.3",
     "jest-preset-angular": "^8.4.0",
-    "jest-sonar-reporter": "^2.0.0",
     "lint-staged": "^10.5.4",
     "mockdate": "^3.0.5",
     "prettier": "^2.2.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9115,15 +9115,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-sonar-reporter@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "jest-sonar-reporter@npm:2.0.0"
-  dependencies:
-    xml: ^1.0.1
-  checksum: a79d87f0db6d83c9306b90b1fe44fa8ea19f1598c3bd11d3198b17617c54b9bd8e982ea3b5a857865acf2f6f96b830321e684e320f7961bcb7444935029be724
-  languageName: node
-  linkType: hard
-
 "jest-util@npm:^26.1.0, jest-util@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-util@npm:26.6.2"
@@ -13242,7 +13233,6 @@ __metadata:
     husky: ^5.2.0
     jest: ^26.6.3
     jest-preset-angular: ^8.4.0
-    jest-sonar-reporter: ^2.0.0
     jquery: ^3.3.1
     lint-staged: ^10.5.4
     mockdate: ^3.0.5
@@ -13252,7 +13242,6 @@ __metadata:
     prettier: ^2.2.1
     puppeteer: ^1.5.0
     rxjs: ^6.5.4
-    sonar-scanner: ^3.1.0
     stylelint: ^13.12.0
     stylelint-config-prettier: ^8.0.2
     stylelint-prettier: ^1.2.0
@@ -13843,15 +13832,6 @@ __metadata:
     ip: ^1.1.5
     smart-buffer: ^4.1.0
   checksum: 2ca9d616e424f645838ebaabb04f85d94ea999e0f8393dc07f86c435af22ed88cb83958feeabd1bb7bc537c635ed47454255635502c6808a6df61af1f41af750
-  languageName: node
-  linkType: hard
-
-"sonar-scanner@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "sonar-scanner@npm:3.1.0"
-  bin:
-    sonar-scanner: index.js
-  checksum: f0275ba329a4b2cd59b177585eeddc484c2639ab0677ed320576bd06ea870ec73b6a7e88a10ce81cd46407d5d3103d279fca2aade2e7e0d2140711731ca0be6b
   languageName: node
   linkType: hard
 
@@ -15859,13 +15839,6 @@ typescript@~4.3.5:
   version: 3.0.0
   resolution: "xml-name-validator@npm:3.0.0"
   checksum: b3ac459afed783c285bb98e4960bd1f3ba12754fd4f2320efa0f9181ca28928c53cc75ca660d15d205e81f92304419afe94c531c7cfb3e0649aa6d140d53ecb0
-  languageName: node
-  linkType: hard
-
-"xml@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "xml@npm:1.0.1"
-  checksum: 11b5545ef3f8fec3fa29ce251f50ad7b6c97c103ed4d851306ec23366f5fa4699dd6a942262df52313a0cd1840ab26256da253c023bad3309d8ce46fe6020ca0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Overview
Removes old SonarQube configuration from RetroQuest, as we now use sonarcloud.io Automatic Scanning.

Once we validate that the scanner works as expected, this PR can be merged in. 