### PR TITLE
Replace ColumnTitle With Column ID on Thought

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/board/Retro.java
+++ b/api/src/main/java/com/ford/labs/retroquest/board/Retro.java
@@ -22,7 +22,6 @@ import com.ford.labs.retroquest.thought.Thought;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record Retro(
     Long id,
@@ -31,19 +30,13 @@ public record Retro(
     List<Thought> thoughts,
     List<Column> columns
 ) {
-    public static Retro fromBoard(Board board) {
-        var calculatedColumns = board.getThoughts().stream()
-            .map(Thought::getColumnTitle)
-            .distinct()
-            .map(Column::fromColumnTitle)
-            .sorted()
-            .collect(Collectors.toList());
+    public static Retro from(Board board, List<Column> columns) {
         return new Retro(
             board.getId(),
             board.getTeamId(),
             board.getDateCreated(),
             board.getThoughts(),
-            calculatedColumns
+            columns.stream().sorted().toList()
         );
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/CsvFile.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/CsvFile.java
@@ -18,6 +18,7 @@
 package com.ford.labs.retroquest.team;
 
 import com.ford.labs.retroquest.actionitem.ActionItem;
+import com.ford.labs.retroquest.column.Column;
 import com.ford.labs.retroquest.thought.Thought;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -31,7 +32,9 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Data
 @AllArgsConstructor
@@ -41,6 +44,7 @@ public class CsvFile {
     private String teamName;
     private List<Thought> thoughts;
     private List<ActionItem> actionItems;
+    private List<Column> columns;
 
     public String getFileName() {
         var today = LocalDate.now();
@@ -51,10 +55,10 @@ public class CsvFile {
         var out = new ByteArrayOutputStream();
         var writer = new BufferedWriter(new OutputStreamWriter(out));
 
-        var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT
-                .withHeader("Column", "Message", "Likes", "Completed", "Assigned To"));
+        var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.withHeader("Column", "Message", "Likes", "Completed", "Assigned To"));
+        Map<Long, String> columnNameMap = columns.stream().collect(Collectors.toMap(Column::getId, Column::getTitle));
         for (var thought : thoughts) {
-            csvPrinter.printRecord(getFieldsFrom(thought));
+            csvPrinter.printRecord(getFieldsFrom(thought, columnNameMap));
         }
 
         for (var actionItem : actionItems) {
@@ -65,9 +69,9 @@ public class CsvFile {
         return out.toString();
     }
 
-    private List<String> getFieldsFrom(Thought thought) {
+    private List<String> getFieldsFrom(Thought thought, Map<Long, String> columnNameMap) {
         return List.of(
-                thought.getColumnTitle().getTitle(),
+                columnNameMap.get(thought.getColumnId()),
                 thought.getMessage(),
                 String.valueOf(thought.getHearts()),
                 getBooleanString(thought.isDiscussed())

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamService.java
@@ -18,6 +18,7 @@
 package com.ford.labs.retroquest.team;
 
 import com.ford.labs.retroquest.actionitem.ActionItemRepository;
+import com.ford.labs.retroquest.column.Column;
 import com.ford.labs.retroquest.column.ColumnTitle;
 import com.ford.labs.retroquest.column.ColumnTitleRepository;
 import com.ford.labs.retroquest.exception.BoardDoesNotExistException;
@@ -28,6 +29,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.stream.Collectors;
 
 @Service
 public class TeamService {
@@ -68,7 +70,8 @@ public class TeamService {
     public CsvFile buildCsvFileFromTeam(String team) {
         var thoughts = thoughtRepository.findAllByTeamIdAndBoardIdIsNullOrderByTopic(team);
         var actionItems = actionItemRepository.findAllByTeamIdAndArchived(team, false);
-        return new CsvFile(team, thoughts, actionItems);
+        var columns = columnTitleRepository.findAllByTeamId(team).stream().map(Column::fromColumnTitle).collect(Collectors.toList());
+        return new CsvFile(team, thoughts, actionItems, columns);
     }
 
     public Team createNewTeam(CreateTeamRequest createTeamRequest) {

--- a/api/src/main/java/com/ford/labs/retroquest/thought/CreateThoughtRequest.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/CreateThoughtRequest.java
@@ -22,12 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record CreateThoughtRequest(
-    Long id,
     String message,
-    int hearts,
     String topic,
-    boolean discussed,
-    String teamId,
-    Long boardId,
     Long columnId
 ) { }

--- a/api/src/main/java/com/ford/labs/retroquest/thought/CreateThoughtRequest.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/CreateThoughtRequest.java
@@ -28,5 +28,6 @@ public record CreateThoughtRequest(
     String topic,
     boolean discussed,
     String teamId,
-    Long boardId
+    Long boardId,
+    Long columnId
 ) { }

--- a/api/src/main/java/com/ford/labs/retroquest/thought/Thought.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/Thought.java
@@ -19,11 +19,10 @@ package com.ford.labs.retroquest.thought;
 
 import com.ford.labs.retroquest.column.ColumnTitle;
 import lombok.*;
-import org.hibernate.Hibernate;
 
 import javax.persistence.*;
-import java.util.Objects;
 
+@Data
 @Getter
 @Setter
 @ToString
@@ -59,17 +58,5 @@ public class Thought {
     )
     private ColumnTitle columnTitle;
     private Long boardId;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
-        Thought thought = (Thought) o;
-        return id != null && Objects.equals(id, thought.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return getClass().hashCode();
-    }
+    private Long columnId;
 }

--- a/api/src/main/java/com/ford/labs/retroquest/thought/Thought.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/Thought.java
@@ -17,10 +17,12 @@
 
 package com.ford.labs.retroquest.thought;
 
-import com.ford.labs.retroquest.column.ColumnTitle;
 import lombok.*;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Data
 @Getter
@@ -43,20 +45,6 @@ public class Thought {
     private boolean discussed;
     private String teamId;
 
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(
-        name = "topic",
-        referencedColumnName = "topic",
-        insertable = false,
-        updatable = false
-    )
-    @JoinColumn(
-        name = "teamId",
-        referencedColumnName = "teamId",
-        insertable = false,
-        updatable = false
-    )
-    private ColumnTitle columnTitle;
     private Long boardId;
     private Long columnId;
 }

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
@@ -68,6 +68,7 @@ public class ThoughtService {
         var columnTitle = columnTitleRepository.findByTeamIdAndId(teamId, columnId).orElseThrow(ColumnTitleNotFoundException::new);
         var thought = fetchThought(teamId, thoughtId);
         thought.setTopic(columnTitle.getTopic());
+        thought.setColumnId(columnTitle.getId());
         var savedThought = thoughtRepository.save(thought);
         websocketService.publishEvent(new WebsocketThoughtEvent(savedThought.getTeamId(), UPDATE, savedThought));
         return savedThought;
@@ -104,6 +105,7 @@ public class ThoughtService {
 
         var columnTitle = columnTitleRepository.findByTeamIdAndTopic(teamId, thought.getTopic());
         thought.setColumnTitle(columnTitle);
+        thought.setColumnId(columnTitle.getId());
         return thoughtRepository.save(thought);
     }
 

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
@@ -89,11 +89,8 @@ public class ThoughtService {
 
     public Thought createThought(String teamId, CreateThoughtRequest request) {
         var thought = new Thought();
-        thought.setId(request.id());
         thought.setMessage(request.message());
-        thought.setHearts(request.hearts());
         thought.setTopic(request.topic());
-        thought.setDiscussed(request.discussed());
         thought.setColumnId(request.columnId());
         thought.setTeamId(teamId);
 

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
@@ -88,24 +88,18 @@ public class ThoughtService {
     }
 
     public Thought createThought(String teamId, CreateThoughtRequest request) {
-        Thought createdThought = createThought(teamId, null, request);
-        websocketService.publishEvent(new WebsocketThoughtEvent(teamId, UPDATE, createdThought));
-        return createdThought;
-    }
-
-    public Thought createThought(String teamId, Long boardId, CreateThoughtRequest request) {
         var thought = new Thought();
         thought.setId(request.id());
         thought.setMessage(request.message());
         thought.setHearts(request.hearts());
         thought.setTopic(request.topic());
         thought.setDiscussed(request.discussed());
+        thought.setColumnId(request.columnId());
         thought.setTeamId(teamId);
-        thought.setBoardId(boardId);
 
-        var columnTitle = columnTitleRepository.findByTeamIdAndTopic(teamId, thought.getTopic());
-        thought.setColumnId(columnTitle.getId());
-        return thoughtRepository.save(thought);
+        Thought createdThought = thoughtRepository.save(thought);
+        websocketService.publishEvent(new WebsocketThoughtEvent(teamId, UPDATE, createdThought));
+        return createdThought;
     }
 
     private Thought fetchThought(String teamId, Long thoughtId) throws ThoughtNotFoundException {

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
@@ -104,7 +104,6 @@ public class ThoughtService {
         thought.setBoardId(boardId);
 
         var columnTitle = columnTitleRepository.findByTeamIdAndTopic(teamId, thought.getTopic());
-        thought.setColumnTitle(columnTitle);
         thought.setColumnId(columnTitle.getId());
         return thoughtRepository.save(thought);
     }

--- a/api/src/main/resources/db/changelog.xml
+++ b/api/src/main/resources/db/changelog.xml
@@ -176,4 +176,14 @@
         </preConditions>
         <dropTable  cascadeConstraints="true" tableName="user"/>
     </changeSet>
+    <changeSet id="add-column-id-foreign-key-to-thought" author="nreuter">
+        <preConditions>
+            <tableExists tableName="thought" />
+        </preConditions>
+        <addColumn tableName="thought">
+            <column name="column_id" type="bigint">
+                <constraints foreignKeyName="fk_thought_column" references="column_title(id)" />
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog.xml
+++ b/api/src/main/resources/db/changelog.xml
@@ -196,4 +196,10 @@
             <where>column_id IS NULL</where>
         </update>
     </changeSet>
+    <changeSet id="make-column-id-not-null" author="nreuter">
+        <preConditions>
+            <columnExists tableName="thought" columnName="column_id" />
+        </preConditions>
+        <addNotNullConstraint tableName="thought" columnName="column_id" />
+    </changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog.xml
+++ b/api/src/main/resources/db/changelog.xml
@@ -186,4 +186,14 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet id="update-column-id-based-on-topic-and-team" author="nreuter">
+        <update tableName="thought">
+            <column name="column_id" valueComputed="(
+                SELECT column_title.id
+                from column_title
+                where column_title.topic = thought.topic and column_title.team_id = thought.team_id
+            )"/>
+            <where>column_id IS NULL</where>
+        </update>
+    </changeSet>
 </databaseChangeLog>

--- a/api/src/test/java/com/ford/labs/retroquest/api/BoardApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/BoardApiTest.java
@@ -113,8 +113,10 @@ class BoardApiTest extends ApiTestBase {
 
     @Test
     public void endRetro_ShouldSaveABoardWithThoughts() throws Exception {
-        Thought savedThought = thoughtService.createThought(teamId, new CreateThoughtRequest(null, "TEST_MESSAGE", 0,
-            "happy", false, teamId, null, columnTitle.getId()));
+        Thought savedThought = thoughtService.createThought(
+                teamId,
+                new CreateThoughtRequest("TEST_MESSAGE","happy", columnTitle.getId())
+        );
 
         mockMvc.perform(put(format("/api/team/%s/end-retro", teamId))
                 .header("Authorization", getBearerAuthToken()))
@@ -126,8 +128,10 @@ class BoardApiTest extends ApiTestBase {
 
     @Test
     public void endRetro_ShouldRemoveThoughtsWithoutABoard() throws Exception {
-        Thought savedThought = thoughtService.createThought(teamId, new CreateThoughtRequest(null, "TEST_MESSAGE", 0,
-            "happy", false, teamId, null, columnTitle.getId()));
+        Thought savedThought = thoughtService.createThought(
+                teamId,
+                new CreateThoughtRequest("TEST_MESSAGE","happy", columnTitle.getId())
+        );
 
         mockMvc.perform(put(format("/api/team/%s/end-retro", teamId))
                 .header("Authorization", getBearerAuthToken()))

--- a/api/src/test/java/com/ford/labs/retroquest/api/BoardApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/BoardApiTest.java
@@ -56,13 +56,15 @@ class BoardApiTest extends ApiTestBase {
     @Autowired
     private ThoughtService thoughtService;
 
+    private ColumnTitle columnTitle;
+
     @BeforeEach
     void setup() {
         thoughtRepository.deleteAllInBatch();
         columnTitleRepository.deleteAllInBatch();
         boardRepository.deleteAllInBatch();
 
-        columnTitleRepository.save(new ColumnTitle(null, "happy", "Happy", teamId));
+        columnTitle = columnTitleRepository.save(new ColumnTitle(null, "happy", "Happy", teamId));
     }
 
     @Test
@@ -112,7 +114,7 @@ class BoardApiTest extends ApiTestBase {
     @Test
     public void endRetro_ShouldSaveABoardWithThoughts() throws Exception {
         Thought savedThought = thoughtService.createThought(teamId, new CreateThoughtRequest(null, "TEST_MESSAGE", 0,
-            "happy", false, teamId, null));
+            "happy", false, teamId, null, columnTitle.getId()));
 
         mockMvc.perform(put(format("/api/team/%s/end-retro", teamId))
                 .header("Authorization", getBearerAuthToken()))
@@ -125,7 +127,7 @@ class BoardApiTest extends ApiTestBase {
     @Test
     public void endRetro_ShouldRemoveThoughtsWithoutABoard() throws Exception {
         Thought savedThought = thoughtService.createThought(teamId, new CreateThoughtRequest(null, "TEST_MESSAGE", 0,
-            "happy", false, teamId, null));
+            "happy", false, teamId, null, columnTitle.getId()));
 
         mockMvc.perform(put(format("/api/team/%s/end-retro", teamId))
                 .header("Authorization", getBearerAuthToken()))

--- a/api/src/test/java/com/ford/labs/retroquest/api/BoardApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/BoardApiTest.java
@@ -20,12 +20,14 @@ package com.ford.labs.retroquest.api;
 import com.ford.labs.retroquest.api.setup.ApiTestBase;
 import com.ford.labs.retroquest.board.Board;
 import com.ford.labs.retroquest.board.BoardRepository;
+import com.ford.labs.retroquest.column.ColumnTitle;
+import com.ford.labs.retroquest.column.ColumnTitleRepository;
 import com.ford.labs.retroquest.thought.CreateThoughtRequest;
 import com.ford.labs.retroquest.thought.Thought;
 import com.ford.labs.retroquest.thought.ThoughtRepository;
 import com.ford.labs.retroquest.thought.ThoughtService;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,9 +37,7 @@ import java.util.List;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -51,15 +51,18 @@ class BoardApiTest extends ApiTestBase {
     private ThoughtRepository thoughtRepository;
 
     @Autowired
+    private ColumnTitleRepository columnTitleRepository;
+
+    @Autowired
     private ThoughtService thoughtService;
 
-    @AfterEach
-    void teardown() {
-        boardRepository.deleteAllInBatch();
+    @BeforeEach
+    void setup() {
         thoughtRepository.deleteAllInBatch();
+        columnTitleRepository.deleteAllInBatch();
+        boardRepository.deleteAllInBatch();
 
-        assertThat(boardRepository.count()).isZero();
-        assertThat(thoughtRepository.count()).isZero();
+        columnTitleRepository.save(new ColumnTitle(null, "happy", "Happy", teamId));
     }
 
     @Test

--- a/api/src/test/java/com/ford/labs/retroquest/api/DownloadTeamBoardApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/DownloadTeamBoardApiTest.java
@@ -35,7 +35,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.sql.Date;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -69,11 +68,6 @@ class DownloadTeamBoardApiTest extends ApiTestBase {
         actionItemRepository.deleteAllInBatch();
         thoughtRepository.deleteAllInBatch();
         columnTitleRepository.deleteAllInBatch();
-
-        assertThat(teamRepository.count()).isZero();
-        assertThat(actionItemRepository.count()).isZero();
-        assertThat(thoughtRepository.count()).isZero();
-        assertThat(columnTitleRepository.count()).isZero();
     }
 
     @Test
@@ -96,11 +90,10 @@ class DownloadTeamBoardApiTest extends ApiTestBase {
         thoughtRepository.save(
                 Thought.builder()
                         .message("task")
-                        .columnTitle(savedColumnTitle)
                         .teamId(teamId)
                         .hearts(5)
                         .discussed(false)
-                        .topic("happy")
+                        .columnId(savedColumnTitle.getId())
                         .build()
         );
 

--- a/api/src/test/java/com/ford/labs/retroquest/api/ThoughtApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ThoughtApiTest.java
@@ -245,13 +245,8 @@ class ThoughtApiTest extends ApiTestBase {
     @Test
     void should_create_thought() throws Exception {
         var createThoughtRequest = new CreateThoughtRequest(
-            null,
             "Hello",
-            0,
             "happy",
-            false,
-            null,
-            null,
             savedColumnTitle.getId()
         );
 
@@ -271,13 +266,8 @@ class ThoughtApiTest extends ApiTestBase {
     @Test
     public void should_not_create_thought_unauthorized() throws Exception {
         var createThoughtRequest = new CreateThoughtRequest(
-            null,
             "Hello",
-            0,
             "happy",
-            false,
-            null,
-            null,
             savedColumnTitle.getId()
         );
 

--- a/api/src/test/java/com/ford/labs/retroquest/api/ThoughtApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ThoughtApiTest.java
@@ -171,7 +171,7 @@ class ThoughtApiTest extends ApiTestBase {
         assertThat(updatedThought.getId()).isEqualTo(savedThought.getId());
         assertThat(updatedThought.getMessage()).isEqualTo(savedThought.getMessage());
         assertThat(updatedThought.getTopic()).isEqualTo(newSavedColumn.getTopic());
-        assertThat(updatedThought.getColumnTitle()).isEqualTo(newSavedColumn);
+        assertThat(updatedThought.getColumnId()).isEqualTo(newSavedColumn.getId());
     }
 
     @Test

--- a/api/src/test/java/com/ford/labs/retroquest/api/ThoughtApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ThoughtApiTest.java
@@ -56,13 +56,11 @@ class ThoughtApiTest extends ApiTestBase {
 
     @BeforeEach
     void setup() {
-        BASE_API_URL = "/api/team/" + teamId;
-    }
-
-    @AfterEach
-    void teardown() {
         thoughtRepository.deleteAllInBatch();
         columnTitleRepository.deleteAllInBatch();
+
+        BASE_API_URL = "/api/team/" + teamId;
+        columnTitleRepository.save(new ColumnTitle(null, "happy", "Happy", teamId));
     }
 
     @Test

--- a/api/src/test/java/com/ford/labs/retroquest/api/ThoughtApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ThoughtApiTest.java
@@ -232,7 +232,7 @@ class ThoughtApiTest extends ApiTestBase {
     @Test
     public void deleteThought_WhenThoughtOnOtherTeam_IgnoresDelete() throws Exception {
         var unauthorizedTeamJwt = jwtBuilder.buildJwt("not-beach-bums");
-        var thought = thoughtRepository.save(Thought.builder().teamId(teamId).message("hello").build());
+        var thought = thoughtRepository.save(Thought.builder().teamId(teamId).message("hello").columnId(savedColumnTitle.getId()).build());
 
         mockMvc.perform(delete("/api/team/%s/thought/%d".formatted("not-beach-bums", thought.getId()))
                 .contentType(APPLICATION_JSON)
@@ -320,6 +320,7 @@ class ThoughtApiTest extends ApiTestBase {
 
         var savedThought = thoughtRepository.save(Thought.builder()
                 .teamId("beach-bums")
+                .columnId(savedColumnTitle.getId())
                 .build());
 
         mockMvc.perform(put("/api/team/not-beach-bums/thought/%d/heart".formatted(savedThought.getId()))

--- a/api/src/test/java/com/ford/labs/retroquest/api/ThoughtApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ThoughtApiTest.java
@@ -251,7 +251,8 @@ class ThoughtApiTest extends ApiTestBase {
             "happy",
             false,
             null,
-            null
+            null,
+            savedColumnTitle.getId()
         );
 
         mockMvc.perform(post(String.join("", "/api/team/", teamId, "/thought"))
@@ -276,7 +277,8 @@ class ThoughtApiTest extends ApiTestBase {
             "happy",
             false,
             null,
-            null
+            null,
+            savedColumnTitle.getId()
         );
 
         mockMvc.perform(post(String.join("", "/api/team/", teamId, "/thought"))

--- a/api/src/test/java/com/ford/labs/retroquest/board/RetroTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/board/RetroTest.java
@@ -32,7 +32,7 @@ public class RetroTest {
     @Test
     public void fromBoard_returnsAllExpectedBoardFields() {
         var columnTitle = new ColumnTitle(3L, "topic", "title", "teamId");
-        var thought = new Thought(2L, "A message", 0, "topic", false, "teamId", columnTitle, 1L);
+        var thought = new Thought(2L, "A message", 0, "topic", false, "teamId", columnTitle, 1L, 3L);
         var board = new Board(1L, "teamId", LocalDate.now(), List.of(thought));
         var retro = Retro.fromBoard(board);
 
@@ -45,8 +45,8 @@ public class RetroTest {
     @Test
     public void fromBoard_returnsDistinctColumnsFromThoughts() {
         var columnTitle1 = new ColumnTitle(3L, "topic", "title", "teamId");
-        var thought1 = new Thought(2L, "A message", 0, "topic", false, "teamId", columnTitle1, 1L);
-        var thought2 = new Thought(4L, "A message", 0, "topic", false, "teamId", columnTitle1, 1L);
+        var thought1 = new Thought(2L, "A message", 0, "topic", false, "teamId", columnTitle1, 1L, 3L);
+        var thought2 = new Thought(4L, "A message", 0, "topic", false, "teamId", columnTitle1, 1L, 3L);
         var board = new Board(1L, "teamId", LocalDate.now(), List.of(thought1, thought2));
         var retro = Retro.fromBoard(board);
 
@@ -57,8 +57,8 @@ public class RetroTest {
     public void fromBoard_returnsColumnsInSavedOrder() {
         var columnTitle1 = new ColumnTitle(2L, "topic", "title", "teamId");
         var columnTitle2 = new ColumnTitle(3L, "topic", "title", "teamId");
-        var thought1 = new Thought(4L, "A message", 0, "topic", false, "teamId", columnTitle2, 1L);
-        var thought2 = new Thought(5L, "A message", 0, "topic", false, "teamId", columnTitle1, 1L);
+        var thought1 = new Thought(4L, "A message", 0, "topic", false, "teamId", columnTitle2, 1L, 3L);
+        var thought2 = new Thought(5L, "A message", 0, "topic", false, "teamId", columnTitle1, 1L, 2L);
         var board = new Board(1L, "teamId", LocalDate.now(), List.of(thought1, thought2));
         var retro = Retro.fromBoard(board);
 

--- a/api/src/test/java/com/ford/labs/retroquest/board/RetroTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/board/RetroTest.java
@@ -17,24 +17,23 @@
 
 package com.ford.labs.retroquest.board;
 
-import com.ford.labs.retroquest.column.ColumnTitle;
+import com.ford.labs.retroquest.column.Column;
 import com.ford.labs.retroquest.thought.Thought;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.util.List;
 
-import static com.ford.labs.retroquest.column.Column.fromColumnTitle;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RetroTest {
 
     @Test
-    public void fromBoard_returnsAllExpectedBoardFields() {
-        var columnTitle = new ColumnTitle(3L, "topic", "title", "teamId");
-        var thought = new Thought(2L, "A message", 0, "topic", false, "teamId", columnTitle, 1L, 3L);
+    public void from_returnsAllExpectedBoardFields() {
+        var column = new Column(3L, "title", "topic");
+        var thought = new Thought(2L, "A message", 0, "topic", false, "teamId", null, 1L, 3L);
         var board = new Board(1L, "teamId", LocalDate.now(), List.of(thought));
-        var retro = Retro.fromBoard(board);
+        var retro = Retro.from(board, List.of(column));
 
         assertThat(retro.id()).isEqualTo(board.getId());
         assertThat(retro.teamId()).isEqualTo(board.getTeamId());
@@ -43,26 +42,13 @@ public class RetroTest {
     }
 
     @Test
-    public void fromBoard_returnsDistinctColumnsFromThoughts() {
-        var columnTitle1 = new ColumnTitle(3L, "topic", "title", "teamId");
-        var thought1 = new Thought(2L, "A message", 0, "topic", false, "teamId", columnTitle1, 1L, 3L);
-        var thought2 = new Thought(4L, "A message", 0, "topic", false, "teamId", columnTitle1, 1L, 3L);
-        var board = new Board(1L, "teamId", LocalDate.now(), List.of(thought1, thought2));
-        var retro = Retro.fromBoard(board);
+    public void from_returnsColumnsInSavedOrder() {
+        var column1 = new Column(2L, "topic", "title");
+        var column2 = new Column(3L, "topic", "title");
+        var board = new Board(1L, "teamId", LocalDate.now(), List.of());
+        var retro = Retro.from(board, List.of(column2, column1));
 
-        assertThat(retro.columns()).isEqualTo(List.of(fromColumnTitle(columnTitle1)));
-    }
-
-    @Test
-    public void fromBoard_returnsColumnsInSavedOrder() {
-        var columnTitle1 = new ColumnTitle(2L, "topic", "title", "teamId");
-        var columnTitle2 = new ColumnTitle(3L, "topic", "title", "teamId");
-        var thought1 = new Thought(4L, "A message", 0, "topic", false, "teamId", columnTitle2, 1L, 3L);
-        var thought2 = new Thought(5L, "A message", 0, "topic", false, "teamId", columnTitle1, 1L, 2L);
-        var board = new Board(1L, "teamId", LocalDate.now(), List.of(thought1, thought2));
-        var retro = Retro.fromBoard(board);
-
-        assertThat(retro.columns()).isEqualTo(List.of(fromColumnTitle(columnTitle1), fromColumnTitle(columnTitle2)));
+        assertThat(retro.columns()).isEqualTo(List.of(column1, column2));
     }
 
 }

--- a/api/src/test/java/com/ford/labs/retroquest/board/RetroTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/board/RetroTest.java
@@ -31,7 +31,7 @@ public class RetroTest {
     @Test
     public void from_returnsAllExpectedBoardFields() {
         var column = new Column(3L, "title", "topic");
-        var thought = new Thought(2L, "A message", 0, "topic", false, "teamId", null, 1L, 3L);
+        var thought = new Thought(2L, "A message", 0, "topic", false, "teamId", 1L, 3L);
         var board = new Board(1L, "teamId", LocalDate.now(), List.of(thought));
         var retro = Retro.from(board, List.of(column));
 

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/BoardServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/BoardServiceTest.java
@@ -142,7 +142,6 @@ class BoardServiceTest {
                     null,
                     false,
                     expectedTeamId,
-                    null,
                     expectedBoardId,
                     null
                 )
@@ -158,7 +157,6 @@ class BoardServiceTest {
                     null,
                     false,
                     expectedTeamId,
-                    null,
                     null,
                     null
                 )

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/BoardServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/BoardServiceTest.java
@@ -139,24 +139,26 @@ class BoardServiceTest {
                     false,
                     expectedTeamId,
                     null,
-                    expectedBoardId
+                    expectedBoardId,
+                    null
                 )
             )
         );
 
         when(thoughtService.fetchAllActiveThoughts(eq(expectedTeamId))).thenReturn(
-                List.of(
-                        new Thought(
-                                4321L,
-                                expectedMessage,
-                                0,
-                                null,
-                                false,
-                                expectedTeamId,
-                                null,
-                                null
-                        )
+            List.of(
+                new Thought(
+                    4321L,
+                    expectedMessage,
+                    0,
+                    null,
+                    false,
+                    expectedTeamId,
+                    null,
+                    null,
+                    null
                 )
+            )
         );
 
         when(boardRepository.save(any(Board.class))).thenAnswer(a -> {

--- a/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/CsvFileTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/deprecated_tests/CsvFileTest.java
@@ -18,6 +18,7 @@
 package com.ford.labs.retroquest.deprecated_tests;
 
 import com.ford.labs.retroquest.actionitem.ActionItem;
+import com.ford.labs.retroquest.column.Column;
 import com.ford.labs.retroquest.column.ColumnTitle;
 import com.ford.labs.retroquest.team.CsvFile;
 import com.ford.labs.retroquest.thought.Thought;
@@ -38,32 +39,32 @@ class CsvFileTest {
 
     @Test
     void shouldConvertThoughtsAndActionItemsToACSV() throws IOException {
+        var column1 = new Column(1L, "Happy", "happy");
+        var column2 = new Column(2L, "Meh", "confused");
+        var column3 = new Column(3L, "Sad", "unhappy");
 
-        Thought firstThought = Thought.builder()
-            .topic("confused")
+        var firstThought = Thought.builder()
             .message("stuff \"goes here\"")
             .hearts(5)
             .discussed(false)
-            .columnTitle(ColumnTitle.builder().title("CONFUSED").build())
+            .columnId(2L)
             .build();
 
-        Thought secondThoght = Thought.builder()
-            .topic("happy")
+        var secondThought = Thought.builder()
             .message("a thought, with a comma")
             .hearts(2)
-            .columnTitle(ColumnTitle.builder().title("HAPPY").build())
             .discussed(true)
+            .columnId(1L)
             .build();
 
-        Thought thirdThought = Thought.builder()
-            .topic("unhappy")
+        var thirdThought = Thought.builder()
             .message("sad")
             .hearts(0)
             .discussed(false)
-            .columnTitle(ColumnTitle.builder().title("SAD").build())
+            .columnId(3L)
             .build();
 
-        ActionItem actionItem = ActionItem.builder()
+        var actionItem = ActionItem.builder()
             .task("tasks and \"stuff, yo\"")
             .completed(false)
             .assignee("test user")
@@ -71,8 +72,9 @@ class CsvFileTest {
 
         String actual = new CsvFile(
             "teamName",
-            List.of(firstThought, secondThoght, thirdThought),
-            List.of(actionItem)
+            List.of(firstThought, secondThought, thirdThought),
+            List.of(actionItem),
+            List.of(column1, column2, column3)
         ).getCsvString();
 
         String expected = FileUtils.readFileToString(
@@ -89,7 +91,8 @@ class CsvFileTest {
         String actual = new CsvFile(
                 "teamName",
                 List.of(),
-                List.of(actionItem)
+                List.of(actionItem),
+                List.of()
         ).getCsvString();
         Assertions.assertThat(actual).contains("action item,task,,yes,assignee");
     }
@@ -100,7 +103,8 @@ class CsvFileTest {
         String actual = new CsvFile(
                 "teamName",
                 List.of(),
-                List.of(actionItem)
+                List.of(actionItem),
+                List.of()
         ).getCsvString();
         Assertions.assertThat(actual).contains("action item,task,,no,assignee");
     }
@@ -111,7 +115,8 @@ class CsvFileTest {
         String actual = new CsvFile(
                 "teamName",
                 List.of(),
-                List.of(actionItem)
+                List.of(actionItem),
+                List.of()
         ).getCsvString();
         Assertions.assertThat(actual).contains("action item,task,,no,");
     }

--- a/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
@@ -187,7 +187,8 @@ class ThoughtServiceTest {
             topic,
             false,
             "the-team",
-            null
+            null,
+            columnTitle.getId()
         );
 
         var expectedThought = new Thought(

--- a/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
@@ -197,7 +197,6 @@ class ThoughtServiceTest {
                 topic,
                 false,
                 "the-team",
-                columnTitle,
                 null,
                 6789L
         );

--- a/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
@@ -107,14 +107,14 @@ class ThoughtServiceTest {
         String newTopic = "right-column";
         Thought thought = Thought.builder().id(1234L).topic("wrong-column").build();
         ColumnTitle expectedColumnTitle = new ColumnTitle(6789L, newTopic, "TITLE", teamId);
-        Thought expectedThought = Thought.builder().id(1234L).topic(newTopic).build();
+        Thought expectedThought = Thought.builder().id(1234L).topic(newTopic).columnId(6789L).build();
         given(this.thoughtRepository.findByTeamIdAndId(teamId, 1234L)).willReturn(Optional.of(thought));
         given(this.thoughtRepository.save(expectedThought)).willReturn(expectedThought);
         given(this.columnTitleRepository.findByTeamIdAndId(teamId, 6789L)).willReturn(Optional.of(expectedColumnTitle));
 
         Thought actualThought = thoughtService.updateColumn(teamId, 1234L, 6789L);
 
-        assertThat(actualThought).isEqualTo(expectedThought);
+        assertThat(actualThought).usingRecursiveComparison().isEqualTo(expectedThought);
     }
 
     @Test
@@ -123,7 +123,7 @@ class ThoughtServiceTest {
         String newTopic = "right-column";
         Thought thought = Thought.builder().id(1234L).topic("wrong-column").build();
         ColumnTitle expectedColumnTitle = new ColumnTitle(6789L, newTopic, "TITLE", teamId);
-        Thought expectedThought = Thought.builder().id(1234L).topic(newTopic).build();
+        Thought expectedThought = Thought.builder().id(1234L).topic(newTopic).columnId(6789L).build();
         given(this.thoughtRepository.findByTeamIdAndId(teamId, 1234L)).willReturn(Optional.of(thought));
         given(this.thoughtRepository.save(expectedThought)).willReturn(expectedThought);
         given(this.columnTitleRepository.findByTeamIdAndId(teamId, 6789L)).willReturn(Optional.of(expectedColumnTitle));
@@ -179,7 +179,7 @@ class ThoughtServiceTest {
     void shouldCreateThought() {
         var message = "Hello there!";
         var topic = "topic";
-        var columnTitle = ColumnTitle.builder().title("Happy").build();
+        var columnTitle = ColumnTitle.builder().id(6789L).title("Happy").build();
         var request = new CreateThoughtRequest(
             null,
             message,
@@ -198,7 +198,8 @@ class ThoughtServiceTest {
                 false,
                 "the-team",
                 columnTitle,
-                null
+                null,
+                6789L
         );
         var expectedEvent = new WebsocketThoughtEvent("the-team", UPDATE, expectedThought);
 

--- a/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
@@ -181,13 +181,8 @@ class ThoughtServiceTest {
         var topic = "topic";
         var columnTitle = ColumnTitle.builder().id(6789L).title("Happy").build();
         var request = new CreateThoughtRequest(
-            null,
             message,
-            0,
             topic,
-            false,
-            "the-team",
-            null,
             columnTitle.getId()
         );
 

--- a/api/src/test/resources/sampleOutput.csv
+++ b/api/src/test/resources/sampleOutput.csv
@@ -1,5 +1,5 @@
 Column,Message,Likes,Completed,Assigned To
-CONFUSED,"stuff ""goes here""",5,no
-HAPPY,"a thought, with a comma",2,yes
-SAD,sad,0,no
+Meh,"stuff ""goes here""",5,no
+Happy,"a thought, with a comma",2,yes
+Sad,sad,0,no
 action item,"tasks and ""stuff, yo""",,no,test user

--- a/ui/cypress/e2e/archivist-journey.spec.ts
+++ b/ui/cypress/e2e/archivist-journey.spec.ts
@@ -31,7 +31,6 @@ describe('Archivist Journey', () => {
 	});
 
 	it('Archives page functionality', () => {
-		console.log(getColumnsForTeam(teamCredentials.teamId));
 		getColumnsForTeam(teamCredentials.teamId).then((columns) => {
 			addThoughtToTeam(
 				teamCredentials.teamId,

--- a/ui/src/App/Team/Archives/ThoughtArchives/ArchivedBoard/ArchivedBoard.spec.tsx
+++ b/ui/src/App/Team/Archives/ThoughtArchives/ArchivedBoard/ArchivedBoard.spec.tsx
@@ -86,6 +86,7 @@ const testBoard: Board = {
 			hearts: 20,
 			discussed: false,
 			topic: Topic.HAPPY,
+			columnId: 10,
 		},
 		{
 			id: 101,
@@ -93,6 +94,7 @@ const testBoard: Board = {
 			hearts: 30,
 			discussed: false,
 			topic: Topic.UNHAPPY,
+			columnId: 11,
 		},
 		{
 			id: 102,
@@ -100,6 +102,7 @@ const testBoard: Board = {
 			hearts: 10,
 			discussed: true,
 			topic: Topic.UNHAPPY,
+			columnId: 11,
 		},
 		{
 			id: 103,
@@ -107,6 +110,7 @@ const testBoard: Board = {
 			hearts: 10,
 			discussed: false,
 			topic: Topic.HAPPY,
+			columnId: 10,
 		},
 	],
 	columns: [
@@ -134,6 +138,7 @@ const singleColumnTestBoard: Board = {
 			hearts: 10,
 			discussed: false,
 			topic: Topic.HAPPY,
+			columnId: 10,
 		},
 		{
 			id: 101,
@@ -141,6 +146,7 @@ const singleColumnTestBoard: Board = {
 			hearts: 30,
 			discussed: true,
 			topic: Topic.HAPPY,
+			columnId: 10,
 		},
 		{
 			id: 102,
@@ -148,6 +154,7 @@ const singleColumnTestBoard: Board = {
 			hearts: 10,
 			discussed: true,
 			topic: Topic.HAPPY,
+			columnId: 10,
 		},
 		{
 			id: 103,
@@ -155,6 +162,7 @@ const singleColumnTestBoard: Board = {
 			hearts: 20,
 			discussed: false,
 			topic: Topic.HAPPY,
+			columnId: 10,
 		},
 	],
 	columns: [

--- a/ui/src/App/Team/Retro/ThoughtColumn/RetroItem/RetroItem.spec.tsx
+++ b/ui/src/App/Team/Retro/ThoughtColumn/RetroItem/RetroItem.spec.tsx
@@ -51,6 +51,7 @@ describe('Retro Item', () => {
 		hearts: 3,
 		discussed: false,
 		topic: Topic.HAPPY,
+		columnId: 10,
 	};
 
 	beforeEach(() => {

--- a/ui/src/App/Team/Retro/ThoughtColumn/RetroItemWithAddAction/RetroItemWithAddAction.spec.tsx
+++ b/ui/src/App/Team/Retro/ThoughtColumn/RetroItemWithAddAction/RetroItemWithAddAction.spec.tsx
@@ -35,6 +35,7 @@ describe('RetroItemWithAddAction', () => {
 		hearts: 3,
 		discussed: false,
 		topic: Topic.HAPPY,
+		columnId: 10,
 	};
 
 	beforeEach(() => {

--- a/ui/src/App/Team/Retro/ThoughtColumn/ThoughtColumn.spec.tsx
+++ b/ui/src/App/Team/Retro/ThoughtColumn/ThoughtColumn.spec.tsx
@@ -103,13 +103,9 @@ describe('ThoughtColumn', () => {
 			userEvent.type(textField, `${thoughtMessage}{enter}`);
 
 			expect(ThoughtService.create).toHaveBeenCalledWith(team.id, {
-				id: -1,
-				teamId: team.id,
-				topic: column.topic,
 				message: thoughtMessage,
-				hearts: 0,
+				topic: column.topic,
 				columnId: column.id,
-				discussed: false,
 			});
 		});
 	});

--- a/ui/src/App/Team/Retro/ThoughtColumn/ThoughtColumn.spec.tsx
+++ b/ui/src/App/Team/Retro/ThoughtColumn/ThoughtColumn.spec.tsx
@@ -38,11 +38,11 @@ const team: Team = {
 	id: 'my-team',
 };
 
-const activeThought1: Thought = getMockThought(Topic.HAPPY, false, 1);
+const activeThought1: Thought = getMockThought(Topic.HAPPY, 1, false, 1);
 activeThought1.id = 943;
-const activeThought2: Thought = getMockThought(Topic.HAPPY, false, 2);
-const discussedThought1: Thought = getMockThought(Topic.HAPPY, true, 3);
-const discussedThought2: Thought = getMockThought(Topic.HAPPY, true, 4);
+const activeThought2: Thought = getMockThought(Topic.HAPPY, 1, false, 2);
+const discussedThought1: Thought = getMockThought(Topic.HAPPY, 1, true, 3);
+const discussedThought2: Thought = getMockThought(Topic.HAPPY, 1, true, 4);
 
 const column: Column = {
 	id: 123456,
@@ -108,6 +108,7 @@ describe('ThoughtColumn', () => {
 				topic: column.topic,
 				message: thoughtMessage,
 				hearts: 0,
+				columnId: column.id,
 				discussed: false,
 			});
 		});

--- a/ui/src/App/Team/Retro/ThoughtColumn/ThoughtColumn.tsx
+++ b/ui/src/App/Team/Retro/ThoughtColumn/ThoughtColumn.tsx
@@ -63,7 +63,7 @@ function ThoughtColumn(props: Props) {
 		if (text && text.length) {
 			ThoughtService.create(
 				team.id,
-				getCreateThoughtRequest(team.id, column.id, column.topic, text)
+				getCreateThoughtRequest(column.id, column.topic, text)
 			).catch(console.error);
 		}
 	};

--- a/ui/src/App/Team/Retro/ThoughtColumn/ThoughtColumn.tsx
+++ b/ui/src/App/Team/Retro/ThoughtColumn/ThoughtColumn.tsx
@@ -63,7 +63,7 @@ function ThoughtColumn(props: Props) {
 		if (text && text.length) {
 			ThoughtService.create(
 				team.id,
-				getCreateThoughtRequest(team.id, column.topic, text)
+				getCreateThoughtRequest(team.id, column.id, column.topic, text)
 			).catch(console.error);
 		}
 	};

--- a/ui/src/Common/AddActionItem/AddActionItem.spec.tsx
+++ b/ui/src/Common/AddActionItem/AddActionItem.spec.tsx
@@ -51,7 +51,7 @@ describe('AddActionItem', () => {
 		id: 'my-team',
 	};
 	let modalContent: ModalContents | null;
-	const thought = getMockThought(Topic.HAPPY);
+	const thought = getMockThought(Topic.HAPPY, 1);
 
 	beforeEach(() => {
 		jest.clearAllMocks();

--- a/ui/src/Hooks/useWebSocketMessageHandler.spec.tsx
+++ b/ui/src/Hooks/useWebSocketMessageHandler.spec.tsx
@@ -56,7 +56,7 @@ describe('useWebsocketMessageHandler Hook', () => {
 		};
 
 		it('should add a thought to the global thoughts state', async () => {
-			const newThought = getMockThought(Topic.HAPPY, false);
+			const newThought = getMockThought(Topic.HAPPY, 1, false);
 
 			render(
 				<RecoilRoot
@@ -77,7 +77,7 @@ describe('useWebsocketMessageHandler Hook', () => {
 		});
 
 		it('should update a thought in the global thoughts state', async () => {
-			const originalThought = getMockThought(Topic.CONFUSED, false);
+			const originalThought = getMockThought(Topic.CONFUSED, 2, false);
 			const updatedThought = originalThought;
 			updatedThought.discussed = true;
 			updatedThought.hearts = 2;
@@ -101,8 +101,8 @@ describe('useWebsocketMessageHandler Hook', () => {
 		});
 
 		it('should delete a thought from the global thoughts state', async () => {
-			const thoughtNotToDelete = getMockThought(Topic.HAPPY, true);
-			const thoughtToDelete = getMockThought(Topic.CONFUSED, false);
+			const thoughtNotToDelete = getMockThought(Topic.HAPPY, 1, true);
+			const thoughtToDelete = getMockThought(Topic.CONFUSED, 2, false);
 
 			render(
 				<RecoilRoot
@@ -242,9 +242,9 @@ describe('useWebsocketMessageHandler Hook', () => {
 			const completeActionItem = getMockActionItem(true);
 			const actionItems = [activeActionItem, completeActionItem];
 			const thoughts = [
-				getMockThought(Topic.HAPPY),
-				getMockThought(Topic.CONFUSED),
-				getMockThought(Topic.UNHAPPY),
+				getMockThought(Topic.HAPPY, 1),
+				getMockThought(Topic.CONFUSED, 2),
+				getMockThought(Topic.UNHAPPY, 3),
 			];
 			render(
 				<RecoilRoot

--- a/ui/src/Services/Api/ThoughtService.spec.ts
+++ b/ui/src/Services/Api/ThoughtService.spec.ts
@@ -36,7 +36,7 @@ describe('Thought Service', () => {
 
 	describe('create', () => {
 		it('should create a new thought for column', async () => {
-			const expectedThought = getMockThought(Topic.HAPPY);
+			const expectedThought = getMockThought(Topic.HAPPY, 1);
 			axios.post = jest.fn().mockResolvedValue({ data: expectedThought });
 
 			const createThoughtRequest: CreateThoughtRequest = {
@@ -46,6 +46,7 @@ describe('Thought Service', () => {
 				topic: Topic.HAPPY,
 				discussed: false,
 				teamId,
+				columnId: 10,
 			};
 
 			const actualThought = await ThoughtService.create(
@@ -64,9 +65,9 @@ describe('Thought Service', () => {
 	describe('getThoughts', () => {
 		it('should get all thoughts for current retro', async () => {
 			const expectedThoughts = [
-				getMockThought(Topic.HAPPY),
-				getMockThought(Topic.UNHAPPY),
-				getMockThought(Topic.CONFUSED),
+				getMockThought(Topic.HAPPY, 1),
+				getMockThought(Topic.UNHAPPY, 3),
+				getMockThought(Topic.CONFUSED, 2),
 			];
 			axios.get = jest.fn().mockResolvedValue({ data: expectedThoughts });
 			const actualThoughts = await ThoughtService.getThoughts(teamId);

--- a/ui/src/Services/Api/ThoughtService.spec.ts
+++ b/ui/src/Services/Api/ThoughtService.spec.ts
@@ -40,12 +40,8 @@ describe('Thought Service', () => {
 			axios.post = jest.fn().mockResolvedValue({ data: expectedThought });
 
 			const createThoughtRequest: CreateThoughtRequest = {
-				id: 1,
 				message: 'I had a thought..',
-				hearts: 5,
 				topic: Topic.HAPPY,
-				discussed: false,
-				teamId,
 				columnId: 10,
 			};
 

--- a/ui/src/Services/Api/__mocks__/BoardService.ts
+++ b/ui/src/Services/Api/__mocks__/BoardService.ts
@@ -30,6 +30,7 @@ export const mockBoards: Board[] = [
 				hearts: 0,
 				discussed: false,
 				topic: Topic.HAPPY,
+				columnId: 10,
 			},
 		],
 		columns: [

--- a/ui/src/Services/Api/__mocks__/ThoughtService.ts
+++ b/ui/src/Services/Api/__mocks__/ThoughtService.ts
@@ -20,6 +20,7 @@ import Topic, { ThoughtTopic } from '../../../Types/Topic';
 
 export const getMockThought = (
 	topic: ThoughtTopic,
+	columnId: number,
 	isDiscussed = false,
 	hearts = 0
 ): Thought => ({
@@ -28,18 +29,19 @@ export const getMockThought = (
 	topic,
 	hearts,
 	discussed: isDiscussed,
+	columnId,
 });
 
 const ThoughtService = {
 	getThoughts: jest
 		.fn()
 		.mockResolvedValue([
-			getMockThought(Topic.HAPPY, false),
-			getMockThought(Topic.HAPPY, true),
-			getMockThought(Topic.CONFUSED, false),
-			getMockThought(Topic.CONFUSED, true),
-			getMockThought(Topic.UNHAPPY, false),
-			getMockThought(Topic.UNHAPPY, true),
+			getMockThought(Topic.HAPPY, 1, false),
+			getMockThought(Topic.HAPPY, 1, true),
+			getMockThought(Topic.CONFUSED, 2, false),
+			getMockThought(Topic.CONFUSED, 2, true),
+			getMockThought(Topic.UNHAPPY, 3, false),
+			getMockThought(Topic.UNHAPPY, 3, true),
 		]),
 	create: jest.fn().mockResolvedValue((thought: Thought) => thought),
 	delete: jest.fn().mockResolvedValue(null),

--- a/ui/src/Services/DragAndDrop/DragAndDrop.spec.tsx
+++ b/ui/src/Services/DragAndDrop/DragAndDrop.spec.tsx
@@ -39,6 +39,7 @@ const thoughts: Thought[] = [
 		topic: Topic.HAPPY,
 		hearts: 2,
 		discussed: false,
+		columnId: 10,
 	},
 	{
 		id: 13,
@@ -46,6 +47,7 @@ const thoughts: Thought[] = [
 		topic: Topic.UNHAPPY,
 		hearts: 2,
 		discussed: false,
+		columnId: 11,
 	},
 ];
 

--- a/ui/src/Stories/RetroItem.stories.tsx
+++ b/ui/src/Stories/RetroItem.stories.tsx
@@ -37,6 +37,7 @@ const thought1: Thought = {
 		"If elevators hadn't been invented, all the CEOs and" +
 		'important people would have their offices on the first floor as a sign of status.',
 	topic: Topic.HAPPY,
+	columnId: 10,
 };
 
 const thought2: Thought = {
@@ -47,6 +48,7 @@ const thought2: Thought = {
 		"If elevators hadn't been invented, all the CEOs and" +
 		'important people would have their offices on the first floor as a sign of status.',
 	topic: Topic.HAPPY,
+	columnId: 10,
 };
 
 const Template: ComponentStory<typeof RetroItem> = () => {

--- a/ui/src/Stories/RetroItemWithAddAction.stories.tsx
+++ b/ui/src/Stories/RetroItemWithAddAction.stories.tsx
@@ -37,6 +37,7 @@ const thought: Thought = {
 		"If elevators hadn't been invented, all the CEOs and" +
 		'important people would have their offices on the first floor as a sign of status.',
 	topic: Topic.HAPPY,
+	columnId: 0,
 };
 
 const Template: ComponentStory<typeof RetroItemWithAddAction> = () => {

--- a/ui/src/Types/CreateThoughtRequest.ts
+++ b/ui/src/Types/CreateThoughtRequest.ts
@@ -15,9 +15,12 @@
  * limitations under the License.
  */
 
+import { ThoughtTopic } from './Topic';
+
 export function getCreateThoughtRequest(
 	teamId: string,
-	topic: string,
+	columnId: number,
+	topic: ThoughtTopic,
 	message: string
 ): CreateThoughtRequest {
 	return {
@@ -27,6 +30,7 @@ export function getCreateThoughtRequest(
 		message,
 		hearts: 0,
 		discussed: false,
+		columnId,
 	};
 }
 
@@ -37,6 +41,7 @@ interface CreateThoughtRequest {
 	topic: string;
 	discussed: boolean;
 	teamId: string;
+	columnId: number;
 }
 
 export default CreateThoughtRequest;

--- a/ui/src/Types/CreateThoughtRequest.ts
+++ b/ui/src/Types/CreateThoughtRequest.ts
@@ -18,29 +18,20 @@
 import { ThoughtTopic } from './Topic';
 
 export function getCreateThoughtRequest(
-	teamId: string,
 	columnId: number,
 	topic: ThoughtTopic,
 	message: string
 ): CreateThoughtRequest {
 	return {
-		id: -1,
-		teamId,
 		topic,
 		message,
-		hearts: 0,
-		discussed: false,
 		columnId,
 	};
 }
 
 interface CreateThoughtRequest {
-	id: number;
 	message: string;
-	hearts: number;
 	topic: string;
-	discussed: boolean;
-	teamId: string;
 	columnId: number;
 }
 

--- a/ui/src/Types/Thought.ts
+++ b/ui/src/Types/Thought.ts
@@ -23,6 +23,7 @@ interface Thought {
 	hearts: number;
 	discussed: boolean;
 	topic: ThoughtTopic;
+	columnId: number;
 	state?: string;
 }
 


### PR DESCRIPTION
## Overview
* Added columnId to the Thought object to handle Thought -> Column relationship
* Made it impossible to add a Thought not tied to a column
* Removed ColumnTitle from Thought object
* Simplify the information passed through a CreateThoughtRequest
* Archived Boards now show all columns even if there are no Thoughts in them

### Notes
Would love another set of eyes on the database migration script. Seemd to work fine when I ran it against my containerized Postgres instance, but another look couldn't hurt.

The next step will be removing the reference to Topic on Thought. Then the only thing tying the two objects together is the column_id foreign key. That should hopefully make the Thought less dependant on the specific columns that a team has, leading to potentially more columns being allowed or different column types.

## Testing Instructions
The application should behave the same as it did before, with the exception viewing an archived board. An archived board should now have all the columns displayed regardless of whether or not there are thoughts in it.