### PR TITLE
Remove in app form validation on login page

### DIFF
--- a/ui/src/App/Login/LoginPage.spec.tsx
+++ b/ui/src/App/Login/LoginPage.spec.tsx
@@ -116,32 +116,6 @@ describe('LoginPage.spec.tsx', () => {
 	});
 
 	describe('Form errors', () => {
-		it('should show validation message when team name is not valid', async () => {
-			expect(screen.queryByTestId('inputValidationMessage')).toBeNull();
-
-			typeIntoPasswordInput(validPassword);
-
-			const invalidTeamName = '&%(#';
-			typeIntoTeamNameInput(invalidTeamName);
-
-			fireEvent.submit(getTeamNameInput());
-
-			expect(screen.getByTestId('inputValidationMessage')).toBeDefined();
-		});
-
-		it('should show validation message when password is not valid', async () => {
-			expect(screen.queryByTestId('inputValidationMessage')).toBeNull();
-
-			typeIntoTeamNameInput(validTeamName);
-
-			const invalidPassword = 'MissingANumber';
-			typeIntoPasswordInput(invalidPassword);
-
-			fireEvent.submit(getPasswordInput());
-
-			expect(screen.getByTestId('inputValidationMessage')).toBeDefined();
-		});
-
 		it('should show error if login was unsuccessful', async () => {
 			TeamService.login = jest.fn().mockRejectedValue(new Error('Async error'));
 

--- a/ui/src/App/Login/LoginPage.tsx
+++ b/ui/src/App/Login/LoginPage.tsx
@@ -25,7 +25,6 @@ import useAuth from '../../Hooks/useAuth';
 import useTeamFromRoute from '../../Hooks/useTeamFromRoute';
 import { CREATE_TEAM_PAGE_PATH } from '../../RouteConstants';
 import TeamService from '../../Services/Api/TeamService';
-import { validatePassword, validateTeamName } from '../../Utils/StringUtils';
 
 function LoginPage(): JSX.Element {
 	const { login } = useAuth();
@@ -34,24 +33,14 @@ function LoginPage(): JSX.Element {
 	const [teamName, setTeamName] = useState<string>('');
 	const [password, setPassword] = useState<string>('');
 
-	const [isValidated, setIsValidated] = useState<boolean>(false);
 	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const [errorMessages, setErrorMessages] = useState<string[]>([]);
 
 	useEffect(() => setTeamName(team.name), [team.name]);
 
-	const teamNameErrorMessage = validateTeamName(teamName);
-	const passwordErrorMessage = validatePassword(password);
-
-	const captureErrors = () => {
-		const errors = [];
-		if (teamNameErrorMessage) errors.push(teamNameErrorMessage);
-		if (passwordErrorMessage) errors.push(passwordErrorMessage);
-		setErrorMessages(errors);
-	};
-
-	const loginTeam = () => {
+	function onLoginFormSubmit() {
 		setIsLoading(true);
+
 		TeamService.login(teamName, password)
 			.then(login)
 			.catch(() => {
@@ -60,17 +49,6 @@ function LoginPage(): JSX.Element {
 				]);
 			})
 			.finally(() => setIsLoading(false));
-	};
-
-	function onLoginFormSubmit() {
-		setIsValidated(true);
-		setErrorMessages([]);
-
-		if (teamNameErrorMessage || passwordErrorMessage) {
-			captureErrors();
-		} else {
-			loginTeam();
-		}
 	}
 
 	return (
@@ -90,7 +68,6 @@ function LoginPage(): JSX.Element {
 						setTeamName(updatedTeamName);
 						setErrorMessages([]);
 					}}
-					invalid={isValidated && !!teamNameErrorMessage}
 					readOnly={isLoading}
 				/>
 				<InputPassword
@@ -99,7 +76,6 @@ function LoginPage(): JSX.Element {
 						setPassword(updatedPassword);
 						setErrorMessages([]);
 					}}
-					invalid={isValidated && !!passwordErrorMessage}
 					readOnly={isLoading}
 				/>
 			</Form>


### PR DESCRIPTION
## Overview
Remove in app form validation on login page. This is needed because there are some teams that have passwords that were created before we implemented password requirements. Those teams are now not allowed to log in. This allows them to login as they did before. (reseting of passwords should be considered for a future feature)

## Testing Instructions
1) Go to the login page and try to login with a team and password that doesn't exist and a password that does not have a number in it.
2) Ensure you can submit the form and a warning is shown saying, "Incorrect team name or password. Please try again.". There should be no warnings about not having the correct password format.