### PR TITLE
Make the feedback stars on the feedback form accessible

### DIFF
--- a/ui/cypress/e2e/retro-member-journey.spec.ts
+++ b/ui/cypress/e2e/retro-member-journey.spec.ts
@@ -121,7 +121,7 @@ describe('Retro Member Journey', () => {
 
 		cy.findByText('Give Feedback').as('giveFeedbackButton').click();
 
-		cy.get('[data-testid=feedbackDialog]')
+		cy.get('[data-testid=feedbackForm]')
 			.as('modal')
 			.should('contain', modalText);
 
@@ -134,7 +134,7 @@ describe('Retro Member Journey', () => {
 		cy.get('@giveFeedbackButton').click();
 		ensureModalIsOpen();
 
-		cy.get('@modal').find('[data-testid=feedback-star-5]').click();
+		cy.get('@modal').find('[data-testid=feedback-star-5-label]').click();
 		cy.get('@modal').findByLabelText('Comments*').type('Doing great!');
 		cy.get('@modal').findByLabelText('Feedback Email').focus().type('a@b.c');
 

--- a/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackForm.spec.tsx
+++ b/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackForm.spec.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Ford Motor Company
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
 import { RecoilRoot } from 'recoil';
 
 import FeedbackService from '../../../../../Services/Api/FeedbackService';
@@ -33,7 +34,7 @@ import FeedbackForm from './FeedbackForm';
 
 jest.mock('../../../../../Services/Api/FeedbackService');
 
-describe('FeedbackForm', () => {
+describe('Feedback Form', () => {
 	const fakeComment = 'This is a fake comment';
 	const fakeEmail = 'user@ford.com';
 	const team: Team = {
@@ -41,13 +42,14 @@ describe('FeedbackForm', () => {
 		id: 'fake-team-id',
 	};
 	let modalContent: ModalContents | null;
+	let container: string | Element;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 
 		modalContent = null;
 
-		render(
+		({ container } = render(
 			<RecoilRoot
 				initializeState={({ set }) => {
 					set(TeamState, team);
@@ -65,11 +67,16 @@ describe('FeedbackForm', () => {
 				/>
 				<FeedbackForm />
 			</RecoilRoot>
-		);
+		));
+	});
+
+	it('should render without axe errors', async () => {
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
 	});
 
 	it('should submit feedback', async () => {
-		userEvent.click(screen.getByTestId('feedback-star-4'));
+		userEvent.click(screen.getByTestId('feedback-star-4-label'));
 		userEvent.type(screen.getByLabelText('Feedback Email'), fakeEmail);
 		userEvent.type(screen.getByLabelText('Comments*'), fakeComment);
 		userEvent.click(screen.getByText('Send!'));
@@ -85,7 +92,7 @@ describe('FeedbackForm', () => {
 	});
 
 	it('should not submit with empty comments', () => {
-		userEvent.click(screen.getByTestId('feedback-star-4'));
+		userEvent.click(screen.getByTestId('feedback-star-4-label'));
 		userEvent.type(screen.getByLabelText('Feedback Email'), fakeEmail);
 		userEvent.click(screen.getByText('Send!'));
 

--- a/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackForm.tsx
+++ b/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackForm.tsx
@@ -52,7 +52,7 @@ function FeedbackForm() {
 
 	return (
 		<FormTemplate
-			testId="feedbackDialog"
+			testId="feedbackForm"
 			className="feedback-form"
 			onSubmit={onSubmit}
 			onCancel={closeModal}
@@ -61,7 +61,7 @@ function FeedbackForm() {
 			cancelButtonText="Cancel"
 			submitButtonText="Send!"
 		>
-			<FeedbackStars className="section" value={stars} onChange={setStars} />
+			<FeedbackStars value={stars} onChange={setStars} />
 			<div className="section comments-section">
 				<label className="label" htmlFor="comments">
 					Comments<span className="required-field">*</span>

--- a/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackStars/FeedbackStars.scss
+++ b/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackStars/FeedbackStars.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Ford Motor Company
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,15 +18,56 @@
 @use '../../../../../../Styles/main';
 
 .feedback-stars {
-	color: main.$blue;
-	font-size: 3.3rem;
+	margin: -1rem 0;
+
+	font-weight: 400;
+	font-size: 2.8rem;
 	text-align: center;
 
-	@media only screen and (max-width: 610px) {
-		font-size: 2.8rem;
+	border: 0;
+
+	@include main.breakpoint-medium {
+		font-size: 3.3rem;
 	}
 
-	.active {
-		color: main.$yellow;
+	.hidden {
+		display: none;
+	}
+
+	.feedback-star-input.with-font {
+		width: 1px;
+		height: 1px;
+		margin: -1px;
+		padding: 0;
+		overflow: hidden;
+
+		border: 0;
+
+		clip: rect(0 0 0 0);
+
+		position: absolute;
+
+		+ label::before {
+			display: inline-block;
+			width: 4rem;
+
+			color: main.$blue;
+			font-family: FontAwesome, serif;
+
+			cursor: pointer;
+
+			content: '\f006';
+		}
+
+		&.highlight + label::before,
+		&:checked + label::before {
+			color: main.$yellow;
+			content: '\f005';
+		}
+
+		&:focus + label::before {
+			color: main.$dark-yellow;
+			font-weight: bold;
+		}
 	}
 }

--- a/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackStars/FeedbackStars.tsx
+++ b/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackStars/FeedbackStars.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Ford Motor Company
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,54 +15,58 @@
  * limitations under the License.
  */
 
-import React, { useMemo, useState } from 'react';
-import classnames from 'classnames';
+import React, { Fragment, useState } from 'react';
+import classNames from 'classnames';
 
 import './FeedbackStars.scss';
-
-type StarState = boolean;
-
-type Stars = [StarState, StarState, StarState, StarState, StarState];
-
-const EMPTY_STARS: Stars = [false, false, false, false, false];
-
-function starsWith(count: number, newState: StarState): Stars {
-	return EMPTY_STARS.map((state, index) =>
-		index < count ? newState : state
-	) as Stars;
-}
 
 type FeedbackStarsProps = {
 	value: number;
 	onChange: (stars: number) => void;
-	className?: string;
 };
 
-export default function FeedbackStars(props: FeedbackStarsProps) {
-	const { value, onChange, className } = props;
-	const [hoverStars, setHoverStars] = useState<Stars>(EMPTY_STARS);
-
-	const activeStars = useMemo(() => {
-		return hoverStars.map((star, index) => (value ? index < value : star));
-	}, [hoverStars, value]);
+function FeedbackStars(props: FeedbackStarsProps) {
+	const { value, onChange } = props;
+	const [hoveredStarValue, setHoveredStarValue] = useState<number>(-1);
 
 	return (
-		<div
-			className={classnames('feedback-stars', className)}
-			onMouseLeave={() => setHoverStars(starsWith(5, false))}
-		>
-			{activeStars.map((star, index) => {
-				const starIndex = index + 1;
-				return (
-					<button
-						key={starIndex}
-						data-testid={`feedback-star-${starIndex}`}
-						className={classnames('fa-star', star ? 'active fas' : 'far')}
-						onMouseEnter={() => setHoverStars(starsWith(starIndex, true))}
-						onClick={() => onChange(starIndex)}
-					/>
-				);
-			})}
-		</div>
+		<fieldset className={`feedback-stars`}>
+			<div role="group" aria-labelledby="rate-retroquest">
+				<p id="rate-retroquest" className="hidden">
+					How would you rate your experience with retroquest?
+				</p>
+				<div className="star-list">
+					{[1, 2, 3, 4, 5].map((starValue) => {
+						const starId = `feedback-star-${starValue}`;
+						const isHovering = starValue <= hoveredStarValue;
+						const isHighlight = starValue <= value;
+						return (
+							<Fragment key={starId}>
+								<input
+									data-testid={`${starId}-input`}
+									id={starId}
+									type="radio"
+									name="feedback-star"
+									value={value}
+									className={classNames('feedback-star-input with-font', {
+										highlight: isHighlight || isHovering,
+									})}
+									onChange={() => onChange(starValue)}
+								/>
+								<label
+									htmlFor={starId}
+									data-testid={`${starId}-label`}
+									onMouseEnter={() => setHoveredStarValue(starValue)}
+									onMouseLeave={() => setHoveredStarValue(value)}
+									aria-label={`Feedback rating of ${starValue}`}
+								/>
+							</Fragment>
+						);
+					})}
+				</div>
+			</div>
+		</fieldset>
 	);
 }
+
+export default FeedbackStars;

--- a/ui/src/Common/Modal/Modal.spec.tsx
+++ b/ui/src/Common/Modal/Modal.spec.tsx
@@ -17,6 +17,7 @@
 
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import { axe } from 'jest-axe';
 import { RecoilRoot } from 'recoil';
 
 import {
@@ -27,7 +28,7 @@ import { RecoilObserver } from '../../Utils/RecoilObserver';
 
 import Modal from './Modal';
 
-describe('ModalContentsWrapper', () => {
+describe('Modal', () => {
 	let modalContent: ModalContents | null;
 
 	beforeEach(() => {
@@ -35,7 +36,7 @@ describe('ModalContentsWrapper', () => {
 	});
 
 	const setupComponentWithModalContents = () => {
-		render(
+		return render(
 			<RecoilRoot
 				initializeState={({ set }) => {
 					set(ModalContentsState, {
@@ -54,6 +55,12 @@ describe('ModalContentsWrapper', () => {
 			</RecoilRoot>
 		);
 	};
+
+	it('should render without axe errors', async () => {
+		const { container } = setupComponentWithModalContents();
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
 
 	it('should show modal when modal contents exist', () => {
 		setupComponentWithModalContents();


### PR DESCRIPTION
## Overview
Updated the feedback modal's star rating component to be accessible and use radio inputs instead of buttons. Functionality should be the same.

Connects N/A

## Testing Instructions
1) Check out the Feedback modal and ensure you can submit the form with the expected star rating
2) Tab through the feedback modal and ensure you can select your star rating using the keyboard (tab to the stars and then use the left and right arrows to select your rating, then tab away). Submit and ensure the correct star rating was submitted.
3) Use a screen reader and ensure that "How would you rate your experience with retroquest?" is announced when you get to the star rating field, and then when selecting, "Feedback rating of ___" is announced when using the arrow keys to select your star rating.