### PR TITLE
Rename End Retro to Archive Retro

### DIFF
--- a/ui/src/app/modules/components/end-retro-dialog/end-retro-dialog.component.html
+++ b/ui/src/app/modules/components/end-retro-dialog/end-retro-dialog.component.html
@@ -29,7 +29,7 @@
                 'dark-theme': darkThemeIsEnabled
             }"
         >
-            Do you want to end the retro?
+            Do you want to end the retro for everybody?
         </div>
         <div
             class="sub-heading"
@@ -37,7 +37,7 @@
                 'dark-theme': darkThemeIsEnabled
             }"
         >
-            This will archive all thoughts!
+            This will permanently archive all thoughts!
         </div>
     </div>
 

--- a/ui/src/app/modules/teams/components/header/header.component.html
+++ b/ui/src/app/modules/teams/components/header/header.component.html
@@ -50,7 +50,7 @@
                     hide: actionsRadiatorViewEnabled
                 }"
                 [theme]="theme"
-                text="end retro"
+                text="archive retro"
                 type="primary"
             >
             </rq-button>


### PR DESCRIPTION
## Overview
This PR will change the "End Retro" text on the end retro button to "Archive Retro". We also change some of the wording on the confirmation prompt. 

### Demo

<img width="524" alt="Screen Shot 2021-09-17 at 1 40 05 PM" src="https://user-images.githubusercontent.com/22086580/133831009-d3a0d9ff-6f0b-47f0-88d8-4a69dbd3009c.png">
<img width="586" alt="Screen Shot 2021-09-17 at 1 39 59 PM" src="https://user-images.githubusercontent.com/22086580/133831011-abbe210a-9670-4b3e-95a2-6ff10e5ffcb9.png">

### Notes
This change is being made because of confusion from users about the purpose of the end retro button. Individual users click the button when completing a retro, causing the facilitator to lose their thoughts into the archive. There may be separate effort necessary to improve the discoverability of archived retros. 

## Testing Instructions
- Run the app
- Ensure the text is changed as expected
- Ensure no functionality related to ending the retro is broken