### PR TITLE
Add survey link to login page

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/config/EnvironmentConfiguration.java
+++ b/api/src/main/java/com/ford/labs/retroquest/config/EnvironmentConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.config;
+
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Data
+public class EnvironmentConfiguration {
+    @Value("${retroquest.marketing.survey-link-href}")
+    String survey_link_href = "";
+}

--- a/api/src/main/java/com/ford/labs/retroquest/config/EnvironmentConfigurationController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/config/EnvironmentConfigurationController.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/config")
+class EnvironmentConfigurationController
+{
+    private final EnvironmentConfiguration configuration;
+
+    EnvironmentConfigurationController(@Autowired EnvironmentConfiguration configuration){
+            this.configuration = configuration;
+    }
+
+    @GetMapping
+    EnvironmentConfiguration getConfiguration() {
+        return configuration;
+    }
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -16,6 +16,8 @@
 #
 
 retroquest:
+  marketing:
+    survey-link-href:
   security:
     require-https: false
     jwt-signing-secret: ASLKJHDKJHikjsdkjhg1iu2heiIUGEIUQ@IUeiUIU@iyrgiu2g3i # This is a default value. Ensure you override this value on any real deployments.

--- a/api/src/test/java/com/ford/labs/retroquest/config/ConfigurationApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/config/ConfigurationApiTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ConfigurationApiTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void shouldReturnPropertyValueAsData() throws Exception {
+        var mvcResult = mockMvc.perform(get("/api/config"))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        assertThat(mvcResult.getResponse().getContentAsString())
+                .isEqualTo("{\"survey_link_href\":\"test-survey-link-href\"}");
+    }
+}

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -16,6 +16,8 @@
 #
 
 retroquest:
+  marketing:
+    survey-link-href: test-survey-link-href
   archive:
     thought:
       page-size: 5

--- a/ui/src/App/Login/LoginPage.scss
+++ b/ui/src/App/Login/LoginPage.scss
@@ -15,8 +15,36 @@
  * limitations under the License.
  */
 
-const configurationService = {
-	get: jest.fn().mockResolvedValue({ survey_link_href: 'mockSurveyLinkHref' }),
-};
+@use '../../Styles/main';
 
-export default configurationService;
+.survey-link {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 125px;
+	height: 45px;
+	margin-bottom: 1rem;
+	padding: 0 24px;
+
+	color: inherit;
+
+	font-family: inherit;
+	font-weight: 700;
+	font-size: 1rem;
+	white-space: nowrap;
+	text-transform: capitalize;
+	text-decoration: none;
+
+	background-color: main.$yellow;
+
+	border: 0;
+	border-radius: 18px;
+	box-shadow: 0 4px 15px rgba(main.$black, 0.25);
+	cursor: pointer;
+
+	&:hover,
+	&:focus {
+		background-color: main.$purple;
+		cursor: pointer;
+	}
+}

--- a/ui/src/App/Login/LoginPage.spec.tsx
+++ b/ui/src/App/Login/LoginPage.spec.tsx
@@ -38,6 +38,8 @@ jest.mock('../../Hooks/useAuth', () => {
 	});
 });
 
