### PR TITLE
Ensure thought is fully expanded in modal view

### DIFF
--- a/ui/src/Common/ColumnItem/EditableText/EditableText.tsx
+++ b/ui/src/Common/ColumnItem/EditableText/EditableText.tsx
@@ -61,11 +61,7 @@ function EditableText(props: EditableTextProps) {
 
 	useEffect(() => {
 		resizeTextArea();
-	}, [value]);
-
-	useEffect(() => {
-		resizeTextArea();
-	}, [editValue]);
+	}, [value, editValue, textAreaRef?.current?.scrollHeight]);
 
 	useEffect(() => {
 		if (editing) {


### PR DESCRIPTION
## Overview
Ensure thought item is fully expanded and does not have scrollbar when in modal

This PR fixes this issue where the thought item isn't fully expanded and has a scroll bar.
<img width="874" alt="Screen Shot 2022-04-07 at 4 46 55 PM" src="https://user-images.githubusercontent.com/17144844/162297288-a6e87ce1-f8f2-4530-8b90-e60266a40e61.png">


## Testing Instructions
1) Create a thought item with a ton of text.
2) Click on the thought so it opens in the modal.
3) Ensure that it is fully expanded and has no scroll bar in the modal.