### PR TITLE
Prepopulate the team name when being redirected to login from a team page

### DIFF
--- a/ui/cypress/e2e/login.spec.ts
+++ b/ui/cypress/e2e/login.spec.ts
@@ -94,7 +94,10 @@ describe('Login', () => {
 			cy.document().setCookie('token', '');
 			cy.document().setCookie('JSESSIONID', '');
 			cy.enterThought(Topic.HAPPY, 'I have a thought');
-			cy.url().should('eq', Cypress.config().baseUrl + '/login');
+			cy.url().should(
+				'eq',
+				Cypress.config().baseUrl + '/login/' + teamCredentials.teamId
+			);
 		});
 
 		it('Redirects to login page when team name back forbidden', () => {
@@ -107,7 +110,10 @@ describe('Login', () => {
 
 			cy.wait('@getTeamName');
 
-			cy.url().should('eq', Cypress.config().baseUrl + '/login');
+			cy.url().should(
+				'eq',
+				Cypress.config().baseUrl + '/login/teamNameThatDoesNotExist'
+			);
 		});
 	});
 });

--- a/ui/src/Services/Api/TeamService.spec.ts
+++ b/ui/src/Services/Api/TeamService.spec.ts
@@ -127,11 +127,13 @@ describe('Team Service', () => {
 					.finally(() => expect(returnedAxiosError).toEqual(axiosError));
 			});
 
-			it('should redirect to login page if NOT already on login or create page', async () => {
+			it('should redirect to login page with team name if NOT already on login or create page', async () => {
 				window.location.pathname = '/team/superwoman';
 				await TeamService.onResponseInterceptRejection(axiosError)
 					.catch(jest.fn())
-					.finally(() => expect(mockAssign).toHaveBeenCalledWith('/login'));
+					.finally(() =>
+						expect(mockAssign).toHaveBeenCalledWith('/login/superwoman')
+					);
 			});
 
 			it('should NOT redirect to login page if already on the login page', async () => {
@@ -173,7 +175,9 @@ describe('Team Service', () => {
 				window.location.pathname = '/team/superwoman';
 				await TeamService.onResponseInterceptRejection(axiosError)
 					.catch(jest.fn())
-					.finally(() => expect(mockAssign).toHaveBeenCalledWith('/login'));
+					.finally(() =>
+						expect(mockAssign).toHaveBeenCalledWith('/login/superwoman')
+					);
 			});
 
 			it('should NOT redirect to login page if already on the login page', async () => {

--- a/ui/src/Services/Api/TeamService.ts
+++ b/ui/src/Services/Api/TeamService.ts
@@ -79,7 +79,14 @@ const TeamService = {
 			const isCreateNewTeamPage = pathname === CREATE_TEAM_PAGE_PATH;
 
 			if (!isLoginPage && !isCreateNewTeamPage) {
-				window.location.assign(LOGIN_PAGE_PATH);
+				let teamNamePath = '';
+				const isTeamPage = pathname.includes('/team');
+				if (isTeamPage) {
+					const params = pathname.split('/');
+					teamNamePath = `/${params[2]}`;
+				}
+
+				window.location.assign(LOGIN_PAGE_PATH + teamNamePath);
 			}
 		}
 		return Promise.reject(error);


### PR DESCRIPTION
## Overview
Currently, if a user is logged out and they go to their team board (ex: `/team/board-name`) they will get redirected to the login page, but their team name will not be prepopulated.

This updates the functionality, so if a user tries to go to their board and they get redirected to the login page, they will get redirected to `/login/board-name`, which will prepopulate the login form with the team name

Connects N/A

## Testing Instructions
1) Create a team, but do not log in. If logged in, clear the cookies.
2) Go to that teams page: `http://localhost:3000/team/yourTeamName`, and ensure that you get redirected to the login page and that your team name is prepopulated in the form.
3) Ensure the same goes for when going to `http://localhost:3000/team/yourTeamName/archives` and `http://localhost:3000/team/yourTeamName/radiator`