+jest.mock('../../Services/Api/ConfigurationService');
+
 describe('LoginPage.spec.tsx', () => {
 	let container: HTMLElement;
 	let rerender: (ui: ReactElement) => void;
@@ -69,6 +71,11 @@ describe('LoginPage.spec.tsx', () => {
 
 	it('should show correct heading', () => {
 		expect(screen.getByText('Sign in to your Team!')).toBeDefined();
+	});
+
+	it('should query the API for survey link href', () => {
+		const surveyLink = screen.getByText(/take the retroquest survey/i);
+		expect(surveyLink.getAttribute('href')).toEqual("mockSurveyLinkHref")
 	});
 
 	it('should show link to create new team', () => {

--- a/ui/src/App/Login/LoginPage.spec.tsx
+++ b/ui/src/App/Login/LoginPage.spec.tsx
@@ -22,11 +22,11 @@ import { axe } from 'jest-axe';
 import { RecoilRoot } from 'recoil';
 
 import { mockContributors } from '../../Services/Api/__mocks__/ContributorsService';
+import ConfigurationService from '../../Services/Api/ConfigurationService';
 import ContributorsService from '../../Services/Api/ContributorsService';
 import TeamService from '../../Services/Api/TeamService';
 
 import LoginPage from './LoginPage';
-import ConfigurationService from "../../Services/Api/ConfigurationService";
 
 jest.mock('../../Services/Api/ContributorsService');
 jest.mock('../../Services/Api/TeamService');
@@ -44,6 +44,7 @@ jest.mock('../../Services/Api/ConfigurationService');
 describe('LoginPage.spec.tsx', () => {
 	let container: HTMLElement;
 	let rerender: (ui: ReactElement) => void;
+	let unmount: () => void;
 	const validTeamName = 'Team Awesome';
 	const validPassword = 'Password1';
 
@@ -52,15 +53,7 @@ describe('LoginPage.spec.tsx', () => {
 		TeamService.getTeamName = jest.fn().mockResolvedValue(validTeamName);
 		TeamService.login = jest.fn().mockResolvedValue(validTeamName);
 
-		({ container, rerender } = render(
-			<MemoryRouter initialEntries={['/login']}>
-				<RecoilRoot>
-					<Routes>
-						<Route path="/login" element={<LoginPage />} />
-					</Routes>
-				</RecoilRoot>
-			</MemoryRouter>
-		));
+		({ container, rerender, unmount } = renderComponent());
 
 		await waitFor(() => expect(ContributorsService.get).toHaveBeenCalled());
 	});
@@ -74,10 +67,21 @@ describe('LoginPage.spec.tsx', () => {
 		expect(screen.getByText('Sign in to your Team!')).toBeDefined();
 	});
 
-	it('should query the API for survey link href', () => {
+	it('should query the API for survey link href and show the survey link', () => {
 		const surveyLink = screen.getByText(/take the retroquest survey/i);
-		expect(surveyLink.getAttribute('href')).toEqual("mockSurveyLinkHref");
+		expect(surveyLink.getAttribute('href')).toEqual('mockSurveyLinkHref');
 		expect(ConfigurationService.get).toHaveBeenCalled();
+	});
+
+	it('should not show the survey link if its href is empty', async () => {
+		unmount();
+		ConfigurationService.get = jest
+			.fn()
+			.mockResolvedValue({ survey_link_href: '' });
+		renderComponent();
+		await waitFor(() => expect(ConfigurationService.get).toHaveBeenCalled());
+		const surveyLink = screen.queryByText(/take the retroquest survey/i);
+		expect(surveyLink).toBeNull();
 	});
 
 	it('should show link to create new team', () => {
@@ -170,3 +174,15 @@ const typeIntoTeamNameInput = (teamName: string) => {
 	const teamNameInput = getTeamNameInput();
 	fireEvent.change(teamNameInput, { target: { value: teamName } });
 };
+
+function renderComponent() {
+	return render(
+		<MemoryRouter initialEntries={['/login']}>
+			<RecoilRoot>
+				<Routes>
+					<Route path="/login" element={<LoginPage />} />
+				</Routes>
+			</RecoilRoot>
+		</MemoryRouter>
+	);
+}

--- a/ui/src/App/Login/LoginPage.spec.tsx
+++ b/ui/src/App/Login/LoginPage.spec.tsx
@@ -26,6 +26,7 @@ import ContributorsService from '../../Services/Api/ContributorsService';
 import TeamService from '../../Services/Api/TeamService';
 
 import LoginPage from './LoginPage';
+import ConfigurationService from "../../Services/Api/ConfigurationService";
 
 jest.mock('../../Services/Api/ContributorsService');
 jest.mock('../../Services/Api/TeamService');
@@ -75,7 +76,8 @@ describe('LoginPage.spec.tsx', () => {
 
 	it('should query the API for survey link href', () => {
 		const surveyLink = screen.getByText(/take the retroquest survey/i);
-		expect(surveyLink.getAttribute('href')).toEqual("mockSurveyLinkHref")
+		expect(surveyLink.getAttribute('href')).toEqual("mockSurveyLinkHref");
+		expect(ConfigurationService.get).toHaveBeenCalled();
 	});
 
 	it('should show link to create new team', () => {

--- a/ui/src/App/Login/LoginPage.tsx
+++ b/ui/src/App/Login/LoginPage.tsx
@@ -24,6 +24,7 @@ import InputTeamName from '../../Common/AuthTemplate/InputTeamName/InputTeamName
 import useAuth from '../../Hooks/useAuth';
 import useTeamFromRoute from '../../Hooks/useTeamFromRoute';
 import { CREATE_TEAM_PAGE_PATH } from '../../RouteConstants';
+import ConfigurationService from "../../Services/Api/ConfigurationService";
 import TeamService from '../../Services/Api/TeamService';
 
 function LoginPage(): JSX.Element {
@@ -32,11 +33,18 @@ function LoginPage(): JSX.Element {
 
 	const [teamName, setTeamName] = useState<string>('');
 	const [password, setPassword] = useState<string>('');
+	const [surveyLink, setSurveyLink] = useState<string>('');
 
 	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const [errorMessages, setErrorMessages] = useState<string[]>([]);
 
 	useEffect(() => setTeamName(team.name), [team.name]);
+
+	useEffect(() => {
+		ConfigurationService.get().then((config) => {
+			setSurveyLink(config.survey_link_href)
+		})
+	}, [])
 
 	function onLoginFormSubmit() {
 		setIsLoading(true);
@@ -56,6 +64,11 @@ function LoginPage(): JSX.Element {
 			header="Sign in to your Team!"
 			subHeader={<Link to={CREATE_TEAM_PAGE_PATH}>or create a new team</Link>}
 		>
+			{surveyLink && (
+				<a href={surveyLink} target="_blank" rel="noopener noreferrer">
+					Take the RetroQuest Survey
+				</a>
+			)}
 			<Form
 				onSubmit={onLoginFormSubmit}
 				errorMessages={errorMessages}

--- a/ui/src/App/Login/LoginPage.tsx
+++ b/ui/src/App/Login/LoginPage.tsx
@@ -24,8 +24,10 @@ import InputTeamName from '../../Common/AuthTemplate/InputTeamName/InputTeamName
 import useAuth from '../../Hooks/useAuth';
 import useTeamFromRoute from '../../Hooks/useTeamFromRoute';
 import { CREATE_TEAM_PAGE_PATH } from '../../RouteConstants';
-import ConfigurationService from "../../Services/Api/ConfigurationService";
+import ConfigurationService from '../../Services/Api/ConfigurationService';
 import TeamService from '../../Services/Api/TeamService';
+
+import './LoginPage.scss';
 
 function LoginPage(): JSX.Element {
 	const { login } = useAuth();
@@ -42,9 +44,9 @@ function LoginPage(): JSX.Element {
 
 	useEffect(() => {
 		ConfigurationService.get().then((config) => {
-			setSurveyLink(config.survey_link_href)
-		})
-	}, [])
+			setSurveyLink(config.survey_link_href);
+		});
+	}, []);
 
 	function onLoginFormSubmit() {
 		setIsLoading(true);
@@ -65,7 +67,12 @@ function LoginPage(): JSX.Element {
 			subHeader={<Link to={CREATE_TEAM_PAGE_PATH}>or create a new team</Link>}
 		>
 			{surveyLink && (
-				<a href={surveyLink} target="_blank" rel="noopener noreferrer">
+				<a
+					href={surveyLink}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="survey-link"
+				>
 					Take the RetroQuest Survey
 				</a>
 			)}

--- a/ui/src/Services/Api/ConfigurationService.spec.ts
+++ b/ui/src/Services/Api/ConfigurationService.spec.ts
@@ -1,11 +1,14 @@
-import configurationService from "./ConfigurationService";
-import axios from "axios";
+import axios from 'axios';
+
+import configurationService from './ConfigurationService';
 
 describe('the configuration service', () => {
-	it('should perform a GET to /api/config', () => {
-		let value = {data:{propertyName:"propertyValue"}};
+	it('should perform a GET to /api/config', async () => {
+		let value = { data: { propertyName: 'propertyValue' } };
 		axios.get = jest.fn().mockResolvedValue(value);
-		configurationService.get().then(result => expect(result).toEqual(value.data));
+		await configurationService
+			.get()
+			.then((result) => expect(result).toEqual(value.data));
 		expect(axios.get).toHaveBeenCalledWith('/api/config');
 	});
-})
+});

--- a/ui/src/Services/Api/ConfigurationService.spec.ts
+++ b/ui/src/Services/Api/ConfigurationService.spec.ts
@@ -1,0 +1,11 @@
+import configurationService from "./ConfigurationService";
+import axios from "axios";
+
+describe('the configuration service', () => {
+	it('should perform a GET to /api/config', () => {
+		let value = {data:{propertyName:"propertyValue"}};
+		axios.get = jest.fn().mockResolvedValue(value);
+		configurationService.get().then(result => expect(result).toEqual(value.data));
+		expect(axios.get).toHaveBeenCalledWith('/api/config');
+	});
+})

--- a/ui/src/Services/Api/ConfigurationService.ts
+++ b/ui/src/Services/Api/ConfigurationService.ts
@@ -1,4 +1,21 @@
-import axios from "axios";
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import axios from 'axios';
 
 interface Config {
 	survey_link_href: string;
@@ -6,8 +23,8 @@ interface Config {
 
 const configurationService = {
 	get(): Promise<Config> {
-		return axios.get('/api/config').then(response => response.data);
-	}
-}
+		return axios.get('/api/config').then((response) => response.data);
+	},
+};
 
 export default configurationService;

--- a/ui/src/Services/Api/ConfigurationService.ts
+++ b/ui/src/Services/Api/ConfigurationService.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const configurationService = {
+	get(){
+		return axios.get('/api/config').then(response => response.data);
+	}
+}
+
+export default configurationService;

--- a/ui/src/Services/Api/ConfigurationService.ts
+++ b/ui/src/Services/Api/ConfigurationService.ts
@@ -1,7 +1,11 @@
 import axios from "axios";
 
+interface Config {
+	survey_link_href: string;
+}
+
 const configurationService = {
-	get(){
+	get(): Promise<Config> {
 		return axios.get('/api/config').then(response => response.data);
 	}
 }

--- a/ui/src/Services/Api/__mocks__/ConfigurationService.ts
+++ b/ui/src/Services/Api/__mocks__/ConfigurationService.ts
@@ -1,0 +1,5 @@
+const configurationService = {
+	get: jest.fn().mockResolvedValue({survey_link_href:"mockSurveyLinkHref"})
+}
+
+export default configurationService;


### PR DESCRIPTION
## Overview
A link to a survey was requested in order to gather information about potential features for retroquest.

Connects N/A

### Demo

![image](https://user-images.githubusercontent.com/17144844/185202567-5d41f831-df2c-434f-b703-fbd58265632e.png)

## Testing Instructions
1) Add a url to the application.yml file and start up the app:
https://github.com/FordLabs/retroquest/pull/455/files?show-viewed-files=true&file-filters%5B%5D=#diff-b9b68fb79dbb518c662c934f2c0bdcb195dde9cb874459f25f59d4752dc4251dR20
2) Ensure a survey link shows up on the landing page
3) Remove the value from the application.yml file and ensure no survey link is present.