### PR TITLE
Allow shift+enter to add a new line in thought and action item task fields

### DIFF
--- a/ui/src/Common/Textarea/Textarea.spec.tsx
+++ b/ui/src/Common/Textarea/Textarea.spec.tsx
@@ -81,6 +81,17 @@ describe('Textarea', () => {
 			)
 		);
 	});
+
+	it('should trim value if user leaves whitespace before or after typing', async () => {
+		userEvent.type(getTextarea(), '      Word!  Another Word!      {enter}');
+
+		await waitFor(() =>
+			expect(mockOnEnter).toHaveBeenCalledWith(
+				'Word!  Another Word!',
+				expect.anything()
+			)
+		);
+	});
 });
 
 function getTextarea() {

--- a/ui/src/Common/Textarea/Textarea.spec.tsx
+++ b/ui/src/Common/Textarea/Textarea.spec.tsx
@@ -45,7 +45,7 @@ describe('Textarea', () => {
 		expect(getTextarea()).toHaveValue(mockInitialValue);
 	});
 
-	it('should auto focus and auto select textarea', () => {
+	it('should auto focus on textarea', () => {
 		expect(getTextarea()).toHaveFocus();
 	});
 
@@ -64,8 +64,15 @@ describe('Textarea', () => {
 		expect(mockOnChange).toHaveBeenCalledWith('Hey!');
 	});
 
+	it('should enter a new line when user clicks shift + enter', () => {
+		const textarea = getTextarea();
+		userEvent.type(textarea, 'Hello there!{shift}{enter}New line.');
+		expect(textarea).toHaveValue(`Hello there!\nNew line.`);
+		expect(mockOnEnter).not.toHaveBeenCalled();
+	});
+
 	it('should trigger onEnter when user types and clicks enter', async () => {
-		userEvent.type(getTextarea(), 'Hello there!{Enter}');
+		userEvent.type(getTextarea(), 'Hello there!{enter}');
 
 		await waitFor(() =>
 			expect(mockOnEnter).toHaveBeenCalledWith(

--- a/ui/src/Common/Textarea/Textarea.tsx
+++ b/ui/src/Common/Textarea/Textarea.tsx
@@ -60,6 +60,9 @@ function Textarea(props: Props) {
 			textArea.style.height = textArea.scrollHeight + 'px';
 		}
 	}
+	function onKeypressEnter(event: KeyboardEvent<HTMLTextAreaElement>) {
+		if (!event.shiftKey) onEnter(editValue, event);
+	}
 
 	return (
 		<div className={classnames('text-area', className)}>
@@ -73,7 +76,7 @@ function Textarea(props: Props) {
 					setEditValue(event.target.value);
 					onChange(event.target.value);
 				}}
-				onKeyDown={onKeys('Enter', (event) => onEnter(editValue, event))}
+				onKeyDown={onKeys('Enter', onKeypressEnter)}
 				maxLength={MAX_LENGTH}
 			/>
 			<FloatingCharacterCountdown

--- a/ui/src/Common/Textarea/Textarea.tsx
+++ b/ui/src/Common/Textarea/Textarea.tsx
@@ -61,7 +61,7 @@ function Textarea(props: Props) {
 		}
 	}
 	function onKeypressEnter(event: KeyboardEvent<HTMLTextAreaElement>) {
-		if (!event.shiftKey) onEnter(editValue, event);
+		if (!event.shiftKey) onEnter(editValue.trim(), event);
 	}
 
 	return (


### PR DESCRIPTION
## Overview
The ability to add new lines in the thought and action item text fields was accidentally removed when rewriting the app in react. This PR adds that feature back in.

### Notes
- [x] Allow shift+enter to add a new line in thought and action item task fields
- [x] Trim white space from text when submitting thought or action item task 

## Testing Instructions
1) Try to type into a thought or action item task and press shift+enter. Ensure this allows you to add a new line and keep typing vs submitting the text.
2) Try to type into a thought or action item task and add white space before and after your text. Press enter and ensure that the white space before and after your text has been removed.