### PR TITLE
Fix flaky API tests

### DIFF
--- a/api/src/test/java/com/ford/labs/retroquest/api/ColumnTitleApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ColumnTitleApiTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.Arrays;
@@ -85,8 +84,6 @@ class ColumnTitleApiTest extends ApiTestBase {
 
     @Test
     void should_update_column_title() throws Exception {
-        StompSession session = getAuthorizedSession();
-        subscribe(session, BASE_SUB_URL);
         var savedColumnTitle = columnTitleRepository.save(ColumnTitle.builder()
                 .teamId("BeachBums")
                 .title("old title")
@@ -101,10 +98,7 @@ class ColumnTitleApiTest extends ApiTestBase {
                 .header("Authorization", getBearerAuthToken()))
                 .andExpect(status().isOk());
 
-        var emittedEvent = takeObjectInSocket(ColumnTitle.class);
-
         assertThat(columnTitleRepository.findAll()).containsExactly(expectedColumnTitle);
-        assertThat(emittedEvent).usingRecursiveComparison().isEqualTo(expectedColumnTitle);
     }
 
     @Test

--- a/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
@@ -75,9 +75,6 @@ public abstract class ApiTestBase {
     @Value("${local.server.port}")
     private int port;
 
-    @Value("${jwt.signing.secret}")
-    private String jwtSigningSecret;
-
     private String bearerAuthToken;
 
     public String teamId;
@@ -117,7 +114,7 @@ public abstract class ApiTestBase {
                 .connect(websocketUrl, new WebSocketHttpHeaders() {
                 }, headers, new StompSessionHandlerAdapter() {
                 })
-                .get(1, SECONDS);
+                .get(10, SECONDS);
     }
 
     private class DefaultStompFrameHandler implements StompFrameHandler {
@@ -133,7 +130,7 @@ public abstract class ApiTestBase {
     }
 
     public <T> T takeObjectInSocket(Class<T> clazz) throws InterruptedException, IOException {
-        String obj = blockingQueue.poll(30, SECONDS);
+        String obj = blockingQueue.poll(10, SECONDS);
         try {
             return objectMapper.treeToValue(objectMapper.readValue(obj, ObjectNode.class).get("payload"), clazz);
         } catch (NullPointerException | IllegalArgumentException exp) {

--- a/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
@@ -153,7 +153,7 @@ public abstract class ApiTestBase {
     }
 
     public <T> T takeObjectInSocket(Class<T> clazz) throws InterruptedException, IOException {
-        String obj = blockingQueue.poll(10, SECONDS);
+        String obj = blockingQueue.poll(30, SECONDS);
         try {
             return objectMapper.treeToValue(objectMapper.readValue(obj, ObjectNode.class).get("payload"), clazz);
         } catch (NullPointerException | IllegalArgumentException exp) {

--- a/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
@@ -18,11 +18,8 @@
 package com.ford.labs.retroquest.api.setup;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.ford.labs.retroquest.contributors.ContributorController;
 import com.ford.labs.retroquest.security.JwtBuilder;
-import com.ford.labs.retroquest.websocket.WebsocketService;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
@@ -31,34 +28,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.messaging.simp.stomp.StompFrameHandler;
-import org.springframework.messaging.simp.stomp.StompHeaders;
-import org.springframework.messaging.simp.stomp.StompSession;
-import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.socket.WebSocketHttpHeaders;
-import org.springframework.web.socket.client.standard.StandardWebSocketClient;
-import org.springframework.web.socket.messaging.WebSocketStompClient;
-import org.springframework.web.socket.sockjs.client.SockJsClient;
-import org.springframework.web.socket.sockjs.client.WebSocketTransport;
-
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.Collections;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.LinkedBlockingDeque;
-
-import static org.mockito.Mockito.clearInvocations;
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Disabled
 @Tag("api")
 public abstract class ApiTestBase {
-
-    public static final int EMPTY_QUEUE_SIZE = 0;
 
     @Autowired
     public ObjectMapper objectMapper;
@@ -72,9 +48,6 @@ public abstract class ApiTestBase {
     @MockBean
     public ContributorController contributorController;
 
-    @SpyBean
-    public WebsocketService mockWebsocketService;
-
     @Value("${local.server.port}")
     private int port;
 
@@ -84,71 +57,14 @@ public abstract class ApiTestBase {
 
     public String websocketUrl;
 
-    private WebSocketStompClient stompClient;
-    private BlockingQueue<String> blockingQueue;
-    private int frameCount;
-
     @BeforeEach
     public void __setup() {
         teamId = "BeachBums";
         websocketUrl = "ws://localhost:" + port + "/websocket";
         bearerAuthToken = "Bearer " + jwtBuilder.buildJwt(teamId);
-
-        blockingQueue = new LinkedBlockingDeque<>();
-        frameCount = EMPTY_QUEUE_SIZE;
-        clearInvocations(mockWebsocketService);
-
-        stompClient = new WebSocketStompClient(new SockJsClient(
-                Collections.singletonList(new WebSocketTransport(new StandardWebSocketClient()))));
-    }
-
-    @AfterEach
-    public void __cleanup() {
-        blockingQueue.clear();
     }
 
     public String getBearerAuthToken() {
         return bearerAuthToken;
     }
-
-    public StompSession getAuthorizedSession() throws InterruptedException, ExecutionException {
-
-        StompHeaders headers = new StompHeaders();
-        headers.add("Authorization", bearerAuthToken);
-
-        return stompClient
-                .connect(
-                        websocketUrl,
-                        new WebSocketHttpHeaders() {},
-                        headers,
-                        new StompSessionHandlerAdapter() {}
-                ).get();
-    }
-
-    private class DefaultStompFrameHandler implements StompFrameHandler {
-        @Override
-        public Type getPayloadType(StompHeaders stompHeaders) {
-            return byte[].class;
-        }
-
-        @Override
-        public void handleFrame(StompHeaders stompHeaders, Object object) {
-            blockingQueue.add(new String((byte[]) object));
-            frameCount += 1;
-        }
-    }
-
-    public <T> T takeObjectInSocket(Class<T> clazz) throws InterruptedException, IOException {
-        String obj = blockingQueue.take();
-        try {
-            return objectMapper.treeToValue(objectMapper.readValue(obj, ObjectNode.class).get("payload"), clazz);
-        } catch (NullPointerException | IllegalArgumentException exp) {
-            return null;
-        }
-    }
-
-    public void subscribe(StompSession session, String url) {
-        session.subscribe(url, new DefaultStompFrameHandler());
-    }
-
 }

--- a/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -50,12 +49,8 @@ import java.util.Collections;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.TimeoutException;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
-import static org.mockito.Mockito.verify;
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -144,11 +139,7 @@ public abstract class ApiTestBase {
     }
 
     public <T> T takeObjectInSocket(Class<T> clazz) throws InterruptedException, IOException {
-        verify(mockWebsocketService).publishEvent(any());
-        assertThat(frameCount).isGreaterThan(EMPTY_QUEUE_SIZE);
-        assertThat(blockingQueue.peek()).isNotNull();
         String obj = blockingQueue.take();
-        frameCount -= 1;
         try {
             return objectMapper.treeToValue(objectMapper.readValue(obj, ObjectNode.class).get("payload"), clazz);
         } catch (NullPointerException | IllegalArgumentException exp) {

--- a/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
@@ -108,30 +108,10 @@ public abstract class ApiTestBase {
         return bearerAuthToken;
     }
 
-    public Claims decodeJWT(String jwt) {
-        //This line will throw an exception if it is not a signed JWS (as expected)
-        return Jwts.parser()
-                .setSigningKey(TextCodec.BASE64.encode(jwtSigningSecret))
-                .parseClaimsJws(jwt)
-                .getBody();
-    }
-
     public StompSession getAuthorizedSession() throws InterruptedException, ExecutionException, TimeoutException {
 
         StompHeaders headers = new StompHeaders();
         headers.add("Authorization", bearerAuthToken);
-
-        return stompClient
-                .connect(websocketUrl, new WebSocketHttpHeaders() {
-                }, headers, new StompSessionHandlerAdapter() {
-                })
-                .get(1, SECONDS);
-    }
-
-    public StompSession getUnauthorizedSession() throws InterruptedException, ExecutionException, TimeoutException {
-
-        StompHeaders headers = new StompHeaders();
-        headers.add("Authorization", "Bearer " + jwtBuilder.buildJwt("unauth-team"));
 
         return stompClient
                 .connect(websocketUrl, new WebSocketHttpHeaders() {
@@ -148,7 +128,7 @@ public abstract class ApiTestBase {
 
         @Override
         public void handleFrame(StompHeaders stompHeaders, Object object) {
-            blockingQueue.offer(new String((byte[]) object));
+            blockingQueue.add(new String((byte[]) object));
         }
     }
 

--- a/api/src/test/java/com/ford/labs/retroquest/columntitle/ColumnTitleServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/columntitle/ColumnTitleServiceTest.java
@@ -1,46 +1,39 @@
 package com.ford.labs.retroquest.columntitle;
 
 import com.ford.labs.retroquest.exception.ColumnTitleNotFoundException;
+import com.ford.labs.retroquest.websocket.WebsocketColumnTitleEvent;
+import com.ford.labs.retroquest.websocket.WebsocketEventType;
+import com.ford.labs.retroquest.websocket.WebsocketService;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
-@SpringBootTest
 class ColumnTitleServiceTest {
-
-    @Autowired
-    ColumnTitleRepository columnTitleRepository;
-
-    @Autowired
-    MeterRegistry meterRegistry;
-
-    @Autowired
-    ColumnTitleService columnTitleService;
-
-    @BeforeEach
-    void beforeEach() {
-        columnTitleRepository.deleteAll();
-    }
-
-    @AfterEach
-    void afterEach() {
-        columnTitleRepository.deleteAll();
-    }
-
     private final ColumnTitle.ColumnTitleBuilder columnTitleBuilder = ColumnTitle.builder();
+
+    private final ColumnTitleRepository columnTitleRepository = mock(ColumnTitleRepository.class);
+    private final MeterRegistry meterRegistry = mock(MeterRegistry.class);
+    private final WebsocketService websocketService = mock(WebsocketService.class);
+    private final ColumnTitleService columnTitleService = new ColumnTitleService(columnTitleRepository, meterRegistry, websocketService);
+
 
     @Test
     void given_teamid_get_column_titles() {
         String teamId = "some team id";
         String teamId2 = "some other team id";
-        var columnTitle1 = columnTitleRepository.save(columnTitleBuilder.topic("happy").title("Some Title").teamId(teamId).build());
-        var columnTitle2 = columnTitleRepository.save(columnTitleBuilder.topic("meh").title("Some Other Title").teamId(teamId).build());
-        var columnTitle3 = columnTitleRepository.save(columnTitleBuilder.topic("happy").title("Some Title").teamId(teamId2).build());
+
+        var columnTitle1 = columnTitleBuilder.topic("happy").title("Some Title").teamId(teamId).build();
+        var columnTitle2 = columnTitleBuilder.topic("meh").title("Some Other Title").teamId(teamId).build();
+        var columnTitle3 = columnTitleBuilder.topic("happy").title("Some Title").teamId(teamId2).build();
+        when(columnTitleRepository.findAllByTeamId(teamId)).thenReturn(List.of(columnTitle1, columnTitle2));
+        when(columnTitleRepository.findAllByTeamId(teamId2)).thenReturn(List.of(columnTitle3));
 
         assertThat(columnTitleService.getColumnTitlesByTeamId(teamId)).containsExactlyInAnyOrder(columnTitle1, columnTitle2);
         assertThat(columnTitleService.getColumnTitlesByTeamId(teamId2)).containsExactlyInAnyOrder(columnTitle3);
@@ -48,23 +41,32 @@ class ColumnTitleServiceTest {
 
     @Test
     void given_column_id_and_column_title_rename_column_in_db_and_return_new_column_title() {
-        String teamId = "some team ID";
-        var columnTitle = columnTitleRepository.save(columnTitleBuilder.topic("happy").title("Some Title").teamId(teamId).build());
+        var teamId = "some team ID";
+        var newColumnName = "Some new Title";
+        var columnId = 42L;
+        var savedColumn = columnTitleBuilder.id(columnId).topic("happy").title("Some Title").teamId(teamId).build();
+        var expectedColumn = columnTitleBuilder.id(columnId).topic("happy").title("Some new Title").teamId(teamId).build();
+        var expectedEvent = new WebsocketColumnTitleEvent(teamId, WebsocketEventType.UPDATE, expectedColumn);
+        var mockedCounter = mock(Counter.class);
 
-        String newColumnName = "Some new Title";
-        var savedColumnTitle = columnTitleService.editColumnTitleName(columnTitle.getId(), newColumnName, teamId );
+        when(columnTitleRepository.findById(columnId)).thenReturn(Optional.of(savedColumn));
+        when(columnTitleRepository.save(expectedColumn)).thenReturn(expectedColumn);
+        when(meterRegistry.counter("retroquest.columns.changed.count")).thenReturn(mockedCounter);
 
-        assertThat(meterRegistry.get("retroquest.columns.changed.count").counter().count()).isEqualTo(1);
-        assertThat(savedColumnTitle.getTitle()).isEqualTo(newColumnName);
-        assertThat(savedColumnTitle.getId()).isEqualTo(columnTitle.getId());
+        var savedColumnTitle = columnTitleService.editColumnTitleName(columnId, newColumnName, teamId );
+
+        assertThat(savedColumnTitle).usingRecursiveComparison().isEqualTo(expectedColumn);
+        verify(mockedCounter, times(1)).increment();
+        verify(websocketService).publishEvent(expectedEvent);
     }
 
     @Test
     void throws_column_title_not_found_exception_when_column_title_not_in_db() {
-        try {
-            columnTitleService.editColumnTitleName(42L, "some name", "some team id");
-        } catch (RuntimeException exception) {
-            assertThat(exception).isInstanceOf(ColumnTitleNotFoundException.class);
-        }
+        var columnId = 42L;
+        when(columnTitleRepository.findById(columnId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                columnTitleService.editColumnTitleName(columnId, "some name", "some team id")
+        ).isInstanceOf(ColumnTitleNotFoundException.class);
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/websocket/WebsocketServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/websocket/WebsocketServiceTest.java
@@ -1,6 +1,5 @@
 package com.ford.labs.retroquest.websocket;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -15,7 +14,7 @@ class WebsocketServiceTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Test
-    public void publishEvent_WithWebsocketEvent_ShouldConvertAndSendToCorrectRoute() throws JsonProcessingException {
+    public void publishEvent_WithWebsocketEvent_ShouldConvertAndSendToCorrectRoute() {
         var service = new WebsocketService(mockMessageTemplate, mapper);
         service.publishEvent(new FakeEvent(WebsocketEventType.DELETE, "Thing to Delete"));
         verify(mockMessageTemplate).convertAndSend(eq("send/to/route"), eq("{\"type\":\"delete\",\"payload\":\"Thing to Delete\"}"));


### PR DESCRIPTION
## Overview
Some API tests will still occasionally fail. I think it has something to do with the `blockingQueue.poll()` call taking too long and returning null. Will try to make tests more reliable.

This will be squashed and merged.