### PR TITLE
Componentize ColumnHeader to make it more readable

### DIFF
--- a/ui/src/App/Team/Retro/ThoughtsColumn/ThoughtsColumn.tsx
+++ b/ui/src/App/Team/Retro/ThoughtsColumn/ThoughtsColumn.tsx
@@ -74,8 +74,8 @@ function ThoughtsColumn(props: Props) {
 			<ColumnHeader
 				initialTitle={column.title}
 				type={column.topic}
-				sortedChanged={setSorted}
-				titleChanged={changeTitle}
+				onSort={setSorted}
+				onTitleChange={changeTitle}
 			/>
 			<CreateColumnItemInput
 				type={column.topic}

--- a/ui/src/Common/ColumnHeader/ColumnHeader.scss
+++ b/ui/src/Common/ColumnHeader/ColumnHeader.scss
@@ -37,43 +37,7 @@
 
 	position: relative;
 
-	.input-container {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-
-		position: relative;
-	}
-
-	@media only screen and (max-width: 610px) {
-		.floating-character-countdown {
-			bottom: -18px;
-		}
-	}
-
-	.column-input {
-		display: inline-block;
-		width: 100%;
-		padding: 0;
-
-		color: main.$white;
-		font-family: inherit;
-		font-weight: inherit;
-		font-size: inherit;
-		text-align: center;
-
-		background-color: transparent;
-		border: 0;
-		outline: none;
-		cursor: inherit;
-
-		/* stylelint-disable selector-no-qualifying-type */
-		&[readonly] {
-			cursor: default;
-		}
-	}
-
-	.display-text {
+	.column-header-title {
 		display: inline-block;
 		width: auto;
 		height: auto;
@@ -93,49 +57,6 @@
 		border: 0;
 		outline: none;
 		cursor: inherit;
-	}
-
-	.sort-button {
-		padding: 0;
-
-		text-align: center;
-
-		position: relative;
-
-		.sort-icon {
-			display: block;
-
-			font-size: 1.5rem;
-
-			cursor: pointer;
-
-			&.sort-icon-translucent {
-				opacity: 0.45;
-			}
-		}
-	}
-
-	.edit-button {
-		padding: 0;
-
-		color: main.$white;
-		font-size: 1rem;
-
-		cursor: pointer;
-
-		position: absolute;
-		right: 5px;
-		top: 5px;
-
-		&:hover,
-		&:focus {
-			.tooltip {
-				visibility: visible;
-				opacity: 1;
-
-				top: 30px;
-			}
-		}
 	}
 
 	&.happy {

--- a/ui/src/Common/ColumnHeader/ColumnHeader.spec.tsx
+++ b/ui/src/Common/ColumnHeader/ColumnHeader.spec.tsx
@@ -34,8 +34,8 @@ describe('ColumnHeader', () => {
 		const { container } = render(
 			<ColumnHeader
 				initialTitle="Some title"
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 		const results = await axe(container);
@@ -46,7 +46,7 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle="Not Sortable"
-				titleChanged={mockHandleTitleChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 		expect(screen.queryByTestId('columnHeader-sortButton')).toBeNull();
@@ -56,8 +56,8 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle="Sortable"
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 		expect(screen.queryByTestId('columnHeader-sortButton')).not.toBeNull();
@@ -66,8 +66,8 @@ describe('ColumnHeader', () => {
 	it('should toggle and emit sort state when the sort is toggled', () => {
 		render(
 			<ColumnHeader
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 
@@ -80,10 +80,7 @@ describe('ColumnHeader', () => {
 
 	it('should not display edit button when header is read only', () => {
 		render(
-			<ColumnHeader
-				initialTitle="Read Only"
-				sortedChanged={mockHandleSortChange}
-			/>
+			<ColumnHeader initialTitle="Read Only" onSort={mockHandleSortChange} />
 		);
 		expect(screen.queryByTestId('columnHeader-editTitleButton')).toBeNull();
 	});
@@ -92,8 +89,8 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle="Not Read Only"
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 		expect(screen.queryByTestId('columnHeader-editTitleButton')).not.toBeNull();
@@ -103,8 +100,8 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle="Change This"
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 		expect(screen.queryByText('5')).toBeNull();
@@ -114,8 +111,8 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle="Change This"
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 		userEvent.click(screen.getByTestId('columnHeader-editTitleButton'));
@@ -126,8 +123,8 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle="Change This"
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 
@@ -141,8 +138,8 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle="Change This"
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 
@@ -159,8 +156,8 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle="Change This"
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 
@@ -176,8 +173,8 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle="No Change"
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 
@@ -194,8 +191,8 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle={title}
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 
@@ -216,8 +213,8 @@ describe('ColumnHeader', () => {
 		render(
 			<ColumnHeader
 				initialTitle={title}
-				sortedChanged={mockHandleSortChange}
-				titleChanged={mockHandleTitleChange}
+				onSort={mockHandleSortChange}
+				onTitleChange={mockHandleTitleChange}
 			/>
 		);
 

--- a/ui/src/Common/ColumnHeader/ColumnHeaderInput/ColumnHeaderInput.scss
+++ b/ui/src/Common/ColumnHeader/ColumnHeaderInput/ColumnHeaderInput.scss
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use 'Styles/main';
+
+.column-header-input {
+	display: inline-block;
+	width: 100%;
+	padding: 0.15rem 1.4rem 0 0;
+
+	color: main.$white;
+	font-family: inherit;
+	font-weight: inherit;
+	font-size: inherit;
+	text-align: center;
+
+	background-color: transparent;
+	border: 0;
+	outline: none;
+	cursor: inherit;
+
+	/* stylelint-disable selector-no-qualifying-type */
+	&[readonly] {
+		cursor: default;
+	}
+}
+
+@media only screen and (max-width: 610px) {
+	.floating-character-countdown {
+		bottom: -18px;
+	}
+}

--- a/ui/src/Common/ColumnHeader/ColumnHeaderInput/ColumnHeaderInput.tsx
+++ b/ui/src/Common/ColumnHeader/ColumnHeaderInput/ColumnHeaderInput.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useState } from 'react';
+
+import { onEachKey } from '../../../Utils/EventUtils';
+import FloatingCharacterCountdown from '../../FloatingCharacterCountdown/FloatingCharacterCountdown';
+
+import './ColumnHeaderInput.scss';
+
+const MAX_TITLE_LENGTH = 16;
+const ALMOST_OUT_OF_CHARACTERS_THRESHOLD = 5;
+
+interface Props {
+	initialTitle: string;
+	updateTitle(title: string): void;
+	setEditing(editing: boolean): void;
+}
+
+function ColumnHeaderInput(props: Props) {
+	const { initialTitle, updateTitle, setEditing } = props;
+
+	const [value, setValue] = useState(initialTitle);
+
+	const handleKeyDown = onEachKey({
+		Enter: () => updateTitle(value),
+		Escape: () => setEditing(false),
+	});
+
+	return (
+		<>
+			<input
+				type="text"
+				className="column-header-input"
+				data-testid="column-input"
+				maxLength={MAX_TITLE_LENGTH}
+				value={value}
+				onChange={(event) => setValue(event.target.value)}
+				onBlur={() => updateTitle(value)}
+				onKeyDown={handleKeyDown}
+				/* eslint-disable-next-line jsx-a11y/no-autofocus */
+				autoFocus={true}
+				onFocus={(event: any) => event.target.select()}
+			/>
+			<FloatingCharacterCountdown
+				characterCount={value.length}
+				maxCharacterCount={MAX_TITLE_LENGTH}
+				charsAreRunningOutThreshold={ALMOST_OUT_OF_CHARACTERS_THRESHOLD}
+			/>
+		</>
+	);
+}
+
+export default ColumnHeaderInput;

--- a/ui/src/Common/ColumnHeader/EditColumnButton/EditColumnButton.scss
+++ b/ui/src/Common/ColumnHeader/EditColumnButton/EditColumnButton.scss
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use 'Styles/main';
+
+.edit-button {
+	padding: 0;
+
+	color: main.$white;
+	font-size: 1rem;
+
+	cursor: pointer;
+
+	position: absolute;
+	right: 5px;
+	top: 5px;
+
+	&:hover,
+	&:focus {
+		.tooltip {
+			visibility: visible;
+			opacity: 1;
+
+			top: 30px;
+		}
+	}
+}

--- a/ui/src/Common/ColumnHeader/EditColumnButton/EditColumnButton.tsx
+++ b/ui/src/Common/ColumnHeader/EditColumnButton/EditColumnButton.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import Tooltip from 'Common/Tooltip/Tooltip';
+
+import './EditColumnButton.scss';
+
+interface Props {
+	title: string;
+	onClick(): void;
+}
+
+function EditColumnButton(props: Props) {
+	const { title, onClick } = props;
+
+	return (
+		<button
+			className="edit-button"
+			onClick={onClick}
+			aria-label={`Edit the "${title}" column title.`}
+			data-testid="columnHeader-editTitleButton"
+		>
+			<i role="presentation" className="fas fa-pencil-alt" aria-hidden />
+			<Tooltip>Edit</Tooltip>
+		</button>
+	);
+}
+
+export default EditColumnButton;

--- a/ui/src/Common/ColumnHeader/SortColumnButton/SortColumnButton.scss
+++ b/ui/src/Common/ColumnHeader/SortColumnButton/SortColumnButton.scss
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.sort-button {
+	padding: 0;
+
+	text-align: center;
+
+	position: relative;
+
+	.sort-icon {
+		display: block;
+
+		font-size: 1.5rem;
+
+		cursor: pointer;
+
+		&.sort-icon-translucent {
+			opacity: 0.45;
+		}
+	}
+}

--- a/ui/src/Common/ColumnHeader/SortColumnButton/SortColumnButton.tsx
+++ b/ui/src/Common/ColumnHeader/SortColumnButton/SortColumnButton.tsx
@@ -26,7 +26,7 @@ interface Props {
 	onClick?(sortedState: boolean): void;
 }
 
-function SortButton(props: Props) {
+function SortColumnButton(props: Props) {
 	const { title, onClick } = props;
 	const [sorted, setSorted] = useState(false);
 
@@ -59,4 +59,4 @@ function SortButton(props: Props) {
 	);
 }
 
-export default SortButton;
+export default SortColumnButton;

--- a/ui/src/Common/ColumnHeader/SortColumnButton/SortColumnButton.tsx
+++ b/ui/src/Common/ColumnHeader/SortColumnButton/SortColumnButton.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import Tooltip from 'Common/Tooltip/Tooltip';
+
+import './SortColumnButton.scss';
+
+interface Props {
+	title: string;
+	onClick?(sortedState: boolean): void;
+}
+
+function SortButton(props: Props) {
+	const { title, onClick } = props;
+	const [sorted, setSorted] = useState(false);
+
+	const getSortedButtonText = (): string => {
+		return sorted ? 'Unsort' : 'Sort';
+	};
+
+	const toggleSort = () => {
+		const sortedState = !sorted;
+		setSorted(sortedState);
+		if (onClick) onClick(sortedState);
+	};
+
+	return (
+		<button
+			className="sort-button"
+			onClick={toggleSort}
+			aria-label={`${getSortedButtonText()} the ${title} column.`}
+			data-testid="columnHeader-sortButton"
+		>
+			<i
+				aria-hidden
+				role="presentation"
+				className={classNames('fas fa-sort-down sort-icon', {
+					'sort-icon-translucent': !sorted,
+				})}
+			/>
+			<Tooltip>{getSortedButtonText()}</Tooltip>
+		</button>
+	);
+}
+
+export default SortButton;


### PR DESCRIPTION
## Overview
Componentize ColumnHeader to make it more readable

Connects N/A

### Notes
Also, when you went to edit toe column header title, the title would shift a little bit when it went from view to edit state. In this PR I made that transition less noticeable.

## Testing Instructions
* Ensure you can still edit each column title and that the transition is smoother than it was before (no major text repositioning)