### PR TITLE
Rename TextField to CreateColumnItemInput

### DIFF
--- a/ui/src/App/Team/Retro/ActionItemsColumn/ActionItemsColumn.tsx
+++ b/ui/src/App/Team/Retro/ActionItemsColumn/ActionItemsColumn.tsx
@@ -20,7 +20,7 @@ import { useRecoilValue } from 'recoil';
 
 import ColumnHeader from '../../../../Common/ColumnHeader/ColumnHeader';
 import CountSeparator from '../../../../Common/CountSeparator/CountSeparator';
-import TextField from '../../../../Common/TextField/TextField';
+import CreateColumnItemInput from '../../../../Common/CreateColumnItemInput/CreateColumnItemInput';
 import ActionItemService from '../../../../Services/Api/ActionItemService';
 import {
 	ActiveActionItemsState,
@@ -74,7 +74,7 @@ function ActionItemsColumn() {
 	return (
 		<div className="action-items-column" data-testid={`retroColumn__${topic}`}>
 			<ColumnHeader initialTitle="Action Items" type={topic} />
-			<TextField
+			<CreateColumnItemInput
 				type={topic}
 				placeholder="Enter an Action Item"
 				handleSubmission={createActionItem}

--- a/ui/src/App/Team/Retro/ThoughtsColumn/ThoughtsColumn.tsx
+++ b/ui/src/App/Team/Retro/ThoughtsColumn/ThoughtsColumn.tsx
@@ -21,7 +21,7 @@ import { useRecoilValue } from 'recoil';
 
 import ColumnHeader from '../../../../Common/ColumnHeader/ColumnHeader';
 import CountSeparator from '../../../../Common/CountSeparator/CountSeparator';
-import TextField from '../../../../Common/TextField/TextField';
+import CreateColumnItemInput from '../../../../Common/CreateColumnItemInput/CreateColumnItemInput';
 import ColumnService from '../../../../Services/Api/ColumnService';
 import ThoughtService from '../../../../Services/Api/ThoughtService';
 import { TeamState } from '../../../../State/TeamState';
@@ -76,7 +76,7 @@ function ThoughtsColumn(props: Props) {
 				sortedChanged={setSorted}
 				titleChanged={changeTitle}
 			/>
-			<TextField
+			<CreateColumnItemInput
 				type={column.topic}
 				placeholder="Enter a Thought"
 				handleSubmission={createThought}

--- a/ui/src/Common/CreateColumnItemInput/CreateColumnItemInput.scss
+++ b/ui/src/Common/CreateColumnItemInput/CreateColumnItemInput.scss
@@ -1,5 +1,5 @@
-/*!
- * Copyright (c) 2021 Ford Motor Company
+/*
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 @use '../../Styles/main';
 
-.text-field {
+.create-column-item-input {
 	display: block;
 	width: 100%;
 	height: 50px;
@@ -33,7 +33,7 @@
 		}
 	}
 
-	.text-input {
+	.input-field {
 		display: block;
 		width: inherit;
 
@@ -55,50 +55,50 @@
 		&::placeholder {
 			color: rgba(main.$asphalt, 0.4);
 		}
-	}
 
-	&.happy input {
-		border-color: main.$green;
-	}
+		&.happy {
+			border-color: main.$green;
+		}
 
-	&.confused input {
-		border-color: main.$blue;
-	}
+		&.confused {
+			border-color: main.$blue;
+		}
 
-	&.unhappy input {
-		border-color: main.$red;
-	}
+		&.unhappy {
+			border-color: main.$red;
+		}
 
-	&.action input {
-		border-color: main.$yellow;
+		&.action {
+			border-color: main.$yellow;
+		}
 	}
 }
 
 @include main.dark-theme {
-	.text-field {
-		.text-input {
+	.create-column-item-input {
+		.input-field {
 			color: main.$gray;
 			background-color: main.$text-field-background-color;
 
 			&::placeholder {
 				color: rgba(main.$gray, 0.4);
 			}
-		}
 
-		&.happy .text-input {
-			border-color: main.$dark-green;
-		}
+			&.happy {
+				border-color: main.$dark-green;
+			}
 
-		&.confused .text-input {
-			border-color: main.$belize-hole;
-		}
+			&.confused {
+				border-color: main.$belize-hole;
+			}
 
-		&.unhappy .text-input {
-			border-color: main.$dark-red;
-		}
+			&.unhappy {
+				border-color: main.$dark-red;
+			}
 
-		&.action .text-input {
-			border-color: main.$dark-yellow;
+			&.action {
+				border-color: main.$dark-yellow;
+			}
 		}
 	}
 }

--- a/ui/src/Common/CreateColumnItemInput/CreateColumnItemInput.spec.tsx
+++ b/ui/src/Common/CreateColumnItemInput/CreateColumnItemInput.spec.tsx
@@ -22,9 +22,9 @@ import { axe } from 'jest-axe';
 
 import Topic from '../../Types/Topic';
 
-import TextField from './TextField';
+import CreateColumnItemInput from './CreateColumnItemInput';
 
-describe('TextField', () => {
+describe('Create Column Item Input', () => {
 	const mockHandleSubmit = jest.fn();
 	const placeholder = 'Enter A Thought';
 
@@ -34,7 +34,7 @@ describe('TextField', () => {
 
 	it('should render without axe errors', async () => {
 		const { container } = render(
-			<TextField
+			<CreateColumnItemInput
 				data-testid="happy"
 				type={Topic.HAPPY}
 				placeholder={placeholder}
@@ -47,48 +47,43 @@ describe('TextField', () => {
 
 	it('should style based on type', () => {
 		const { rerender } = render(
-			<TextField
-				data-testid="happy"
+			<CreateColumnItemInput
 				type={Topic.HAPPY}
 				placeholder={placeholder}
 				handleSubmission={mockHandleSubmit}
 			/>
 		);
-		expect(screen.getByTestId('happy').className).toContain('happy');
+		expect(screen.getByPlaceholderText(placeholder)).toHaveClass('happy');
 
 		rerender(
-			<TextField
-				data-testid="confused"
+			<CreateColumnItemInput
 				type={Topic.CONFUSED}
 				placeholder={placeholder}
 				handleSubmission={mockHandleSubmit}
 			/>
 		);
-		expect(screen.getByTestId('confused').className).toContain('confused');
+		expect(screen.getByPlaceholderText(placeholder)).toHaveClass('confused');
 
 		rerender(
-			<TextField
-				data-testid="unhappy"
+			<CreateColumnItemInput
 				type={Topic.UNHAPPY}
 				placeholder={placeholder}
 				handleSubmission={mockHandleSubmit}
 			/>
 		);
-		expect(screen.getByTestId('unhappy').className).toContain('unhappy');
+		expect(screen.getByPlaceholderText(placeholder)).toHaveClass('unhappy');
 	});
 
 	it('should submit on enter', () => {
 		render(
-			<TextField
+			<CreateColumnItemInput
 				type={Topic.HAPPY}
 				placeholder={placeholder}
 				handleSubmission={mockHandleSubmit}
 			/>
 		);
 		const textField = screen.getByPlaceholderText(placeholder);
-
 		userEvent.type(textField, 'Submission Text{enter}');
-
 		expect(mockHandleSubmit).toHaveBeenCalledWith('Submission Text');
 	});
 });

--- a/ui/src/Common/CreateColumnItemInput/CreateColumnItemInput.tsx
+++ b/ui/src/Common/CreateColumnItemInput/CreateColumnItemInput.tsx
@@ -15,47 +15,50 @@
  * limitations under the License.
  */
 
-import React, { HTMLAttributes, useState } from 'react';
+import React, { useState } from 'react';
 import classnames from 'classnames';
 
 import Topic from '../../Types/Topic';
 import { onKeys } from '../../Utils/EventUtils';
 import FloatingCharacterCountdown from '../FloatingCharacterCountdown/FloatingCharacterCountdown';
 
-import './TextField.scss';
+import './CreateColumnItemInput.scss';
 
-export interface TextFieldProps extends HTMLAttributes<HTMLSpanElement> {
+interface Props {
 	type: Topic;
 	placeholder: string;
 	handleSubmission: (string: string) => void;
 }
 
-const maxCharacterCount = 255;
+const MAX_CHARACTER_COUNT = 255;
 
-export default function TextField(props: TextFieldProps): JSX.Element {
+function CreateColumnItemInput(props: Props): JSX.Element {
 	const { placeholder, type, handleSubmission, ...labelProps } = props;
 
-	const [text, setText] = useState('');
+	const [value, setValue] = useState('');
 
 	return (
-		<label {...labelProps} className={classnames('text-field', type)}>
+		<label {...labelProps} className="create-column-item-input">
 			<input
 				type="text"
-				className="text-input"
+				data-testid="createColumnItemInputField"
+				className={classnames('input-field', type)}
 				placeholder={placeholder}
-				maxLength={maxCharacterCount}
-				value={text}
-				onChange={(event) => setText(event.target.value)}
+				maxLength={MAX_CHARACTER_COUNT}
+				value={value}
+				onChange={(event) => setValue(event.target.value)}
 				onKeyPress={onKeys('Enter', () => {
-					handleSubmission(text);
-					setText('');
+					handleSubmission(value);
+					setValue('');
 				})}
 			/>
 			<FloatingCharacterCountdown
-				maxCharacterCount={maxCharacterCount}
+				maxCharacterCount={MAX_CHARACTER_COUNT}
 				charsAreRunningOutThreshold={50}
-				characterCount={text.length}
+				characterCount={value.length}
 			/>
 		</label>
 	);
 }
+
+export default CreateColumnItemInput;

--- a/ui/src/Stories/CreateColumnItemInput.tsx
+++ b/ui/src/Stories/CreateColumnItemInput.tsx
@@ -18,13 +18,13 @@
 import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import TextField from '../Common/TextField/TextField';
+import CreateColumnItemInput from '../Common/CreateColumnItemInput/CreateColumnItemInput';
 import Topic from '../Types/Topic';
 
 export default {
-	title: 'components/TextField',
-	component: TextField,
-} as ComponentMeta<typeof TextField>;
+	title: 'components/CreateColumnItemInput',
+	component: CreateColumnItemInput,
+} as ComponentMeta<typeof CreateColumnItemInput>;
 
 const props = {
 	placeholder: 'Enter A Thought',
@@ -33,7 +33,7 @@ const props = {
 	},
 };
 
-const Template: ComponentStory<typeof TextField> = () => (
+const Template: ComponentStory<typeof CreateColumnItemInput> = () => (
 	<span
 		style={{
 			display: 'flex',
@@ -42,10 +42,10 @@ const Template: ComponentStory<typeof TextField> = () => (
 			maxWidth: '800px',
 		}}
 	>
-		<TextField {...props} type={Topic.HAPPY} />
-		<TextField {...props} type={Topic.CONFUSED} />
-		<TextField {...props} type={Topic.UNHAPPY} />
-		<TextField {...props} type={Topic.ACTION} />
+		<CreateColumnItemInput {...props} type={Topic.HAPPY} />
+		<CreateColumnItemInput {...props} type={Topic.CONFUSED} />
+		<CreateColumnItemInput {...props} type={Topic.UNHAPPY} />
+		<CreateColumnItemInput {...props} type={Topic.ACTION} />
 	</span>
 );
 


### PR DESCRIPTION
## Overview
Rename TextField to CreateColumnItemInput to better reflect what it is and so as to not be confused with other fields.

## Testing Instructions
* Nothing should have visually or functionally changed