### PR TITLE
Update password reset confirmation message

### DIFF
--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.spec.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.spec.tsx
@@ -50,16 +50,17 @@ describe('Password Reset Request Page', () => {
 		expect(TeamService.sendPasswordResetLink).toHaveBeenCalledTimes(0);
 	});
 
-	it('should show "Saved!" if the backend returns 200 after submission', async () => {
+	const confirmationMessage = 'Link Sent!';
+	it('should show confirmation message if the backend returns 200 after submission', async () => {
 		await renderPasswordResetRequestPage();
 		submitValidForm();
 
-		await screen.findByText('Link Sent!');
+		await screen.findByText(confirmationMessage);
 	});
 
-	it('should not show "Saved!" if the form is not submitted', async () => {
+	it('should not show confirmation message if the form is not submitted', async () => {
 		await renderPasswordResetRequestPage();
-		expect(screen.queryByText('Saved!')).not.toBeInTheDocument();
+		expect(screen.queryByText(confirmationMessage)).not.toBeInTheDocument();
 	});
 
 	it('should show an error message if the request is not successful that persists until you type in either input', async () => {

--- a/ui/src/App/ResetPassword/ResetPasswordPage.scss
+++ b/ui/src/App/ResetPassword/ResetPasswordPage.scss
@@ -22,18 +22,83 @@
 		@include main.white-form;
 	}
 
-	.success-feedback-container {
+	.login-link-container {
 		text-align: center;
 
 		.login-link {
 			display: inline-block;
-			margin-top: 0.5rem;
+			margin-top: 1.5rem;
 
 			color: main.$dark-turquoise;
+			font-weight: 700;
+			font-size: 16px;
+			font-style: normal;
+			line-height: 16px;
 
 			&:focus,
 			&:hover {
 				color: main.$turquoise;
+			}
+		}
+	}
+
+	.success-feedback-container {
+		.success-indicator {
+			font-weight: 700;
+			font-size: 20px;
+			line-height: 25px;
+			letter-spacing: 0;
+			text-align: center;
+		}
+
+		.login-button-link {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 100%;
+			min-width: 125px;
+			height: 45px;
+			margin-top: 2rem;
+			padding: 0 24px;
+
+			color: main.$gray-1;
+
+			font-family: inherit;
+			font-weight: 700;
+			font-size: 1rem;
+			white-space: nowrap;
+			text-transform: capitalize;
+			text-decoration: none;
+
+			background-color: main.$dark-turquoise;
+
+			border: 0;
+			border-radius: 6px;
+			box-shadow: none;
+			cursor: pointer;
+
+			&:disabled {
+				cursor: initial;
+				opacity: 0.3;
+			}
+
+			&:hover:not(:disabled),
+			&:focus:not(:disabled) {
+				background-color: main.$turquoise;
+			}
+		}
+	}
+}
+
+@include main.dark-theme {
+	.success-feedback-container {
+		.login-button-link {
+			color: main.$asphalt;
+			background-color: main.$turquoise;
+
+			&:hover,
+			&:focus {
+				background-color: main.$dark-turquoise;
 			}
 		}
 	}

--- a/ui/src/App/ResetPassword/ResetPasswordPage.spec.tsx
+++ b/ui/src/App/ResetPassword/ResetPasswordPage.spec.tsx
@@ -30,6 +30,12 @@ describe('Reset Password Page', () => {
 		expect(screen.getByText('RetroQuest')).toBeDefined();
 	});
 
+	it('should have "Return to Login" link', () => {
+		renderWithToken('');
+		const loginLink = screen.getByText('Return to Login');
+		expect(loginLink).toHaveAttribute('href', '/login');
+	});
+
 	it('should have a field for password and password confirmation, plus a disabled submit button', async () => {
 		renderWithToken('');
 		expect(screen.getByLabelText('New Password')).toBeInTheDocument();
@@ -77,20 +83,23 @@ describe('Reset Password Page', () => {
 		expect(TeamService.setPassword).toHaveBeenCalledTimes(0);
 	});
 
-	it('should show success message if the backend returns 200 after submission', async () => {
+	const confirmationMessage = 'All set! Your password has been changed.';
+	it('should show success message and hide form if the backend returns 200 after submission', async () => {
 		renderWithToken('ABC321');
 		submitValidForm();
 
-		await screen.findByText('Your Password has been changed!');
-		const loginLink = await screen.findByText('Go to log in page');
+		await screen.findByText(confirmationMessage);
+
+		const loginLink = await screen.findByText('Return to Login');
 		expect(loginLink).toHaveAttribute('href', '/login');
+
+		expect(screen.queryByTestId('resetPasswordFormDescription')).toBeNull();
+		expect(screen.queryByTestId('form')).toBeNull();
 	});
 
-	it('should not show auccess message if the form is not submitted', async () => {
+	it('should not show success message if the form is not submitted', async () => {
 		renderWithToken('ABC321');
-		expect(
-			screen.queryByText('Your Password has been changed!')
-		).not.toBeInTheDocument();
+		expect(screen.queryByText(confirmationMessage)).not.toBeInTheDocument();
 	});
 });
 

--- a/ui/src/App/ResetPassword/ResetPasswordPage.tsx
+++ b/ui/src/App/ResetPassword/ResetPasswordPage.tsx
@@ -27,16 +27,14 @@ import './ResetPasswordPage.scss';
 function ResetPasswordPage(): JSX.Element {
 	const { search } = useLocation();
 
+	const [isReset, setIsReset] = useState(false);
 	const [newPassword, setNewPassword] = useState<string>('');
-	const [shouldShowSaved, setShouldShowSaved] = useState(false);
 	const [isValid, setIsValid] = useState<boolean>(false);
 
 	function submitNewPassword() {
 		if (newPassword) {
 			const token = new URLSearchParams(search).get('token') || '';
-			TeamService.setPassword(newPassword, token).then(() =>
-				setShouldShowSaved(true)
-			);
+			TeamService.setPassword(newPassword, token).then(() => setIsReset(true));
 		}
 	}
 
@@ -45,31 +43,41 @@ function ResetPasswordPage(): JSX.Element {
 			<Header name="RetroQuest" />
 			<div className="reset-password-form">
 				<h1>Reset Your Password</h1>
-				<p>
-					Almost done! Enter your new password here and then remember to tell
-					any active teammates so that they can continue to login to your board.
-				</p>
-				<Form
-					onSubmit={submitNewPassword}
-					submitButtonText="Reset Password"
-					disableSubmitBtn={!isValid}
-				>
-					<InputPassword
-						label="New Password"
-						password={newPassword}
-						onPasswordInputChange={(newPassword, isValid) => {
-							setNewPassword(newPassword);
-							setIsValid(isValid);
-						}}
-					/>
-				</Form>
-				{shouldShowSaved && (
-					<div className={'success-feedback-container'}>
-						<div className="success-indicator">
-							Your Password has been changed!
+				{!isReset && (
+					<>
+						<p data-testid="resetPasswordFormDescription">
+							Almost done! Enter your new password here and then remember to
+							tell any active teammates so that they can continue to login to
+							your board.
+						</p>
+						<Form
+							onSubmit={submitNewPassword}
+							submitButtonText="Reset Password"
+							disableSubmitBtn={!isValid}
+						>
+							<InputPassword
+								label="New Password"
+								password={newPassword}
+								onPasswordInputChange={(newPassword, isValid) => {
+									setNewPassword(newPassword);
+									setIsValid(isValid);
+								}}
+							/>
+						</Form>
+						<div className="login-link-container">
+							<Link className="login-link" to="/login">
+								Return to Login
+							</Link>
 						</div>
-						<Link className={'login-link'} to={'/login'}>
-							Go to log in page
+					</>
+				)}
+				{isReset && (
+					<div className="success-feedback-container">
+						<div className="success-indicator">
+							All set! Your password has been changed.
+						</div>
+						<Link className="login-button-link" to="/login">
+							Return to Login
 						</Link>
 					</div>
 				)}

--- a/ui/src/Common/AuthTemplate/Form/Form.tsx
+++ b/ui/src/Common/AuthTemplate/Form/Form.tsx
@@ -40,6 +40,7 @@ function Form(props: FormProps): JSX.Element {
 
 	return (
 		<form
+			data-testid="form"
 			className="form"
 			onSubmit={(event) => {
 				event.preventDefault();


### PR DESCRIPTION
## What was done
- [x] Updated the password reset confirmation screen to match the designs

## Testing Instructions
1) Request a password reset email and click on the link in the email
2) Reset your password on the page the link takes you
3) Ensure the confirmation message that appears when the form is sent successfully matches the designs

<img width="647" alt="Screen Shot 2022-09-19 at 1 46 27 PM" src="https://user-images.githubusercontent.com/17144844/191080729-ea2aade7-dfbc-425d-919e-f440ce8d89b9.png">
