### PR TITLE
Fix sort ignoring discussed status

### DIFF
--- a/ui/src/App/Team/Retro/ThoughtColumn/ThoughtColumn.spec.tsx
+++ b/ui/src/App/Team/Retro/ThoughtColumn/ThoughtColumn.spec.tsx
@@ -159,8 +159,8 @@ const confirmThoughtsAreInOriginalOrder = () => {
 const confirmThoughtsAreInSortedOrder = () => {
 	const thoughtItems = screen.getAllByTestId('retroItem');
 	expect(thoughtItems).toHaveLength(4);
-	expect(within(thoughtItems[0]).getByText('4')).toBeDefined();
-	expect(within(thoughtItems[1]).getByText('3')).toBeDefined();
-	expect(within(thoughtItems[2]).getByText('2')).toBeDefined();
-	expect(within(thoughtItems[3]).getByText('1')).toBeDefined();
+	expect(within(thoughtItems[0]).getByText('2')).toBeDefined();
+	expect(within(thoughtItems[1]).getByText('1')).toBeDefined();
+	expect(within(thoughtItems[2]).getByText('4')).toBeDefined();
+	expect(within(thoughtItems[3]).getByText('3')).toBeDefined();
 };

--- a/ui/src/State/ThoughtState.spec.ts
+++ b/ui/src/State/ThoughtState.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022. Ford Motor Company
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { snapshot_UNSTABLE } from 'recoil';
+
+import Thought from '../Types/Thought';
+import Topic from '../Types/Topic';
+
+import {
+	ActiveThoughtCountByTopicState,
+	SortableThoughtsByTopicState,
+	ThoughtByIdState,
+	ThoughtsByTopicState,
+	ThoughtsState,
+} from './ThoughtsState';
+
+describe('Thought State', () => {
+	const happyThought1 = {
+		id: 1,
+		hearts: 1,
+		topic: Topic.HAPPY,
+		discussed: true,
+	};
+	const happyThought2 = {
+		id: 2,
+		hearts: 2,
+		topic: Topic.HAPPY,
+		discussed: false,
+	};
+	const happyThought3 = {
+		id: 3,
+		hearts: 3,
+		topic: Topic.HAPPY,
+		discussed: false,
+	};
+	const happyThought4 = {
+		id: 4,
+		hearts: 4,
+		topic: Topic.HAPPY,
+		discussed: true,
+	};
+	const confusedThought1 = {
+		id: 5,
+		hearts: 5,
+		topic: Topic.CONFUSED,
+		discussed: true,
+	};
+	const sadThought1 = {
+		id: 6,
+		hearts: 6,
+		topic: Topic.UNHAPPY,
+		discussed: true,
+	};
+	const thoughts = [
+		happyThought1,
+		happyThought2,
+		happyThought3,
+		happyThought4,
+		confusedThought1,
+		sadThought1,
+	] as Thought[];
+
+	const initialSnapshot = snapshot_UNSTABLE(({ set }) =>
+		set(ThoughtsState, thoughts)
+	);
+
+	describe('ThoughtByIdState', () => {
+		it('should return a thought with the same ID', () => {
+			const actual = initialSnapshot
+				.getLoadable(ThoughtByIdState(2))
+				.valueOrThrow();
+			expect(actual).toEqual(happyThought2);
+		});
+
+		it('should return null if no thought matching ID', () => {
+			const actual = initialSnapshot
+				.getLoadable(ThoughtByIdState(-1))
+				.valueOrThrow();
+			expect(actual).toBeNull();
+		});
+	});
+
+	describe('ThoughtsByTopicState', () => {
+		it('should return thoughts with the same topic', () => {
+			const actual = initialSnapshot
+				.getLoadable(ThoughtsByTopicState(Topic.HAPPY))
+				.valueOrThrow();
+			expect(actual).toEqual([
+				happyThought1,
+				happyThought2,
+				happyThought3,
+				happyThought4,
+			]);
+		});
+	});
+
+	describe('SortableThoughtsByTopicState', () => {
+		it('should return thoughts grouped by discussed', () => {
+			const actual = initialSnapshot
+				.getLoadable(
+					SortableThoughtsByTopicState({ topic: Topic.HAPPY, sorted: false })
+				)
+				.valueOrThrow();
+			expect(actual).toEqual([
+				happyThought2,
+				happyThought3,
+				happyThought1,
+				happyThought4,
+			]);
+		});
+
+		it('should return thoughts sorted by like and then group them by discussed', () => {
+			const actual = initialSnapshot
+				.getLoadable(
+					SortableThoughtsByTopicState({ topic: Topic.HAPPY, sorted: true })
+				)
+				.valueOrThrow();
+			expect(actual).toEqual([
+				happyThought3,
+				happyThought2,
+				happyThought4,
+				happyThought1,
+			]);
+		});
+	});
+
+	describe('ActiveThoughtCountByTopicState', () => {
+		it('should return number of non discussed thoughts per column', () => {
+			const actual = initialSnapshot
+				.getLoadable(ActiveThoughtCountByTopicState(Topic.HAPPY))
+				.valueOrThrow();
+			expect(actual).toEqual(2);
+		});
+	});
+});

--- a/ui/src/State/ThoughtsState.ts
+++ b/ui/src/State/ThoughtsState.ts
@@ -64,14 +64,14 @@ export const SortableThoughtsByTopicState = atomFamily<
 		get:
 			(params: ThoughtFilterParams) =>
 			({ get }) => {
-				const thoughts = get(ThoughtsByTopicState(params.topic));
-				const sortedByIfDiscussed = [...thoughts].sort((a, b) => {
+				let thoughts = get(ThoughtsByTopicState(params.topic));
+				if (params.sorted) {
+					thoughts = [...thoughts].sort((a, b) => b.hearts - a.hearts);
+				}
+				return [...thoughts].sort((a, b) => {
 					if (a.discussed === b.discussed) return 0;
 					return a.discussed ? 1 : -1;
 				});
-				return params.sorted
-					? sortedByIfDiscussed.sort((a, b) => b.hearts - a.hearts)
-					: sortedByIfDiscussed;
 			},
 	}),
 });
@@ -83,9 +83,9 @@ export const ActiveThoughtCountByTopicState = atomFamily<number, ThoughtTopic>({
 		get:
 			(topic: ThoughtTopic) =>
 			({ get }) => {
-				return get(ThoughtsState)
-					.filter((thought) => thought.topic === topic)
-					.filter((thought) => !thought.discussed).length;
+				return get(ThoughtsByTopicState(topic)).filter(
+					(thought) => !thought.discussed
+				).length;
 			},
 	}),
 });


### PR DESCRIPTION
## Overview
Fix the sorting logic in the ThoughtState file to sort by stars first and then by discussion status to group them afterwards.

Connects #419 

### Demo
<img width="351" alt="Screen Shot 2022-04-07 at 4 05 03 PM" src="https://user-images.githubusercontent.com/37785108/162287022-75a098c2-8eba-408c-b44b-d5cdb44c876b.png">

### Notes
Also adds test file for ThoughtState to demo how to test Recoil Atoms

## Testing Instructions
* Add three thoughts
* Add stars as desired
* Mark one or two as discussed
* Click sort
* See that the discussed thoughts are below the undiscussed thoughts and both are sorted by number of stars descending