### PR TITLE
Allow Cypress tests to run against any target

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/security/WebController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/security/WebController.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.security;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class WebController {
+    @RequestMapping(value = {"/login", "/create", "/team/**"})
+    public String redirect() {
+        return "forward:/";
+    }
+}

--- a/ui/cypress.json
+++ b/ui/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:4200"
+  "baseUrl": "http://localhost:4200",
+  "chromeWebSecurity": false
 }

--- a/ui/cypress/integration/conduct-retro.e2e.spec.ts
+++ b/ui/cypress/integration/conduct-retro.e2e.spec.ts
@@ -19,8 +19,8 @@ import { createTeamIfNecessaryAndLogin, TeamCredentials } from '../util/utils';
 
 describe('Conduct Retro', () => {
   const teamCredentials = {
-    teamName: 'Conduct Retro',
-    teamId: 'conduct-retro',
+    teamName: 'Test Conduct Retro',
+    teamId: 'test-conduct-retro',
     password: 'Retro1234',
     jwt: '',
   } as TeamCredentials;
@@ -38,6 +38,10 @@ describe('Conduct Retro', () => {
   }
 
   function clearBoard() {
+    // cy.get() will hang forever if the query is empty
+    enterThought('happy', 'first thought');
+    enterActionItems('first action item');
+
     cy.get(`rq-thoughts-column rq-task`)
       .each((input) => {
         deleteCard(input);
@@ -86,13 +90,18 @@ describe('Conduct Retro', () => {
     columnClass: string,
     expectedCount: number
   ): void {
-    cy.get(
-      `rq-thoughts-column rq-task[ng-reflect-type="${columnClass}"] textarea`
-    ).should('have.length', expectedCount);
+    cy.get(`rq-thoughts-column rq-task.${columnClass} textarea`).should(
+      'have.length',
+      expectedCount
+    );
   }
 
   before(() => {
+    cy.visit('/create');
     createTeamIfNecessaryAndLogin(teamCredentials);
+
+    clearBoard();
+
     enterThought('happy', 'Good flow to our work this week');
     enterThought('happy', 'Switching to e2e was a good idea');
     enterThought(
@@ -152,8 +161,8 @@ describe('Conduct Retro', () => {
     it('There is one thought in the confused column', () => {
       confirmNumberOfThoughtsInColumn('confused', 1);
     });
-    it('There is one thought in the unhappy column', () => {
-      confirmNumberOfThoughtsInColumn('unhappy', 1);
+    it('There is one thought in the sad column', () => {
+      confirmNumberOfThoughtsInColumn('sad', 1);
     });
     it('There are two action items', () => {
       cy.get(`rq-actions-column rq-action-item-task`).should('have.length', 2);

--- a/ui/cypress/integration/create.e2e.spec.ts
+++ b/ui/cypress/integration/create.e2e.spec.ts
@@ -19,26 +19,22 @@ import { createTeamIfNecessaryAndLogin, TeamCredentials } from '../util/utils';
 
 describe('Create Page', () => {
   const teamCredentials = {
-    teamName: 'Create Board Tests',
-    teamId: 'create-board-tests',
+    teamName: 'Test Create Board',
+    teamId: 'test-create-board',
     password: 'Test1234',
     jwt: '',
   } as TeamCredentials;
 
-  const teamName = 'Create Board Tests';
-  const teamId = 'create-board-tests';
-  const password = 'Test1234';
-
   describe('navigation', () => {
     it('should be able to navigate to /create', () => {
       cy.visit('/create');
-      cy.url().should('eq', 'http://localhost:4200/create');
+      cy.url().should('eq', Cypress.config().baseUrl + '/create');
     });
 
     it('should be able to navigate to /login from link', () => {
       cy.visit('/create');
       cy.get('#loginBoard').click();
-      cy.url().should('eq', 'http://localhost:4200/login');
+      cy.url().should('eq', Cypress.config().baseUrl + '/login');
     });
   });
 

--- a/ui/cypress/integration/login.e2e.spec.ts
+++ b/ui/cypress/integration/login.e2e.spec.ts
@@ -23,8 +23,8 @@ import {
 
 describe('Logging In', () => {
   const teamCredentials = {
-    teamName: 'Login Tests',
-    teamId: 'login-tests',
+    teamName: 'Test Login',
+    teamId: 'test-login',
     password: 'Login1234',
     jwt: '',
   } as TeamCredentials;
@@ -38,6 +38,9 @@ describe('Logging In', () => {
     cy.get('#teamNameInput').type(teamCredentials.teamName);
     cy.get('#teamPasswordInput').type(teamCredentials.password);
     cy.get('#signInButton').click();
-    cy.url().should('eq', teamBoardUrl(teamCredentials.teamId));
+    cy.url().should(
+      'eq',
+      Cypress.config().baseUrl + teamBoardUrl(teamCredentials.teamId)
+    );
   });
 });

--- a/ui/cypress/util/utils.ts
+++ b/ui/cypress/util/utils.ts
@@ -24,7 +24,7 @@ export interface TeamCredentials {
 
 export function teamBoardUrl(teamId: string): string {
   console.log(`**** ${teamId} *****`);
-  return `http://localhost:4200/team/${teamId}`;
+  return `/team/${teamId}`;
 }
 
 export function goToTeamBoard(teamCredentials: TeamCredentials) {
@@ -62,7 +62,7 @@ export function createTeamIfNecessaryAndLogin(
   teamCredentials: TeamCredentials
 ) {
   cy.request({
-    url: `http://localhost:4200/api/team/login`,
+    url: `/api/team/login`,
     failOnStatusCode: false,
     method: 'POST',
     body: {

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,7 @@
     "lint-fix": "ng lint --fix",
     "postinstall": "ngcc",
     "prepare": "cd .. && husky install ui/.husky",
-    "cypress": "cypress run --headless --browser chrome",
+    "cypress": "cypress run --headless",
     "cypress-supervise": "cypress open"
   },
   "private": true,


### PR DESCRIPTION
## Overview
Currently the Cypress tests expect to only ever run against http://localhost:4200 (the Angular dev server). This pull request allows the Cypress tests to be run against any URL, by overriding Cypress's `baseUrl` property (for example, by setting the `CYPRESS_BASE_URL` environment variable). 

We also fixed a bug in the API where the frontend application was being correctly served by the API, but with a 404 status code. This did not seem to impact the production instance of RetroQuest at all, but did cause failures when running Cypress tests against the frontend when served by the API. 

## Testing Instructions
- Run the Cypress tests locally the same way we have done before and ensure they still pass
- Run the Cypress tests against an alternate target (for example, http://localhost:8080 served by the API+bundled frontend)