### PR TITLE
Add metric for teams that have had a login in the past three months

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/Metrics.java
@@ -23,6 +23,7 @@ import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
 
 import java.time.LocalDate;
+import java.time.Period;
 
 @ManagedResource
 public class Metrics {
@@ -79,11 +80,11 @@ public class Metrics {
             );
     }
 
-    public int getTeamLogins() {
-        return getTeamLogins(null, null);
+    public int getActiveTeams() {
+        return getActiveTeams(LocalDate.now().minus(Period.ofMonths(3)), LocalDate.now());
     }
 
-    public int getTeamLogins(LocalDate startDate, LocalDate endDate) {
+    public int getActiveTeams(LocalDate startDate, LocalDate endDate) {
         var dateRange = DateTimeRange.fromStartAndEnd(startDate, endDate);
 
         return (int) teamRepository.countByLastLoginDateBetween(

--- a/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsConfiguration.java
+++ b/api/src/main/java/com/ford/labs/retroquest/metrics/MetricsConfiguration.java
@@ -46,5 +46,9 @@ public class MetricsConfiguration {
         Gauge.builder("retroquest.feedback.averageRating", this.metrics, Metrics::getAverageRating)
             .strongReference(true)
             .register(this.meterRegistry);
+
+        Gauge.builder("retroquest.teams.activeTeams.count", this.metrics, Metrics::getActiveTeams)
+            .strongReference(true)
+            .register(this.meterRegistry);
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/MetricsIntegrationTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/MetricsIntegrationTest.java
@@ -1,0 +1,34 @@
+package com.ford.labs.retroquest.deprecated_tests;
+
+import com.ford.labs.retroquest.metrics.Metrics;
+import com.ford.labs.retroquest.team.Team;
+import com.ford.labs.retroquest.team.TeamRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class MetricsIntegrationTest {
+
+    @Autowired
+    TeamRepository teamRepository;
+    @Autowired
+    Metrics metrics;
+
+    @Test
+    void getTeamLogins_whenGivenBothAStartAndEndDate_passesDatesToRepository() {
+
+        var teamBuilder = new Team().toBuilder();
+
+        teamRepository.save(teamBuilder.lastLoginDate(LocalDate.now()).uri("something").build());
+        teamRepository.save(teamBuilder.lastLoginDate(LocalDate.now().minus(Period.ofMonths(4))).uri("somethingelse").build());
+
+        assertThat(metrics.getActiveTeams()).isEqualTo(1);
+
+    }
+}

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/MetricsTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/MetricsTest.java
@@ -111,7 +111,7 @@ class MetricsTest {
     @Test
     void getTeamLogins_whenCalledWithNoArguments_returnsTheTotalNumberOfTeamsCreated() {
         given(mockTeamRepository.countByLastLoginDateBetween(any(), any())).willReturn(2L);
-        assertEquals(2, metrics.getTeamLogins());
+        assertEquals(2, metrics.getActiveTeams());
     }
 
     @Test
@@ -121,7 +121,7 @@ class MetricsTest {
 
         given(mockTeamRepository.countByLastLoginDateBetween(any(), any())).willReturn(1L);
 
-        metrics.getTeamLogins(startDate, endDate);
+        metrics.getActiveTeams(startDate, endDate);
 
         then(mockTeamRepository).should()
             .countByLastLoginDateBetween(startDate, endDate);


### PR DESCRIPTION
## Overview
Adds an meter metric so we can better understand how many teams are actively using RetroQuest

### Notes
I wrote an integration test to validate the count of 'active' teams, and repurposed an unused (???) function that already existed in the Metrics class to retrieve the data.

