### PR TITLE
Fix thought archive element colors from black to opaque black

### DIFF
--- a/ui/src/App/Team/Archives/ThoughtArchives/ArchivedBoardsList/ArchivedBoardTile/ArchivedBoardTile.scss
+++ b/ui/src/App/Team/Archives/ThoughtArchives/ArchivedBoardsList/ArchivedBoardTile/ArchivedBoardTile.scss
@@ -62,7 +62,7 @@
 		background: main.$light-asphalt;
 
 		.thought-count {
-			background: main.$black;
+			background-color: rgba(main.$black, 0.22);
 		}
 
 		.view-button {

--- a/ui/src/App/Team/Archives/ThoughtArchives/ArchivedBoardsList/ArchivedBoardsListHeader/ArchivedBoardListHeader.scss
+++ b/ui/src/App/Team/Archives/ThoughtArchives/ArchivedBoardsList/ArchivedBoardsListHeader/ArchivedBoardListHeader.scss
@@ -63,7 +63,7 @@
 
 @include main.dark-theme {
 	.list-header {
-		background: main.$black;
+		background-color: rgba(main.$black, 0.22);
 
 		.sort-button {
 			color: main.$gray-2;


### PR DESCRIPTION
## Overview
Fix thought archive element colors from black to opaque black

Connects N/A

### Demo
**Before:**
<img width="669" alt="Screen Shot 2022-07-21 at 10 33 03 AM" src="https://user-images.githubusercontent.com/17144844/180240316-2bc7f523-06d8-42d1-b37c-8a7d60a745f6.png">

**After:**
<img width="620" alt="Screen Shot 2022-07-21 at 10 32 57 AM" src="https://user-images.githubusercontent.com/17144844/180240328-70cef943-3bac-4766-bdeb-d5467dc7a4e6.png">

## Testing Instructions
1) Archive a board, then go to the archives page
2) Ensure the styles look cohesive now