### PR TITLE
Update password reset request styles

### DIFF
--- a/ui/src/App/CreateTeam/CreateTeamPage.spec.tsx
+++ b/ui/src/App/CreateTeam/CreateTeamPage.spec.tsx
@@ -69,74 +69,76 @@ describe('CreatePage.spec.tsx', () => {
 		expect(screen.getByText('Create a New Team!')).toBeDefined();
 	});
 
-	it('should disable submit button until form is populated', () => {
-		const submitButton = screen.getByTestId('formSubmitButton');
-		expect(submitButton).toBeDisabled();
-		typeIntoTeamNameInput(validTeamName);
-		expect(submitButton).toBeDisabled();
-		typeIntoPasswordInput(validPassword);
-		expect(submitButton).toBeDisabled();
-		typeIntoEmail(validEmail);
-		expect(submitButton).toBeEnabled();
-	});
+	describe('should disable submit button', () => {
+		it('until form is populated', () => {
+			const submitButton = screen.getByTestId('formSubmitButton');
+			expect(submitButton).toBeDisabled();
+			typeIntoTeamNameInput(validTeamName);
+			expect(submitButton).toBeDisabled();
+			typeIntoPasswordInput(validPassword);
+			expect(submitButton).toBeDisabled();
+			typeIntoEmail1(validEmail);
+			expect(submitButton).toBeEnabled();
+		});
 
-	it('should disable submit button if form is filled out, and a required field is cleared', () => {
-		const submitButton = screen.getByTestId('formSubmitButton');
-		expect(submitButton).toBeDisabled();
-		typeIntoTeamNameInput(validTeamName);
-		typeIntoPasswordInput(validPassword);
-		typeIntoEmail(validEmail);
-		expect(submitButton).toBeEnabled();
-		typeIntoEmail('');
-		expect(submitButton).toBeDisabled();
-	});
+		it('if form is filled out, and a required field is cleared', () => {
+			const submitButton = screen.getByTestId('formSubmitButton');
+			expect(submitButton).toBeDisabled();
+			typeIntoTeamNameInput(validTeamName);
+			typeIntoPasswordInput(validPassword);
+			typeIntoEmail1(validEmail);
+			expect(submitButton).toBeEnabled();
+			typeIntoEmail1('');
+			expect(submitButton).toBeDisabled();
+		});
 
-	it('should disable submit button if form is filled out using invalid password', () => {
-		const submitButton = screen.getByTestId('formSubmitButton');
-		expect(submitButton).toBeDisabled();
-		typeIntoTeamNameInput(validTeamName);
-		typeIntoPasswordInput(validPassword);
-		typeIntoEmail(validEmail);
-		expect(submitButton).toBeEnabled();
-		const tooShortPassword = validPassword.substring(0, 6);
-		typeIntoPasswordInput(tooShortPassword);
-		expect(submitButton).toBeDisabled();
-	});
+		it('if form is filled out using invalid password', () => {
+			const submitButton = screen.getByTestId('formSubmitButton');
+			expect(submitButton).toBeDisabled();
+			typeIntoTeamNameInput(validTeamName);
+			typeIntoPasswordInput(validPassword);
+			typeIntoEmail1(validEmail);
+			expect(submitButton).toBeEnabled();
+			const tooShortPassword = validPassword.substring(0, 6);
+			typeIntoPasswordInput(tooShortPassword);
+			expect(submitButton).toBeDisabled();
+		});
 
-	it('should disable submit button if form is filled out using invalid email', () => {
-		const submitButton = screen.getByTestId('formSubmitButton');
-		expect(submitButton).toBeDisabled();
-		typeIntoTeamNameInput(validTeamName);
-		typeIntoPasswordInput(validPassword);
-		typeIntoEmail(validEmail);
-		expect(submitButton).toBeEnabled();
-		const emailWithNoAt = 'email';
-		typeIntoEmail(emailWithNoAt);
-		expect(submitButton).toBeDisabled();
-	});
+		it('if form is filled out using invalid email', () => {
+			const submitButton = screen.getByTestId('formSubmitButton');
+			expect(submitButton).toBeDisabled();
+			typeIntoTeamNameInput(validTeamName);
+			typeIntoPasswordInput(validPassword);
+			typeIntoEmail1(validEmail);
+			expect(submitButton).toBeEnabled();
+			const emailWithNoAt = 'email';
+			typeIntoEmail1(emailWithNoAt);
+			expect(submitButton).toBeDisabled();
+		});
 
-	it('should disable submit button if form is filled out using invalid team name', () => {
-		const submitButton = screen.getByTestId('formSubmitButton');
-		expect(submitButton).toBeDisabled();
-		typeIntoTeamNameInput(validTeamName);
-		typeIntoPasswordInput(validPassword);
-		typeIntoEmail(validEmail);
-		expect(submitButton).toBeEnabled();
-		const teamNameWithSpecialCharacter = validTeamName + '-';
-		typeIntoTeamNameInput(teamNameWithSpecialCharacter);
-		expect(submitButton).toBeDisabled();
-	});
+		it('if form is filled out using invalid team name', () => {
+			const submitButton = screen.getByTestId('formSubmitButton');
+			expect(submitButton).toBeDisabled();
+			typeIntoTeamNameInput(validTeamName);
+			typeIntoPasswordInput(validPassword);
+			typeIntoEmail1(validEmail);
+			expect(submitButton).toBeEnabled();
+			const teamNameWithSpecialCharacter = validTeamName + '-';
+			typeIntoTeamNameInput(teamNameWithSpecialCharacter);
+			expect(submitButton).toBeDisabled();
+		});
 
-	it('should disable submit button if form is filled out using invalid second email', () => {
-		const submitButton = screen.getByTestId('formSubmitButton');
-		expect(submitButton).toBeDisabled();
-		typeIntoTeamNameInput(validTeamName);
-		typeIntoPasswordInput(validPassword);
-		typeIntoEmail(validEmail);
-		expect(submitButton).toBeEnabled();
-		const tooShortEmail = '@b';
-		typeIntoSecondaryEmail(tooShortEmail);
-		expect(submitButton).toBeDisabled();
+		it('if form is filled out using invalid second email', () => {
+			const submitButton = screen.getByTestId('formSubmitButton');
+			expect(submitButton).toBeDisabled();
+			typeIntoTeamNameInput(validTeamName);
+			typeIntoPasswordInput(validPassword);
+			typeIntoEmail1(validEmail);
+			expect(submitButton).toBeEnabled();
+			const tooShortEmail = '@b';
+			typeIntoSecondaryEmail(tooShortEmail);
+			expect(submitButton).toBeDisabled();
+		});
 	});
 
 	it('should show link to login page', () => {
@@ -155,7 +157,7 @@ describe('CreatePage.spec.tsx', () => {
 	it('should successfully create team', async () => {
 		typeIntoTeamNameInput(validTeamName);
 		typeIntoPasswordInput(validPassword);
-		typeIntoEmail(validEmail);
+		typeIntoEmail1(validEmail);
 
 		const submitButton = screen.getByText('Create Team');
 		userEvent.click(submitButton);
@@ -171,7 +173,7 @@ describe('CreatePage.spec.tsx', () => {
 	it('should successfully create team with the optional secondary email', async () => {
 		typeIntoTeamNameInput(validTeamName);
 		typeIntoPasswordInput(validPassword);
-		typeIntoEmail(validEmail);
+		typeIntoEmail1(validEmail);
 		typeIntoSecondaryEmail(validSecondaryEmail);
 
 		const submitButton = screen.getByText('Create Team');
@@ -191,46 +193,38 @@ describe('CreatePage.spec.tsx', () => {
 			expect(screen.queryByTestId('formErrorMessage')).toBeNull();
 		});
 
-		it('should warn user with message when team name has special characters', async () => {
-			typeIntoPasswordInput(validPassword);
-
+		it('should warn user when team name has special characters', () => {
 			const invalidTeamName = '&%(#';
 			typeIntoTeamNameInput(invalidTeamName);
 
-			fireEvent.submit(getTeamNameInput());
-
-			const inputValidationMessage = screen.getByTestId(
-				'inputValidationMessage'
-			);
-			expect(inputValidationMessage.textContent).toBe(
-				'Must have: letters, numbers, and spaces only'
-			);
-
-			const formErrorMessage = screen.getByTestId('formErrorMessage');
-			expect(formErrorMessage.textContent).toBe(
-				'Please enter a team name without any special characters.'
-			);
+			expect(
+				screen.getByText('Must have: letters, numbers, and spaces only')
+			).toBeDefined();
 		});
 
-		it('should warn user with message when password is not valid', async () => {
-			typeIntoTeamNameInput(validTeamName);
-
+		it('should warn user when password is not valid', () => {
 			const invalidPassword = 'MissingANumber';
 			typeIntoPasswordInput(invalidPassword);
 
-			fireEvent.submit(getPasswordInput());
+			expect(
+				screen.getByText(
+					'Must have: 8+ Characters, 1 Upper Case Letter, 1 Number'
+				)
+			).toBeDefined();
+		});
 
-			const inputValidationMessage = screen.getByTestId(
-				'inputValidationMessage'
-			);
-			expect(inputValidationMessage.textContent).toBe(
-				'Must have: 8+ Characters, 1 Upper Case Letter, 1 Number'
-			);
+		it('should warn user when primary email is not valid', () => {
+			const invalidEmail = 'Aaaaa.com';
+			typeIntoEmail1(invalidEmail);
 
-			const formErrorMessage = screen.getByTestId('formErrorMessage');
-			expect(formErrorMessage.textContent).toBe(
-				'Password must contain at least one number.'
-			);
+			expect(screen.getByText('Valid email address required')).toBeDefined();
+		});
+
+		it('should warn user when secondary email is not valid', () => {
+			const invalidEmail = 'Aaaaa.com';
+			typeIntoSecondaryEmail(invalidEmail);
+
+			expect(screen.getByText('Valid email address required')).toBeDefined();
 		});
 	});
 });
@@ -253,7 +247,7 @@ const typeIntoPasswordInput = (password: string) => {
 	fireEvent.change(passwordInput, { target: { value: password } });
 };
 
-const typeIntoEmail = (email: string) => {
+const typeIntoEmail1 = (email: string) => {
 	const emailInput = getEmailInput();
 	fireEvent.change(emailInput, {
 		target: { value: email },

--- a/ui/src/App/CreateTeam/CreateTeamPage.tsx
+++ b/ui/src/App/CreateTeam/CreateTeamPage.tsx
@@ -24,10 +24,6 @@ import InputTeamName from 'Common/InputTeamName/InputTeamName';
 import useAuth from 'Hooks/useAuth';
 import { LOGIN_PAGE_PATH } from 'RouteConstants';
 import TeamService from 'Services/Api/TeamService';
-import {
-	getPasswordInvalidMessage,
-	getTeamNameInvalidMessage,
-} from 'Utils/StringUtils';
 
 import './CreateTeamPage.scss';
 
@@ -52,20 +48,7 @@ function CreateTeamPage(): JSX.Element {
 		value: '',
 		validity: true,
 	});
-
-	const [isValidated, setIsValidated] = useState<boolean>(false);
-	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const [errorMessages, setErrorMessages] = useState<string[]>([]);
-
-	const teamNameErrorMessage = getTeamNameInvalidMessage(teamName.value);
-	const passwordErrorMessage = getPasswordInvalidMessage(password.value);
-
-	const captureErrors = () => {
-		const errors = [];
-		if (teamNameErrorMessage) errors.push(teamNameErrorMessage);
-		if (passwordErrorMessage) errors.push(passwordErrorMessage);
-		setErrorMessages(errors);
-	};
 
 	function disableSubmitButton(): boolean {
 		return (
@@ -77,7 +60,6 @@ function CreateTeamPage(): JSX.Element {
 	}
 
 	function createTeam() {
-		setIsLoading(true);
 		TeamService.create(
 			teamName.value,
 			password.value,
@@ -95,19 +77,12 @@ function CreateTeamPage(): JSX.Element {
 							: error.message;
 				}
 				setErrorMessages([errorMsg]);
-			})
-			.finally(() => setIsLoading(false));
+			});
 	}
 
 	function onSubmit() {
-		setIsValidated(true);
 		setErrorMessages([]);
-
-		if (teamNameErrorMessage || passwordErrorMessage) {
-			captureErrors();
-		} else {
-			createTeam();
-		}
+		createTeam();
 	}
 
 	return (
@@ -116,7 +91,7 @@ function CreateTeamPage(): JSX.Element {
 				onSubmit={onSubmit}
 				errorMessages={errorMessages}
 				submitButtonText="Create Team"
-				disableSubmitBtn={isLoading || disableSubmitButton()}
+				disableSubmitBtn={disableSubmitButton()}
 			>
 				<InputTeamName
 					value={teamName.value}
@@ -124,8 +99,6 @@ function CreateTeamPage(): JSX.Element {
 						setTeamName({ value: updatedTeamName, validity: validity });
 						setErrorMessages([]);
 					}}
-					invalid={isValidated && !!teamNameErrorMessage}
-					readOnly={isLoading}
 				/>
 				<InputPassword
 					password={password.value}
@@ -136,8 +109,6 @@ function CreateTeamPage(): JSX.Element {
 						setPassword({ value: updatedPassword, validity: isValid });
 						setErrorMessages([]);
 					}}
-					invalid={isValidated && !!passwordErrorMessage}
-					readOnly={isLoading}
 				/>
 				<InputEmail
 					id="emailInput"
@@ -147,7 +118,6 @@ function CreateTeamPage(): JSX.Element {
 						setEmail({ value: value, validity: validity });
 						setErrorMessages([]);
 					}}
-					readOnly={isLoading}
 				/>
 				<InputEmail
 					id="secondEmailInput"
@@ -158,7 +128,6 @@ function CreateTeamPage(): JSX.Element {
 						setSecondEmail({ value: value, validity: validity });
 						setErrorMessages([]);
 					}}
-					readOnly={isLoading}
 				/>
 			</Form>
 			<div className="or-separator-line">

--- a/ui/src/App/CreateTeam/CreateTeamPage.tsx
+++ b/ui/src/App/CreateTeam/CreateTeamPage.tsx
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as React from 'react';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import Form from 'Common/AuthTemplate/Form/Form';
+import InputEmail from 'Common/InputEmail/InputEmail';
 import InputPassword from 'Common/InputPassword/InputPassword';
 import InputTeamName from 'Common/InputTeamName/InputTeamName';
 import useAuth from 'Hooks/useAuth';
@@ -29,18 +29,18 @@ import {
 	getTeamNameInvalidMessage,
 } from 'Utils/StringUtils';
 
-import InputEmail from '../../Common/InputEmail/InputEmail';
-
 import './CreateTeamPage.scss';
 
-export default function CreateTeamPage(): JSX.Element {
-	interface ValueAndValidity {
-		value: string;
-		validity: boolean;
-	}
-	const blankValueWithValidity = { value: '', validity: false };
+const blankValueWithValidity = { value: '', validity: false };
 
+interface ValueAndValidity {
+	value: string;
+	validity: boolean;
+}
+
+function CreateTeamPage(): JSX.Element {
 	const { login } = useAuth();
+
 	const [teamName, setTeamName] = useState<ValueAndValidity>(
 		blankValueWithValidity
 	);
@@ -174,3 +174,5 @@ export default function CreateTeamPage(): JSX.Element {
 		</AuthTemplate>
 	);
 }
+
+export default CreateTeamPage;

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.scss
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.scss
@@ -20,6 +20,9 @@
 .password-reset-request-page {
 	.password-reset-description {
 		margin-bottom: 0;
+
+		color: main.$dark-gray;
+		font-size: 1rem;
 	}
 
 	.success-indicator {

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.spec.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.spec.tsx
@@ -16,6 +16,7 @@
  */
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ContributorsService from 'Services/Api/ContributorsService';
 import TeamService from 'Services/Api/TeamService';
 
@@ -25,11 +26,23 @@ jest.mock('Services/Api/TeamService');
 jest.mock('Services/Api/ContributorsService');
 
 describe('Password Reset Request Page', () => {
-	it('should have a field for team name and email, plus a send link button', async () => {
+	it('should have a field for team name and email, plus a disabled send link button', async () => {
 		await renderPasswordResetRequestPage();
 		expect(screen.getByLabelText('Team Name')).toBeInTheDocument();
 		expect(screen.getByLabelText('Email')).toBeInTheDocument();
-		expect(screen.getByText('Send reset link')).toBeInTheDocument();
+		const submitButton = screen.getByText('Send reset link');
+		expect(submitButton).toBeDisabled();
+	});
+
+	it('should enable submit button when fields are populated with valid values', async () => {
+		await renderPasswordResetRequestPage();
+		userEvent.type(screen.getByLabelText('Team Name'), 'Super Board');
+		const emailInput = screen.getByLabelText('Email');
+		userEvent.type(emailInput, 'a@');
+		const submitButton = screen.getByText('Send reset link');
+		expect(submitButton).toBeDisabled();
+		userEvent.type(emailInput, 'a@b');
+		expect(submitButton).toBeEnabled();
 	});
 
 	it('should send team name and email to the backend on submission', async () => {

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
@@ -23,24 +23,37 @@ import TeamService from 'Services/Api/TeamService';
 
 import './PasswordResetRequestPage.scss';
 
+const blankValueWithValidity = { value: '', validity: false };
+
+interface ValueAndValidity {
+	value: string;
+	validity: boolean;
+}
+
 function PasswordResetRequestPage(): JSX.Element {
 	const [shouldShowSent, setShouldShowSent] = useState(false);
-	const [teamName, setTeamName] = useState<string>('');
-	const [email, setEmail] = useState<string>('');
+
+	const [teamName, setTeamName] = useState<ValueAndValidity>(
+		blankValueWithValidity
+	);
+	const [email, setEmail] = useState<ValueAndValidity>(blankValueWithValidity);
+
 	const [errorMessages, setErrorMessages] = useState<string[]>([]);
 
 	function submitRequest() {
 		if (!!teamName && !!email) {
-			TeamService.sendPasswordResetLink(teamName, email)
-				.then(() => {
-					setShouldShowSent(true);
-				})
-				.catch(() => {
+			TeamService.sendPasswordResetLink(teamName.value, email.value)
+				.then(() => setShouldShowSent(true))
+				.catch(() =>
 					setErrorMessages([
 						'Team name or email is incorrect. Please try again.',
-					]);
-				});
+					])
+				);
 		}
+	}
+
+	function disableSubmitButton(): boolean {
+		return !teamName.validity || !email.validity;
 	}
 
 	return (
@@ -59,22 +72,21 @@ function PasswordResetRequestPage(): JSX.Element {
 				submitButtonText="Send reset link"
 				onSubmit={submitRequest}
 				errorMessages={errorMessages}
+				disableSubmitBtn={disableSubmitButton()}
 			>
 				<InputTeamName
-					value={teamName}
-					onChange={(name) => {
-						setTeamName(name);
+					value={teamName.value}
+					onChange={(name, isValid) => {
+						setTeamName({ value: name, validity: isValid });
 						setErrorMessages([]);
 					}}
-					required
 				/>
 				<InputEmail
-					value={email}
-					onChange={(email) => {
-						setEmail(email);
+					value={email.value}
+					onChange={(email, isValid) => {
+						setEmail({ value: email, validity: isValid });
 						setErrorMessages([]);
 					}}
-					required
 				/>
 			</Form>
 			{shouldShowSent && <div className="success-indicator">Link Sent!</div>}

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
@@ -45,11 +45,12 @@ function PasswordResetRequestPage(): JSX.Element {
 
 	return (
 		<AuthTemplate
-			header="Reset your password"
+			header="Reset your Password"
 			subHeader={
 				<p className="password-reset-description">
-					Enter the Team Name and email associated with your team's account and
-					we’ll send an email with instructions to reset your password.
+					Enter the Team Name <u>and</u> email associated with your team's
+					account and we’ll send an email with instructions to reset your
+					password.
 				</p>
 			}
 			className="password-reset-request-page"

--- a/ui/src/Common/AuthTemplate/AuthTemplate.scss
+++ b/ui/src/Common/AuthTemplate/AuthTemplate.scss
@@ -74,6 +74,7 @@
 
 	.auth-sub-heading {
 		font-size: 1.2rem;
+		text-align: left;
 
 		a {
 			color: main.$dark-turquoise;

--- a/ui/src/Common/AuthTemplate/Form/Form.scss
+++ b/ui/src/Common/AuthTemplate/Form/Form.scss
@@ -18,14 +18,25 @@
 @use '../../../Styles/main';
 
 .form {
-	.error-message {
-		margin-top: 1rem;
-		color: main.$dark-red;
+	.error-messages {
+		display: flex;
+		flex-direction: column;
+		flex-flow: column-reverse;
+		height: 2rem;
+
+		.error-message {
+			margin: 0.5rem 0;
+
+			color: main.$red;
+			font-weight: 500;
+			font-size: 14px;
+			font-style: normal;
+			line-height: 18px;
+		}
 	}
 
 	.submit-button {
 		width: 100%;
-		margin-top: 48px;
 
 		color: main.$gray-1;
 
@@ -45,8 +56,10 @@
 
 @include main.dark-theme {
 	.form {
-		.error-message {
-			color: main.$red;
+		.error-messages {
+			.error-message {
+				color: main.$light-red;
+			}
 		}
 
 		.submit-button {

--- a/ui/src/Common/AuthTemplate/Form/Form.scss
+++ b/ui/src/Common/AuthTemplate/Form/Form.scss
@@ -20,8 +20,7 @@
 .form {
 	.error-messages {
 		display: flex;
-		flex-direction: column;
-		flex-flow: column-reverse;
+		flex-direction: column-reverse;
 		height: 2rem;
 
 		.error-message {

--- a/ui/src/Common/AuthTemplate/Form/Form.tsx
+++ b/ui/src/Common/AuthTemplate/Form/Form.tsx
@@ -49,15 +49,17 @@ function Form(props: FormProps): JSX.Element {
 			{...formProps}
 		>
 			{children}
-			{errorMessages.map((errorMessage, index) => (
-				<div
-					className="error-message"
-					key={index}
-					data-testid="formErrorMessage"
-				>
-					{errorMessage}
-				</div>
-			))}
+			<div className="error-messages">
+				{errorMessages.map((errorMessage, index) => (
+					<span
+						className="error-message"
+						key={index}
+						data-testid="formErrorMessage"
+					>
+						{errorMessage}
+					</span>
+				))}
+			</div>
 			<PrimaryButton
 				className="submit-button"
 				disabled={disableSubmitBtn}

--- a/ui/src/Utils/StringUtils.spec.ts
+++ b/ui/src/Utils/StringUtils.spec.ts
@@ -14,62 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-	checkValidityOfPassword,
-	getPasswordInvalidMessage,
-	getTeamNameInvalidMessage,
-} from './StringUtils';
+import { checkValidityOfPassword } from './StringUtils';
 
 describe('String Utils', () => {
-	const emptyTeamNameError = 'Please enter a team name.';
-	const specialCharacterError =
-		'Please enter a team name without any special characters.';
-
-	it.each([
-		['', emptyTeamNameError],
-		[null, emptyTeamNameError],
-		[undefined, emptyTeamNameError],
-		['!', specialCharacterError],
-		['@', specialCharacterError],
-		['-', specialCharacterError],
-		['_', specialCharacterError],
-		['\\', specialCharacterError],
-		['a', undefined],
-		['1', undefined],
-		['a1', undefined],
-	])(
-		'validating team name "%s" should return error message "%s"',
-		(teamName, errorMessage) => {
-			expect(getTeamNameInvalidMessage(teamName!)).toBe(errorMessage);
-		}
-	);
-
-	const emptyPasswordError = 'Please enter a password.';
-	const minLengthError = 'Password must be at least 8 characters.';
-	const uppercaseError =
-		'Password must contain at least one upper case letter.';
-	const numberError = 'Password must contain at least one number.';
-
-	it.each([
-		['', emptyPasswordError],
-		[null, emptyPasswordError],
-		[undefined, emptyPasswordError],
-		['1', minLengthError],
-		['1234567', minLengthError],
-		['A', minLengthError],
-		['a', minLengthError],
-		['aA1', minLengthError],
-		['12345678a', uppercaseError],
-		['abcdefgA', numberError],
-		['abcdefgA1', undefined],
-		["abcdefgA1#!@#$%^&*()_+}{[];'\\<>? ", undefined],
-	])(
-		'validating password %s should return error message "%s"',
-		(password, errorMessage) => {
-			expect(getPasswordInvalidMessage(password!)).toBe(errorMessage);
-		}
-	);
-
 	it.each([
 		['', false],
 		[null, false],

--- a/ui/src/Utils/StringUtils.ts
+++ b/ui/src/Utils/StringUtils.ts
@@ -14,34 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const TEAM_NAME_REGEX = /^[A-Za-z0-9 ]+$/;
-export const PASSWORD_REGEX = /^(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$/;
 
-export const LOWERCASE_REGEX = /[a-z]/;
 export const UPPERCASE_REGEX = /[A-Z]/;
 export const NUMBER_REGEX = /\d/;
-
-export function getTeamNameInvalidMessage(team: string): string | undefined {
-	if (!team) {
-		return 'Please enter a team name.';
-	} else if (!team.match(TEAM_NAME_REGEX)) {
-		return 'Please enter a team name without any special characters.';
-	}
-}
-
-export function getPasswordInvalidMessage(
-	password: string
-): string | undefined {
-	if (!password) {
-		return 'Please enter a password.';
-	} else if (password.length < 8) {
-		return 'Password must be at least 8 characters.';
-	} else if (!password.match(UPPERCASE_REGEX)) {
-		return 'Password must contain at least one upper case letter.';
-	} else if (!password.match(NUMBER_REGEX)) {
-		return 'Password must contain at least one number.';
-	}
-}
 
 export function checkValidityOfPassword(password: string): boolean {
 	return (


### PR DESCRIPTION
## What was done
**Reset Password Request**
- [x] Change Title to "Reset your Password" with a capital P
- [x] Reformat subheader text to: Quicksand Bold, 16px font, Dark Gray (#64717D), Left aligned, with "and" underlined.
- [x] Changed state of "Send Reset Link" button to disabled until the user types in valid values
- [x] Ensured form has red validation messages that show up until a user types in valid values
- [x] Updated the error message that comes back from the server to be positioned right above the submit button and to not move anything when it appears 

**Create Team Page**
- [x] Updated the error message that comes back from the server to be positioned right above the submit button and to not move anything when it appears 
- [x] Removed relic/now unused error handling 

## Testing Instructions
Test the Reset password request page and the create page to ensure that all of the above is true and matches mockups