### PR TITLE
Send email when hitting request password endpoint

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
 

--- a/api/src/main/java/com/ford/labs/retroquest/email/EmailService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/email/EmailService.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ford.labs.retroquest.email;
+
+import com.ford.labs.retroquest.team.RequestPasswordResetRequest;
+import com.ford.labs.retroquest.team.password.PasswordResetToken;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+public class EmailService {
+
+	@Value("${retroquest.app-base-url}")
+	private String appBaseUrl;
+
+	@Value("${retroquest.email.from-address}")
+	private String fromEmailAddress;
+
+	@Value("${retroquest.email.is-enabled}")
+	private boolean emailEnabled;
+
+	private final JavaMailSender javaMailSender;
+
+	@Autowired
+	public EmailService(JavaMailSender javaMailSender) {
+		this.javaMailSender = javaMailSender;
+	}
+
+	public void sendUnencryptedEmail(String subject, String message, String... toAddresses) {
+		if (emailEnabled) {
+			SimpleMailMessage mailMessage = new SimpleMailMessage();
+			mailMessage.setTo(toAddresses);
+			mailMessage.setSubject(subject);
+			mailMessage.setText(message);
+			mailMessage.setFrom(fromEmailAddress);
+			mailMessage.setSentDate(new Date());
+			try {
+				javaMailSender.send(mailMessage);
+			} catch (Exception e) {
+				System.out.println("Error in sending email message: " + e.getMessage());
+			}
+		}
+	}
+
+	public String getPasswordResetMessage(
+			PasswordResetToken passwordResetToken,
+			RequestPasswordResetRequest requestPasswordResetRequest
+	) {
+		return (
+			"Hi there! \n" +
+			"We’ve received a request to reset the password for the " +
+			requestPasswordResetRequest.getTeamName() +
+			" RetroQuest account associated with the email address " +
+			requestPasswordResetRequest.getEmail() +
+			". No changes have been made to your account yet. \r\n" +
+			"You can reset the password by clicking the link below: \r\n" +
+			appBaseUrl +
+			"/password/reset?token=" +
+			passwordResetToken.getResetToken() +
+			"\r\n" +
+			"This link will expire in 10 minutes. After 10 minutes, you must submit a new password reset request at " +
+			"\r\n" +
+			appBaseUrl +
+			"/request-password-reset ." +
+			"\r\n" +
+			"If you didn’t make this request, you can safely ignore this email. \r\n"
+		);
+	}
+}

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
@@ -17,6 +17,7 @@
 
 package com.ford.labs.retroquest.team;
 
+import com.ford.labs.retroquest.email.EmailService;
 import com.ford.labs.retroquest.exception.BadResetTokenException;
 import com.ford.labs.retroquest.exception.TeamDoesNotExistException;
 import com.ford.labs.retroquest.security.JwtBuilder;
