### PR TITLE
Make feedback stars on feedback modal smaller on mobile screens

### DIFF
--- a/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackStars/FeedbackStars.scss
+++ b/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackStars/FeedbackStars.scss
@@ -18,10 +18,10 @@
 @use '../../../../../../Styles/main';
 
 .feedback-stars {
-	margin: -1rem 0;
+	margin: 0 0 1.5rem;
 
 	font-weight: 400;
-	font-size: 2.8rem;
+	font-size: 2rem;
 	text-align: center;
 
 	border: 0;
@@ -49,7 +49,7 @@
 
 		+ label::before {
 			display: inline-block;
-			width: 4rem;
+			width: 3rem;
 
 			color: main.$blue;
 			font-family: FontAwesome, serif;
@@ -57,6 +57,10 @@
 			cursor: pointer;
 
 			content: '\f006';
+
+			@include main.breakpoint-medium {
+				width: 4rem;
+			}
 		}
 
 		&.highlight + label::before,

--- a/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackStars/FeedbackStars.tsx
+++ b/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackStars/FeedbackStars.tsx
@@ -30,7 +30,7 @@ function FeedbackStars(props: FeedbackStarsProps) {
 	const [hoveredStarValue, setHoveredStarValue] = useState<number>(-1);
 
 	return (
-		<fieldset className={`feedback-stars`}>
+		<fieldset className="feedback-stars">
 			<div role="group" aria-labelledby="rate-retroquest">
 				<p id="rate-retroquest" className="hidden">
 					How would you rate your experience with retroquest?

--- a/ui/src/Styles/main.scss
+++ b/ui/src/Styles/main.scss
@@ -58,7 +58,8 @@ body {
 
 li,
 ol,
-ul {
+ul,
+fieldset {
 	margin: 0;
 	padding: 0;
 


### PR DESCRIPTION
## Overview
Make feedback stars on feedback modal smaller on mobile screens

### Demo
Mobile:
<img width="350" alt="Screen Shot 2022-04-13 at 10 12 38 AM" src="https://user-images.githubusercontent.com/17144844/163200156-f4cb0358-a5f3-4b68-aee6-252420e3204d.png">

Tablet/Desktop:
<img width="525" alt="Screen Shot 2022-04-13 at 10 12 50 AM" src="https://user-images.githubusercontent.com/17144844/163200167-9069e158-4ddb-4e25-b228-4f9ffc0c1cdc.png">


## Testing Instructions
* Open the feedback modal on a small mobile size screen and ensure the stars are small enough to not wrap around.
* Open the feedback modal on tablet or desktop and ensure the stars are larger and also do not wrap around.