### PR TITLE
Fill security hole

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
@@ -18,8 +18,6 @@
 package com.ford.labs.retroquest.actionitem;
 
 
-import com.ford.labs.retroquest.websocket.events.WebsocketActionItemEvent;
-import com.ford.labs.retroquest.websocket.WebsocketService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -33,9 +31,8 @@ import javax.transaction.Transactional;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Optional;
 
-import static com.ford.labs.retroquest.websocket.events.WebsocketEventType.DELETE;
-import static com.ford.labs.retroquest.websocket.events.WebsocketEventType.UPDATE;
 import static java.lang.String.format;
 
 @RestController
@@ -46,83 +43,10 @@ import static java.lang.String.format;
 })
 public class ActionItemController {
 
-    private final ActionItemRepository actionItemRepository;
-    private final WebsocketService websocketService;
+    private final ActionItemService actionItemService;
 
-    public ActionItemController(ActionItemRepository actionItemRepository, WebsocketService websocketService) {
-        this.actionItemRepository = actionItemRepository;
-        this.websocketService = websocketService;
-    }
-
-    @PutMapping("/api/team/{teamId}/action-item/{thoughtId}/completed")
-    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @Operation(summary = "Marks a thought as complete for a given team id", description = "completeActionItem")
-    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
-    public void completeActionItem(
-            @PathVariable("thoughtId") Long id,
-            @PathVariable("teamId") String teamId,
-            @RequestBody UpdateActionItemCompletedRequest request
-    ) {
-        var actionItem = actionItemRepository.findById(id).orElseThrow();
-        actionItem.setCompleted(request.completed());
-        var updatedActionItem = actionItemRepository.save(actionItem);
-        websocketService.publishEvent(new WebsocketActionItemEvent(teamId, UPDATE, updatedActionItem));
-    }
-
-    @PutMapping("/api/team/{teamId}/action-item/{thoughtId}/task")
-    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @Operation(summary = "Updates an action item given a thought id and a team id", description = "updateActionItemTask")
-    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
-    public void updateActionItemTask(
-        @PathVariable("thoughtId") Long actionItemId,
-        @PathVariable("teamId") String teamId,
-        @RequestBody UpdateActionItemTaskRequest request
-    ) {
-        var savedActionItem = actionItemRepository.findById(actionItemId).orElseThrow();
-        savedActionItem.setTask(request.task());
-        var updatedActionItem = actionItemRepository.save(savedActionItem);
-        websocketService.publishEvent(new WebsocketActionItemEvent(teamId, UPDATE, updatedActionItem));
-    }
-
-    @PutMapping("/api/team/{teamId}/action-item/{thoughtId}/assignee")
-    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @Operation(summary = "Updates an action item assignee a thought id and a team id", description = "updateActionItemAssignee")
-    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
-    public void updateActionItemAssignee(
-        @PathVariable("thoughtId") Long actionItemId,
-        @PathVariable("teamId") String teamId,
-        @RequestBody UpdateActionItemAssigneeRequest request
-    ) {
-        var savedActionItem = actionItemRepository.findById(actionItemId).orElseThrow();
-        savedActionItem.setAssignee(request.assignee());
-        var updatedActionItem = actionItemRepository.save(savedActionItem);
-        websocketService.publishEvent(new WebsocketActionItemEvent(teamId, UPDATE, updatedActionItem));
-    }
-
-    @PutMapping("/api/team/{teamId}/action-item/{actionItemId}/archived")
-    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @Operation(summary = "Updates an action item's archived status with a thought id and a team id", description = "updateActionItemArchivedStatus")
-    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
-    public void updateActionItemArchivedStatus(
-            @PathVariable String teamId,
-            @PathVariable Long actionItemId,
-            @RequestBody UpdateActionItemArchivedRequest request
-    ) {
-        var savedActionItem = actionItemRepository.findById(actionItemId).orElseThrow();
-        savedActionItem.setArchived(request.archived());
-        var updatedActionItem = actionItemRepository.save(savedActionItem);
-        websocketService.publishEvent(new WebsocketActionItemEvent(teamId, UPDATE, updatedActionItem));
-    }
-
-    @GetMapping("/api/team/{teamId}/action-item")
-    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @Operation(summary = "Retrieves all action items given a team id", description = "getActionItemsForTeam", parameters = {
-        @Parameter(name = "archived", description = "The archived status of the action items")
-    })
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
-    public List<ActionItem> getActionItemsForTeam(@PathVariable("teamId") String teamId, @RequestParam(required = false) Boolean archived) {
-        if(archived != null) return actionItemRepository.findAllByTeamIdAndArchived(teamId, archived);
-        else return actionItemRepository.findAllByTeamId(teamId);
+    public ActionItemController(ActionItemService actionItemService) {
+        this.actionItemService = actionItemService;
     }
 
     @PostMapping("/api/team/{teamId}/action-item")
@@ -130,28 +54,78 @@ public class ActionItemController {
     @Operation(summary = "Creates an action item given a team id", description = "createActionItemForTeam")
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Created")})
     public ResponseEntity<URI> createActionItemForTeam(
-        @PathVariable("teamId") String teamId,
-        @RequestBody CreateActionItemRequest request
+            @PathVariable("teamId") String teamId,
+            @RequestBody CreateActionItemRequest request
     ) throws URISyntaxException {
-        var actionItem = createActionItem(teamId, request);
+        var actionItem = actionItemService.createActionItem(teamId, request);
         var actionItemUri = new URI(format("/api/team/%s/action-item/%d", teamId, actionItem.getId()));
-        websocketService.publishEvent(new WebsocketActionItemEvent(teamId, UPDATE, actionItem));
         return ResponseEntity.created(actionItemUri).build();
     }
 
+    @GetMapping("/api/team/{teamId}/action-item")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @Operation(summary = "Retrieves all action items given a team id", description = "getActionItemsForTeam", parameters = {
+            @Parameter(name = "archived", description = "The archived status of the action items")
+    })
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
+    public List<ActionItem> getActionItemsForTeam(@PathVariable("teamId") String teamId, @RequestParam(required = false) Boolean archived) {
+        return actionItemService.getActionItems(teamId, Optional.ofNullable(archived));
+    }
+
+    @PutMapping("/api/team/{teamId}/action-item/{actionItemId}/completed")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @Operation(summary = "Marks a thought as complete for a given team id", description = "completeActionItem")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
+    public void completeActionItem(
+            @PathVariable("teamId") String teamId,
+            @PathVariable("actionItemId") Long actionItemId,
+            @RequestBody UpdateActionItemCompletedRequest request
+    ) {
+        actionItemService.updateCompletedStatus(teamId, actionItemId, request);
+    }
+
+    @PutMapping("/api/team/{teamId}/action-item/{actionItemId}/task")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @Operation(summary = "Updates an action item given a thought id and a team id", description = "updateActionItemTask")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
+    public void updateActionItemTask(
+        @PathVariable("teamId") String teamId,
+        @PathVariable("actionItemId") Long actionItemId,
+        @RequestBody UpdateActionItemTaskRequest request
+    ) {
+        actionItemService.updateTask(teamId, actionItemId, request);
+    }
+
+    @PutMapping("/api/team/{teamId}/action-item/{actionItemId}/assignee")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @Operation(summary = "Updates an action item assignee a thought id and a team id", description = "updateActionItemAssignee")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
+    public void updateActionItemAssignee(
+        @PathVariable("teamId") String teamId,
+        @PathVariable("actionItemId") Long actionItemId,
+        @RequestBody UpdateActionItemAssigneeRequest request
+    ) {
+        actionItemService.updateAssignee(teamId, actionItemId, request);
+    }
+
+    @PutMapping("/api/team/{teamId}/action-item/{actionItemId}/archived")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @Operation(summary = "Updates an action item's archived status with a thought id and a team id", description = "updateActionItemArchivedStatus")
+    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
+    public void updateActionItemArchivedStatus(
+            @PathVariable("teamId") String teamId,
+            @PathVariable("actionItemId") Long actionItemId,
+            @RequestBody UpdateActionItemArchivedRequest request
+    ) {
+        actionItemService.updateArchivedStatus(teamId, actionItemId, request);
+    }
+
     @Transactional
-    @DeleteMapping("/api/team/{teamId}/action-item/{id}")
+    @DeleteMapping("/api/team/{teamId}/action-item/{actionItemId}")
     @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Deletes an action item given a team id and action item id", description = "deleteActionItem")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
-    public void deleteActionItemByTeamIdAndId(@PathVariable("teamId") String teamId, @PathVariable("id") Long id) {
-        actionItemRepository.deleteActionItemByTeamIdAndId(teamId, id);
-        websocketService.publishEvent(new WebsocketActionItemEvent(teamId, DELETE, ActionItem.builder().id(id).build()));
-    }
-
-    private ActionItem createActionItem(String teamId, CreateActionItemRequest request) {
-        var actionItem = request.toActionItem();
-        actionItem.setTeamId(teamId);
-        return actionItemRepository.save(actionItem);
+    public void deleteActionItemByTeamIdAndId(@PathVariable("teamId") String teamId, @PathVariable("actionItemId") Long actionItemId) {
+        actionItemService.deleteActionItem(teamId, actionItemId);
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
@@ -55,7 +55,7 @@ public class ActionItemController {
     }
 
     @PutMapping("/api/team/{teamId}/action-item/{thoughtId}/completed")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Marks a thought as complete for a given team id", description = "completeActionItem")
     @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
     public void completeActionItem(
@@ -70,7 +70,7 @@ public class ActionItemController {
     }
 
     @PutMapping("/api/team/{teamId}/action-item/{thoughtId}/task")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Updates an action item given a thought id and a team id", description = "updateActionItemTask")
     @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
     public void updateActionItemTask(
@@ -85,7 +85,7 @@ public class ActionItemController {
     }
 
     @PutMapping("/api/team/{teamId}/action-item/{thoughtId}/assignee")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Updates an action item assignee a thought id and a team id", description = "updateActionItemAssignee")
     @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
     public void updateActionItemAssignee(
@@ -100,7 +100,7 @@ public class ActionItemController {
     }
 
     @PutMapping("/api/team/{teamId}/action-item/{actionItemId}/archived")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Updates an action item's archived status with a thought id and a team id", description = "updateActionItemArchivedStatus")
     @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "No Content")})
     public void updateActionItemArchivedStatus(
@@ -115,7 +115,7 @@ public class ActionItemController {
     }
 
     @GetMapping("/api/team/{teamId}/action-item")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Retrieves all action items given a team id", description = "getActionItemsForTeam", parameters = {
         @Parameter(name = "archived", description = "The archived status of the action items")
     })
@@ -126,7 +126,7 @@ public class ActionItemController {
     }
 
     @PostMapping("/api/team/{teamId}/action-item")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Creates an action item given a team id", description = "createActionItemForTeam")
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Created")})
     public ResponseEntity<URI> createActionItemForTeam(
@@ -141,7 +141,7 @@ public class ActionItemController {
 
     @Transactional
     @DeleteMapping("/api/team/{teamId}/action-item/{id}")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Deletes an action item given a team id and action item id", description = "deleteActionItem")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public void deleteActionItemByTeamIdAndId(@PathVariable("teamId") String teamId, @PathVariable("id") Long id) {

--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemRepository.java
@@ -21,9 +21,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ActionItemRepository extends JpaRepository<ActionItem, Long>{
+    Optional<ActionItem> findByTeamIdAndId(String teamId, Long actionItemId);
     List<ActionItem> findAllByTeamId(String teamId);
     List<ActionItem> findAllByTeamIdAndArchived(String teamId, boolean archived);
     List<ActionItem> findAllByTeamIdAndArchivedIsFalseAndCompletedIsTrue(String teamId);

--- a/api/src/main/java/com/ford/labs/retroquest/board/BoardController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/board/BoardController.java
@@ -44,7 +44,7 @@ public class BoardController {
     }
 
     @GetMapping("/team/{teamId}/boards")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Gets a retro board given a team id and page index", description = "getBoardsForTeamId")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public List<Retro> getBoardsForTeamId(
@@ -55,7 +55,7 @@ public class BoardController {
     }
 
     @PostMapping("/team/{teamId}/board")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Saves a board given a team id", description = "saveBoard")
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Created")})
     public ResponseEntity<Void> createBoard(@PathVariable("teamId") String teamId) throws URISyntaxException {
@@ -65,7 +65,7 @@ public class BoardController {
     }
 
     @PutMapping("/team/{teamId}/end-retro")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Ends a retro for a given team", description = "endTeamRetro")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public void endRetro(@PathVariable("teamId") String teamId) {

--- a/api/src/main/java/com/ford/labs/retroquest/column/ColumnController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/column/ColumnController.java
@@ -44,7 +44,7 @@ public class ColumnController {
     }
 
     @GetMapping("/api/team/{teamId}/columns")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Gets all columns of a retro board for a given Team ID", description = "getColumns")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
@@ -56,7 +56,7 @@ public class ColumnController {
 
     @Transactional
     @PutMapping("/api/team/{teamId}/column/{columnId}/title")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(
         summary = "Updates the title of a column of a retro board given a team id and column id",
         description = "updateTitleOfColumn"

--- a/api/src/main/java/com/ford/labs/retroquest/column/ColumnService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/column/ColumnService.java
@@ -66,7 +66,7 @@ public class ColumnService {
         return newColumnTitle;
     }
 
-    private ColumnTitle fetchColumnTitle(String teamId, Long columnId) {
+    public ColumnTitle fetchColumnTitle(String teamId, Long columnId) {
         return columnTitleRepository.findByTeamIdAndId(teamId, columnId).orElseThrow(ColumnTitleNotFoundException::new);
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/column/ColumnService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/column/ColumnService.java
@@ -54,7 +54,7 @@ public class ColumnService {
     }
 
     public ColumnTitle editColumnTitleName(Long columnId, String newColumnName, String teamId) {
-        var existingColumnTitle = columnTitleRepository.findById(columnId).orElseThrow(ColumnTitleNotFoundException::new);
+        var existingColumnTitle = fetchColumnTitle(teamId, columnId);
         existingColumnTitle.setTitle(newColumnName);
 
         ColumnTitle newColumnTitle = columnTitleRepository.save(existingColumnTitle);
@@ -64,5 +64,9 @@ public class ColumnService {
         meterRegistry.counter("retroquest.columns.changed.count").increment();
 
         return newColumnTitle;
+    }
+
+    private ColumnTitle fetchColumnTitle(String teamId, Long columnId) {
+        return columnTitleRepository.findByTeamIdAndId(teamId, columnId).orElseThrow(ColumnTitleNotFoundException::new);
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/column/ColumnTitleRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/column/ColumnTitleRepository.java
@@ -21,9 +21,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ColumnTitleRepository extends JpaRepository<ColumnTitle, Long> {
+    Optional<ColumnTitle> findByTeamIdAndId(String teamId, Long id);
     ColumnTitle findByTeamIdAndTopic(String teamId, String topic);
     List<ColumnTitle> findAllByTeamId(String teamId);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/exception/ActionItemDoesNotExistException.java
+++ b/api/src/main/java/com/ford/labs/retroquest/exception/ActionItemDoesNotExistException.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022. Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.exception;
+
+public class ActionItemDoesNotExistException extends RuntimeException{
+}

--- a/api/src/main/java/com/ford/labs/retroquest/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/ford/labs/retroquest/exception/GlobalExceptionHandler.java
@@ -92,4 +92,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(thoughtNotFoundException.getMessage());
     }
 
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
+    @ExceptionHandler(ActionItemDoesNotExistException.class)
+    public void actionItemDoesNotExistExceptionHandler() {
+        // Used by Spring for Controller Advice
+    }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/security/TeamAuthorization.java
+++ b/api/src/main/java/com/ford/labs/retroquest/security/TeamAuthorization.java
@@ -22,9 +22,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @Service
-public class ApiAuthorization {
+public class TeamAuthorization {
 
-    public ApiAuthorization() {}
+    public TeamAuthorization() {}
 
     public boolean requestIsAuthorized(Authentication authentication, String teamId) {
         return Objects.nullSafeEquals(authentication.getPrincipal(), teamId);

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
@@ -72,7 +72,7 @@ public class TeamController {
     }
 
     @GetMapping(value = "/team/{teamId}/csv", produces = "application/board.csv")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "downloads a team board", description = "downloadTeamBoard")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public ResponseEntity<byte[]> downloadTeamBoard(@PathVariable("teamId") String teamId) throws IOException {
@@ -84,7 +84,7 @@ public class TeamController {
     }
 
     @GetMapping(value = "team/{teamId}/validate")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Validates a team id", description = "deprecated")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public ResponseEntity<Void> validateTeamId(@PathVariable("teamId") String teamId) {

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtController.java
@@ -46,6 +46,30 @@ public class ThoughtController {
         this.thoughtService = thoughtService;
     }
 
+    @PostMapping("/api/team/{teamId}/thought")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @Operation(summary = "Creates a thought given a team id and thought", description = "createThoughtForTeam")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Created"),
+            @ApiResponse(responseCode = "400", description = "Path to saved thought is not a valid URI")
+    })
+    public ResponseEntity<Void> createThoughtForTeam(
+            @PathVariable("teamId") String teamId,
+            @RequestBody CreateThoughtRequest request
+    ) throws URISyntaxException {
+        var thought = thoughtService.createThought(teamId, request);
+        var uri = new URI(String.format("/api/team/%s/thought/%s", thought.getTeamId(), thought.getId()));
+        return ResponseEntity.created(uri).build();
+    }
+
+    @GetMapping("/api/team/{teamId}/thoughts")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @Operation(summary = "Returns all thoughts given a team id", description = "getThoughtsForTeam")
+    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "OK") })
+    public List<Thought> getThoughtsForTeam(@PathVariable("teamId") String teamId) {
+        return thoughtService.fetchAllActiveThoughts(teamId);
+    }
+
     @Transactional
     @PutMapping("/api/team/{teamId}/thought/{thoughtId}/heart")
     @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
@@ -93,14 +117,6 @@ public class ThoughtController {
         thoughtService.updateThoughtMessage(teamId, id, request.message());
     }
 
-    @GetMapping("/api/team/{teamId}/thoughts")
-    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @Operation(summary = "Returns all thoughts given a team id", description = "getThoughtsForTeam")
-    @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "OK") })
-    public List<Thought> getThoughtsForTeam(@PathVariable("teamId") String teamId) {
-        return thoughtService.fetchAllActiveThoughts(teamId);
-    }
-
     @Transactional
     @DeleteMapping("/api/team/{teamId}/thought/{thoughtId}")
     @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
@@ -108,21 +124,5 @@ public class ThoughtController {
     @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "OK") })
     public void clearIndividualThoughtForTeam(@PathVariable("teamId") String teamId, @PathVariable("thoughtId") Long id) {
         thoughtService.deleteThought(teamId, id);
-    }
-
-    @PostMapping("/api/team/{teamId}/thought")
-    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
-    @Operation(summary = "Creates a thought given a team id and thought", description = "createThoughtForTeam")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = "Created"),
-        @ApiResponse(responseCode = "400", description = "Path to saved thought is not a valid URI")
-    })
-    public ResponseEntity<Void> createThoughtForTeam(
-        @PathVariable("teamId") String teamId,
-        @RequestBody CreateThoughtRequest request
-    ) throws URISyntaxException {
-        var thought = thoughtService.createThought(teamId, request);
-        var uri = new URI(String.format("/api/team/%s/thought/%s", thought.getTeamId(), thought.getId()));
-        return ResponseEntity.created(uri).build();
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtController.java
@@ -48,7 +48,7 @@ public class ThoughtController {
 
     @Transactional
     @PutMapping("/api/team/{teamId}/thought/{thoughtId}/heart")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "adds a like to a thought given a thought and team id", description = "likeThought")
     @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Created") })
     public void likeThought(@PathVariable("thoughtId") Long thoughtId, @PathVariable("teamId") String teamId) {
@@ -56,7 +56,7 @@ public class ThoughtController {
     }
 
     @PutMapping("/api/team/{teamId}/thought/{thoughtId}/discuss")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "toggles between a thought being discussed or not discussed", description = "discussThought")
     @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "OK") })
     public void discussThought(
@@ -69,7 +69,7 @@ public class ThoughtController {
 
     @Transactional
     @PutMapping("/api/team/{teamId}/thought/{thoughtId}/column-id")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Updates the topic of a thought given a thought and team id", description = "moveThought")
     @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "OK") })
     public void moveThought(
@@ -82,7 +82,7 @@ public class ThoughtController {
 
     @Transactional
     @PutMapping("/api/team/{teamId}/thought/{id}/message")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(
         summary = "Updates the content of a thought given a thought and team id",
         description = "updateThoughtMessage"
@@ -94,7 +94,7 @@ public class ThoughtController {
     }
 
     @GetMapping("/api/team/{teamId}/thoughts")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Returns all thoughts given a team id", description = "getThoughtsForTeam")
     @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "OK") })
     public List<Thought> getThoughtsForTeam(@PathVariable("teamId") String teamId) {
@@ -103,7 +103,7 @@ public class ThoughtController {
 
     @Transactional
     @DeleteMapping("/api/team/{teamId}/thought/{thoughtId}")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Removes a thought given a team id and thought id", description = "clearIndividualThoughtForTeam")
     @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "OK") })
     public void clearIndividualThoughtForTeam(@PathVariable("teamId") String teamId, @PathVariable("thoughtId") Long id) {
@@ -111,7 +111,7 @@ public class ThoughtController {
     }
 
     @PostMapping("/api/team/{teamId}/thought")
-    @PreAuthorize("@apiAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "Creates a thought given a team id and thought", description = "createThoughtForTeam")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "Created"),

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtController.java
@@ -52,7 +52,7 @@ public class ThoughtController {
     @Operation(summary = "adds a like to a thought given a thought and team id", description = "likeThought")
     @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Created") })
     public void likeThought(@PathVariable("thoughtId") Long thoughtId, @PathVariable("teamId") String teamId) {
-        thoughtService.likeThought(thoughtId);
+        thoughtService.likeThought(teamId, thoughtId);
     }
 
     @PutMapping("/api/team/{teamId}/thought/{thoughtId}/discuss")
@@ -64,7 +64,7 @@ public class ThoughtController {
         @PathVariable("teamId") String teamId,
         @RequestBody UpdateThoughtDiscussedRequest request
     ) {
-        thoughtService.discussThought(thoughtId, request.discussed());
+        thoughtService.discussThought(teamId, thoughtId, request.discussed());
     }
 
     @Transactional
@@ -77,7 +77,7 @@ public class ThoughtController {
         @PathVariable Long thoughtId,
         @RequestBody MoveThoughtRequest request
     ) {
-        thoughtService.updateColumn(thoughtId, request.columnId());
+        thoughtService.updateColumn(teamId, thoughtId, request.columnId());
     }
 
     @Transactional
@@ -90,7 +90,7 @@ public class ThoughtController {
     @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "OK") })
     public void updateThoughtMessage(@PathVariable("id") Long id, @RequestBody UpdateThoughtMessageRequest request,
                                      @PathVariable("teamId") String teamId) {
-        thoughtService.updateThoughtMessage(id, request.message());
+        thoughtService.updateThoughtMessage(teamId, id, request.message());
     }
 
     @GetMapping("/api/team/{teamId}/thoughts")

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtRepository.java
@@ -24,16 +24,16 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ThoughtRepository extends JpaRepository<Thought, Long> {
     List<Thought> findAllByTeamId(String teamId);
-
     List<Thought> findAllByTeamIdAndBoardIdIsNull(String teamId);
-
     List<Thought> findAllByTeamIdAndBoardIdIsNullOrderByTopic(String teamId);
 
     void deleteThoughtByTeamIdAndId(String teamId, Long id);
+    Optional<Thought> findByTeamIdAndId(String teamId, Long id);
 
     @Modifying
     @Query("UPDATE Thought thought set thought.hearts = thought.hearts + 1 where thought.id = :thoughtId")

--- a/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/thought/ThoughtService.java
@@ -65,7 +65,7 @@ public class ThoughtService {
     }
 
     public Thought updateColumn(String teamId, Long thoughtId, long columnId) {
-        var columnTitle = columnTitleRepository.findById(columnId).orElseThrow(ColumnTitleNotFoundException::new);
+        var columnTitle = columnTitleRepository.findByTeamIdAndId(teamId, columnId).orElseThrow(ColumnTitleNotFoundException::new);
         var thought = fetchThought(teamId, thoughtId);
         thought.setTopic(columnTitle.getTopic());
         var savedThought = thoughtRepository.save(thought);

--- a/api/src/test/java/com/ford/labs/retroquest/actionitem/ActionItemServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/actionitem/ActionItemServiceTest.java
@@ -17,6 +17,7 @@
 
 package com.ford.labs.retroquest.actionitem;
 
+import com.ford.labs.retroquest.websocket.WebsocketService;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -25,7 +26,8 @@ import static org.mockito.Mockito.*;
 
 class ActionItemServiceTest {
     private final ActionItemRepository mockActionItemRepository = mock(ActionItemRepository.class);
-    private final ActionItemService actionItemService = new ActionItemService(mockActionItemRepository);
+    private final WebsocketService mockWebsocketService = mock(WebsocketService.class);
+    private final ActionItemService actionItemService = new ActionItemService(mockActionItemRepository, mockWebsocketService);
 
     @Test
     public void archiveCompletedActionItems_MarksCompletedButUnarchivedActionItemsAsArchived() {

--- a/api/src/test/java/com/ford/labs/retroquest/api/ActionItemApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ActionItemApiTest.java
@@ -161,6 +161,24 @@ class ActionItemApiTest extends ApiTestBase {
     }
 
     @Test
+    public void deleteActionItem_WhenActionItemOnOtherTeam_IgnoresDelete() throws Exception {
+        String unauthorizedTeamJwt = jwtBuilder.buildJwt("not-beach-bums");
+        String authorizationHeader = format("Bearer %s", unauthorizedTeamJwt);
+
+        ActionItem savedActionItem = actionItemRepository.save(ActionItem.builder()
+                .task("Some Action")
+                .teamId("beach-bums")
+                .build());
+
+        mockMvc.perform(delete("/api/team/not-beach-bums/action-item/%d".formatted(savedActionItem.getId()))
+                .header("Authorization", authorizationHeader))
+                .andExpect(status().isOk());
+
+        assertThat(actionItemRepository.count()).isEqualTo(1);
+        assertThat(savedActionItem).isEqualTo(actionItemRepository.findAll().get(0));
+    }
+
+    @Test
     void should_edit_action_item_task() throws Exception {
         ActionItem expectedActionItem = actionItemRepository.save(ActionItem.builder()
             .task("I AM A TEMPORARY TASK")
@@ -206,7 +224,7 @@ class ActionItemApiTest extends ApiTestBase {
     }
 
     @Test
-    public void should_archive_action_item() throws Exception{
+    public void should_archive_action_item() throws Exception {
         var request = new UpdateActionItemArchivedRequest(true);
         ActionItem actionItem = actionItemRepository.save(ActionItem.builder()
                 .task(teamId)

--- a/api/src/test/java/com/ford/labs/retroquest/api/ColumnApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ColumnApiTest.java
@@ -114,4 +114,21 @@ public class ColumnApiTest extends ApiTestBase {
                 .header("Authorization", getBearerAuthToken()))
                 .andExpect(status().isNotFound());
     }
+
+    @Test
+    public void updateColumnTitle_WithColumnIdFromOtherTeam_ReturnsNotFound() throws Exception {
+        var savedColumnTitle = columnTitleRepository.save(ColumnTitle.builder()
+                .teamId("NotBeachBums")
+                .title("old title")
+                .build());
+        var expectedColumnTitle = new ColumnTitle(savedColumnTitle.getId(), null, "new title", "BeachBums");
+
+        var request = new UpdateColumnTitleRequest("new title");
+
+        mockMvc.perform(put("/api/team/BeachBums/column/%d/title".formatted(expectedColumnTitle.getId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(request))
+                .header("Authorization", getBearerAuthToken()))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/column/ColumnServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/column/ColumnServiceTest.java
@@ -62,7 +62,7 @@ class ColumnServiceTest {
         var expectedEvent = new WebsocketColumnTitleEvent(teamId, WebsocketEventType.UPDATE, expectedColumn);
         var mockedCounter = mock(Counter.class);
 
-        when(columnTitleRepository.findById(columnId)).thenReturn(Optional.of(savedColumn));
+        when(columnTitleRepository.findByTeamIdAndId(teamId, columnId)).thenReturn(Optional.of(savedColumn));
         when(columnTitleRepository.save(expectedColumn)).thenReturn(expectedColumn);
         when(meterRegistry.counter("retroquest.columns.changed.count")).thenReturn(mockedCounter);
 

--- a/api/src/test/java/com/ford/labs/retroquest/column/ColumnServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/column/ColumnServiceTest.java
@@ -75,11 +75,23 @@ class ColumnServiceTest {
 
     @Test
     void throws_column_title_not_found_exception_when_column_title_not_in_db() {
-        var columnId = 42L;
-        when(columnTitleRepository.findById(columnId)).thenReturn(Optional.empty());
-
         assertThatThrownBy(() ->
-                service.editColumnTitleName(columnId, "some name", "some team id")
+                service.editColumnTitleName(42L, "some name", "some team id")
+        ).isInstanceOf(ColumnTitleNotFoundException.class);
+    }
+
+    @Test
+    public void fetchColumnTitle() {
+        var expected = new ColumnTitle(42L, "topic", "title", "teamId");
+        when(columnTitleRepository.findByTeamIdAndId("teamId", 42L)).thenReturn(Optional.of(expected));
+        var actual = service.fetchColumnTitle("teamId", 42L);
+        assertThat(actual).usingRecursiveComparison().isEqualTo(actual);
+    }
+
+    @Test
+    public void fetchColumnTitle_WithMissingColumnTitle_ThrowsColumnNotFoundException() {
+        assertThatThrownBy(() ->
+                service.fetchColumnTitle("some team id", 42L)
         ).isInstanceOf(ColumnTitleNotFoundException.class);
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/security/TeamAuthorizationTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/security/TeamAuthorizationTest.java
@@ -24,21 +24,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-class ApiAuthorizationTest {
+class TeamAuthorizationTest {
 
     private final Authentication authentication = mock(Authentication.class);
-    private final ApiAuthorization apiAuthorization = new ApiAuthorization();
+    private final TeamAuthorization teamAuthorization = new TeamAuthorization();
 
     @Test
     void requestIsAuthorized_WithMatchingPrincipal_ReturnsTrue() {
         given(authentication.getPrincipal()).willReturn("teamId");
-        assertThat(apiAuthorization.requestIsAuthorized(authentication, "teamId")).isTrue();
+        assertThat(teamAuthorization.requestIsAuthorized(authentication, "teamId")).isTrue();
     }
 
     @Test
     void requestIsAuthorized_WithoutMatchingPrincipal_ReturnsFalse() {
         given(authentication.getPrincipal()).willReturn("notAuthorized");
-        assertThat(apiAuthorization.requestIsAuthorized(authentication, "teamId")).isFalse();
+        assertThat(teamAuthorization.requestIsAuthorized(authentication, "teamId")).isFalse();
     }
 
 }

--- a/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/thought/ThoughtServiceTest.java
@@ -21,8 +21,8 @@ import com.ford.labs.retroquest.column.ColumnTitle;
 import com.ford.labs.retroquest.column.ColumnTitleRepository;
 import com.ford.labs.retroquest.exception.ColumnTitleNotFoundException;
 import com.ford.labs.retroquest.exception.ThoughtNotFoundException;
-import com.ford.labs.retroquest.websocket.events.WebsocketEvent;
 import com.ford.labs.retroquest.websocket.WebsocketService;
+import com.ford.labs.retroquest.websocket.events.WebsocketEvent;
 import com.ford.labs.retroquest.websocket.events.WebsocketThoughtEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -110,7 +110,7 @@ class ThoughtServiceTest {
         Thought expectedThought = Thought.builder().id(1234L).topic(newTopic).build();
         given(this.thoughtRepository.findByTeamIdAndId(teamId, 1234L)).willReturn(Optional.of(thought));
         given(this.thoughtRepository.save(expectedThought)).willReturn(expectedThought);
-        given(this.columnTitleRepository.findById(6789L)).willReturn(Optional.of(expectedColumnTitle));
+        given(this.columnTitleRepository.findByTeamIdAndId(teamId, 6789L)).willReturn(Optional.of(expectedColumnTitle));
 
         Thought actualThought = thoughtService.updateColumn(teamId, 1234L, 6789L);
 
@@ -126,7 +126,7 @@ class ThoughtServiceTest {
         Thought expectedThought = Thought.builder().id(1234L).topic(newTopic).build();
         given(this.thoughtRepository.findByTeamIdAndId(teamId, 1234L)).willReturn(Optional.of(thought));
         given(this.thoughtRepository.save(expectedThought)).willReturn(expectedThought);
-        given(this.columnTitleRepository.findById(6789L)).willReturn(Optional.of(expectedColumnTitle));
+        given(this.columnTitleRepository.findByTeamIdAndId(teamId, 6789L)).willReturn(Optional.of(expectedColumnTitle));
 
         thoughtService.updateColumn(teamId, 1234L, 6789L);
 


### PR DESCRIPTION
## Overview
Our security implementation stopped after checking that your token contains the same teamId that's in the API route. We've updated all additional points on a team to require the teamId when searching the repository, which should fill the hole.

## Testing Instructions
How to test this PR

Given you have a valid token for `team-one`, if you request to update an action item/thought/column on another team you should get back a 404.
```/api/team/team-one/thought/id-of-thought-on-other-team/heart -> 404```