@@ -52,11 +53,14 @@ public class TeamController {
 
     private final PasswordEncoder passwordEncoder;
 
-    public TeamController(TeamService teamService, JwtBuilder jwtBuilder, PasswordResetTokenRepository passwordResetRepository, PasswordEncoder passwordEncoder) {
+    private final EmailService emailService;
+
+    public TeamController(TeamService teamService, JwtBuilder jwtBuilder, PasswordResetTokenRepository passwordResetRepository, PasswordEncoder passwordEncoder, EmailService emailService) {
         this.teamService = teamService;
         this.jwtBuilder = jwtBuilder;
         this.passwordResetRepository = passwordResetRepository;
         this.passwordEncoder = passwordEncoder;
+        this.emailService = emailService;
     }
 
     @PostMapping("/team")
@@ -90,7 +94,12 @@ public class TeamController {
             passwordResetToken.setTeam(team);
             passwordResetRepository.deleteAllByTeam(team);
             passwordResetRepository.save(passwordResetToken);
-            //send the email here
+
+            emailService.sendUnencryptedEmail(
+                    "Your password reset link from RetroQuest!",
+                    emailService.getPasswordResetMessage(passwordResetToken, requestPasswordResetRequest),
+                    team.getEmail()
+            );
         }
         else throw new TeamDoesNotExistException();
     }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -39,7 +39,7 @@ spring:
   liquibase:
     change-log: db/changelog.xml
   mail:
-    host: mrl.azell.com
+    host: hostieboi.mail.com
     port: 25
 
 server:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -21,6 +21,10 @@ retroquest:
   security:
     require-https: false
     jwt-signing-secret: ASLKJHDKJHikjsdkjhg1iu2heiIUGEIUQ@IUeiUIU@iyrgiu2g3i # This is a default value. Ensure you override this value on any real deployments.
+  app-base-url: something.com
+  email:
+    from-address: rq@test.com
+    is-enabled: true
 
 spring:
   data:
@@ -34,6 +38,9 @@ spring:
     show-sql: false
   liquibase:
     change-log: db/changelog.xml
+  mail:
+    host: mrl.azell.com
+    port: 25
 
 server:
   error:

--- a/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
@@ -47,6 +48,9 @@ public abstract class ApiTestBase {
 
     @MockBean
     public ContributorController contributorController;
+
+    @MockBean
+    public JavaMailSender javaMailSender;
 
     @Value("${local.server.port}")
     private int port;

--- a/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/setup/ApiTestBase.java
@@ -49,9 +49,6 @@ public abstract class ApiTestBase {
     @MockBean
     public ContributorController contributorController;
 
-    @MockBean
-    public JavaMailSender javaMailSender;
-
     @Value("${local.server.port}")
     private int port;
 

--- a/api/src/test/java/com/ford/labs/retroquest/config/ConfigurationApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/config/ConfigurationApiTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/com/ford/labs/retroquest/email/EmailServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/email/EmailServiceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.email;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class EmailServiceTest {
+    @Test
+    void shouldTransmitCorrectValuesToMailSender() {
+        JavaMailSender mockSender = Mockito.mock(JavaMailSender.class);
+        EmailService underTest = new EmailService(mockSender);
+        ReflectionTestUtils.setField(underTest, "emailEnabled", true);
+
+        underTest.sendUnencryptedEmail("a subject", "a message", "address1@e.m", "address2@e.m");
+
+        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        verify(mockSender).send(captor.capture());
+        assertThat(captor.getValue().getSubject()).isEqualTo("a subject");
+        assertThat(captor.getValue().getText()).isEqualTo("a message");
+        assertThat(captor.getValue().getTo()).isEqualTo(new String[]{"address1@e.m", "address2@e.m"});
+    }
+}

--- a/api/src/test/java/com/ford/labs/retroquest/email/EmailServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/email/EmailServiceTest.java
@@ -17,6 +17,9 @@
 
 package com.ford.labs.retroquest.email;
 
+import com.ford.labs.retroquest.team.RequestPasswordResetRequest;
+import com.ford.labs.retroquest.team.Team;
+import com.ford.labs.retroquest.team.password.PasswordResetToken;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -26,6 +29,8 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -46,5 +51,33 @@ class EmailServiceTest {
         assertThat(captor.getValue().getSubject()).isEqualTo("a subject");
         assertThat(captor.getValue().getText()).isEqualTo("a message");
         assertThat(captor.getValue().getTo()).isEqualTo(new String[]{"address1@e.m", "address2@e.m"});
+    }
+
+    @Test
+    void shouldTheMessage(){
+        JavaMailSender mockSender = Mockito.mock(JavaMailSender.class);
+        EmailService underTest = new EmailService(mockSender);
+        ReflectionTestUtils.setField(underTest, "emailEnabled", true);
+        ReflectionTestUtils.setField(underTest, "appBaseUrl", "something.com");
+
+        String actual = underTest.getPasswordResetMessage(new PasswordResetToken("t0k3n", new Team("teamUri", "teamUri", "passw0rD1"), LocalDateTime.now(), 600), new RequestPasswordResetRequest("teamUri", "e@ma.il"));
+
+        assertThat(actual).isEqualTo(			"Hi there! \n" +
+                "We’ve received a request to reset the password for the " +
+                "teamUri" +
+                " RetroQuest account associated with the email address " +
+                "e@ma.il" +
+                ". No changes have been made to your account yet. \r\n" +
+                "You can reset the password by clicking the link below: \r\n" +
+                "something.com" +
+                "/password/reset?token=" +
+                "t0k3n" +
+                "\r\n" +
+                "This link will expire in 10 minutes. After 10 minutes, you must submit a new password reset request at " +
+                "\r\n" +
+                "something.com" +
+                "/request-password-reset ." +
+                "\r\n" +
+                "If you didn’t make this request, you can safely ignore this email. \r\n");
     }
 }

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -42,3 +42,6 @@ spring:
     driver-class-name: org.h2.Driver
   liquibase:
     change-log: db/changelog.xml
+  mail:
+    host: hostieboi.mail.com
+    port: 25

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -18,12 +18,13 @@
 retroquest:
   marketing:
     survey-link-href: test-survey-link-href
-  archive:
-    thought:
-      page-size: 5
   security:
     require-https: false
     jwt-signing-secret: IMSOSECRETYOUDONTEVENKNOW
+  app-base-url: something.com
+  email:
+    from-address: test@mail.com
+    is-enabled: true
 
 spring:
   data:


### PR DESCRIPTION
## What was done
This PR updates the `/password/request-reset` to send an email with the created reset token to the user who made the request

## Testing Instructions
1) Ensure all tests pass
2) ** CANNOT be tested locally, must test in dev