### PR TITLE
Change ui port back to React default (3000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ npm run start
 ```
 
 This will start the frontend with a proxy to direct all requests to localhost:8080 where the api is running. The
-application will start at [localhost:4200](http://localhost:4200)
+application will start at [localhost:3000](http://localhost:3000)
 
 ## Tests
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -13,7 +13,7 @@ the commands are very similar using [Yarn Package Manager](https://yarnpkg.com/)
 npm run start
 ```
 
-This command will start the server. Navigate to http://localhost:4200/ to begin interacting on your desktop with the
+This command will start the server. Navigate to http://localhost:3000/ to begin interacting on your desktop with the
 app. The app will automatically reload if you change any of the source files.
 
 ### Testing Strategy

--- a/ui/cypress.json
+++ b/ui/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:4200",
+  "baseUrl": "http://localhost:3000",
   "integrationFolder": "cypress/e2e",
   "downloadsFolder": "cypress/downloads",
   "chromeWebSecurity": false

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "update-version": "node getApplicationVersion.js",
-    "start": "PORT=4200 react-scripts start",
+    "start": "react-scripts start",
     "build": "BUILD_PATH='../api/src/main/resources/static' react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
## Overview
Changes the frontend port back to the React default, which is port 3000. It doesn't have to be 4200 for any particular reason.