### PR TITLE
Make incrementing heart increment via database lock

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/thought/Thought.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/Thought.java
@@ -67,10 +67,6 @@ public class Thought {
         return Arrays.asList(columnTitle.getTitle(), message, String.valueOf(hearts), getDiscussedString());
     }
 
-    public void incrementHearts() {
-        hearts++;
-    }
-
     private String getDiscussedString() {
         return discussed ? "yes" : "no";
     }

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtRepository.java
@@ -18,11 +18,12 @@
 package com.ford.labs.retroquest.thought;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface ThoughtRepository extends JpaRepository<Thought, Long> {
@@ -32,10 +33,9 @@ public interface ThoughtRepository extends JpaRepository<Thought, Long> {
 
     List<Thought> findAllByTeamIdAndBoardIdIsNullOrderByTopic(String teamId);
 
-    void deleteAllByTeamId(String teamId);
-
     void deleteThoughtByTeamIdAndId(String teamId, Long id);
 
-    @Query("SELECT MAX(t.id) FROM Thought t Where t.teamId = :teamId")
-    Optional<Long> getMaxIdByTeamId(String teamId);
+    @Modifying
+    @Query("UPDATE Thought thought set thought.hearts = thought.hearts + 1 where thought.id = :thoughtId")
+    void incrementHeartCount(@Param("thoughtId") Long thoughtId);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
@@ -53,11 +53,10 @@ public class ThoughtService {
     }
 
     public Thought likeThought(Long thoughtId) {
+        thoughtRepository.incrementHeartCount(thoughtId);
         var thought = fetchThought(thoughtId);
-        thought.incrementHearts();
-        var savedThought = thoughtRepository.save(thought);
-        websocketService.publishEvent(new WebsocketThoughtEvent(savedThought.getTeamId(), UPDATE, savedThought));
-        return savedThought;
+        websocketService.publishEvent(new WebsocketThoughtEvent(thought.getTeamId(), UPDATE, thought));
+        return thought;
     }
 
     public Thought discussThought(Long thoughtId, boolean discussed) {

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
@@ -44,7 +44,7 @@ public class ThoughtService {
         this.websocketService = websocketService;
     }
 
-    public Thought fetchThought(Long thoughtId) {
+    public Thought fetchThought(Long thoughtId) throws ThoughtNotFoundException {
         return thoughtRepository.findById(thoughtId).orElseThrow(() -> new ThoughtNotFoundException(thoughtId));
     }
 


### PR DESCRIPTION
## Overview
Make incrementing the heart on a thought a lockable interaction. One of the cypress tests was failing because sometimes when clicking the star twice, one request would not complete before the next one was processed. This lead to two events being published with the same heart count.