### PR TITLE
Reset password request confirmation

### DIFF
--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -15,10 +15,6 @@
 # limitations under the License.
 #
 
-retroquest:
-  marketing:
-    survey-link-href: http://localhost:3000
-
 spring:
   h2:
     console:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -16,8 +16,6 @@
 #
 
 retroquest:
-  marketing:
-    survey-link-href:
   security:
     require-https: false
     jwt-signing-secret: ASLKJHDKJHikjsdkjhg1iu2heiIUGEIUQ@IUeiUIU@iyrgiu2g3i # This is a default value. Ensure you override this value on any real deployments.

--- a/api/src/test/java/com/ford/labs/retroquest/api/ConfigurationApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ConfigurationApiTest.java
@@ -15,20 +15,20 @@
  * limitations under the License.
  */
 
-package com.ford.labs.retroquest.config;
+package com.ford.labs.retroquest.api;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Tag("api")
 @SpringBootTest
 @AutoConfigureMockMvc
 public class ConfigurationApiTest {
@@ -42,6 +42,6 @@ public class ConfigurationApiTest {
                 .andReturn();
 
         assertThat(mvcResult.getResponse().getContentAsString())
-                .isEqualTo("{\"survey_link_href\":\"test-survey-link-href\"}");
+                .isEqualTo("{\"email_from_address\":\"test@mail.com\"}");
     }
 }

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -16,8 +16,6 @@
 #
 
 retroquest:
-  marketing:
-    survey-link-href: test-survey-link-href
   security:
     require-https: false
     jwt-signing-secret: IMSOSECRETYOUDONTEVENKNOW

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.scss
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.scss
@@ -58,6 +58,10 @@
 
 @include main.dark-theme {
 	.password-reset-request-page {
+		.password-reset-description {
+			color: main.$light-gray;
+		}
+
 		.paragraph-1 {
 			color: main.$turquoise;
 		}

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.scss
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.scss
@@ -25,15 +25,45 @@
 		font-size: 1rem;
 	}
 
-	.success-indicator {
-		margin-top: 1rem;
+	.paragraph-1-container {
+		display: flex;
+		align-items: center;
 
-		color: main.$dark-turquoise;
+		.checkbox-icon {
+			width: 35px;
+			height: 28px;
+			margin: 1rem;
+		}
+
+		.paragraph-1 {
+			margin-top: 1rem;
+
+			color: main.$dark-turquoise;
+			font-weight: bold;
+		}
+	}
+
+	.paragraph-2 {
+		margin: 0.5rem 0 0;
+
+		color: main.$dark-gray;
 		font-weight: bold;
 		text-align: center;
 	}
 
 	.login-button-link {
 		@include main.button-primary;
+	}
+}
+
+@include main.dark-theme {
+	.password-reset-request-page {
+		.paragraph-1 {
+			color: main.$turquoise;
+		}
+
+		.paragraph-2 {
+			color: main.$light-gray;
+		}
 	}
 }

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.scss
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.scss
@@ -32,4 +32,8 @@
 		font-weight: bold;
 		text-align: center;
 	}
+
+	.login-button-link {
+		@include main.button-primary;
+	}
 }

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.spec.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.spec.tsx
@@ -79,18 +79,17 @@ describe('Password Reset Request Page', () => {
 		await waitFor(() =>
 			expect(screen.queryByText('Reset your Password')).toBeNull()
 		);
-		expect(screen.getByText(confirmationMessage)).toBeInTheDocument();
-		expect(
-			screen.getByText(
-				`We’ve sent an email to test@mail.com with password reset instructions.`
-			)
-		).toBeInTheDocument();
-		expect(
-			screen.getByText(
-				"If an email doesn't show up soon, check your spam folder. We sent it from mock@email.com."
-			)
-		).toBeInTheDocument();
 		expect(screen.queryByText('Github')).toBeNull();
+		expect(screen.getByText(confirmationMessage)).toBeInTheDocument();
+		const paragraph1 = `We’ve sent an email to test@mail.com with password reset instructions.`;
+		expect(screen.getByText(paragraph1)).toBeInTheDocument();
+		const paragraph2 =
+			"If an email doesn't show up soon, check your spam folder. We sent it from mock@email.com.";
+		expect(screen.getByText(paragraph2)).toBeInTheDocument();
+		expect(screen.getByText('Return to Login')).toHaveAttribute(
+			'href',
+			'/login'
+		);
 	});
 
 	it('should not show confirmation message if the form is not submitted', async () => {

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.spec.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.spec.tsx
@@ -33,12 +33,13 @@ jest.mock('Services/Api/ContributorsService');
 jest.mock('Services/Api/ConfigurationService');
 
 describe('Password Reset Request Page', () => {
-	it('should have a field for team name and email, plus a disabled send link button', async () => {
+	it('should have a field for team name and email, a disabled send link button, & a github link', async () => {
 		await renderPasswordResetRequestPage();
 		expect(screen.getByLabelText('Team Name')).toBeInTheDocument();
 		expect(screen.getByLabelText('Email')).toBeInTheDocument();
 		const submitButton = screen.getByText('Send reset link');
 		expect(submitButton).toBeDisabled();
+		expect(screen.getByText('Github')).toBeInTheDocument();
 	});
 
 	it('should enable submit button when fields are populated with valid values', async () => {
@@ -89,6 +90,7 @@ describe('Password Reset Request Page', () => {
 				"If an email doesn't show up soon, check your spam folder. We sent it from mock@email.com."
 			)
 		).toBeInTheDocument();
+		expect(screen.queryByText('Github')).toBeNull();
 	});
 
 	it('should not show confirmation message if the form is not submitted', async () => {

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.spec.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.spec.tsx
@@ -16,11 +16,15 @@
  */
 
 import { MemoryRouter } from 'react-router-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MutableSnapshot } from 'recoil';
 import ConfigurationService from 'Services/Api/ConfigurationService';
 import ContributorsService from 'Services/Api/ContributorsService';
 import TeamService from 'Services/Api/TeamService';
+import { ThemeState } from 'State/ThemeState';
+import Theme from 'Types/Theme';
+import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
 
 import PasswordResetRequestPage from './PasswordResetRequestPage';
 
@@ -95,6 +99,30 @@ describe('Password Reset Request Page', () => {
 		expect(screen.getByText('Reset your Password')).toBeInTheDocument();
 	});
 
+	it('should render checkbox in confirmation screen as dark turquoise in light mode', async () => {
+		await renderPasswordResetRequestPage(({ set }) => {
+			set(ThemeState, Theme.LIGHT);
+		});
+		submitValidForm();
+
+		const checkedCheckboxIcon = await screen.findByTestId(
+			'checkedCheckboxIcon'
+		);
+		expect(checkedCheckboxIcon.getAttribute('fill')).toBe('#16a085');
+	});
+
+	it('should render checkbox in confirmation screen as light turquoise in dark mode', async () => {
+		await renderPasswordResetRequestPage(({ set }) => {
+			set(ThemeState, Theme.DARK);
+		});
+		submitValidForm();
+
+		const checkedCheckboxIcon = await screen.findByTestId(
+			'checkedCheckboxIcon'
+		);
+		expect(checkedCheckboxIcon.getAttribute('fill')).toBe('#1abc9c');
+	});
+
 	it('should show an error message if the request is not successful that persists until you type in either input', async () => {
 		TeamService.sendPasswordResetLink = jest
 			.fn()
@@ -116,11 +144,14 @@ describe('Password Reset Request Page', () => {
 	});
 });
 
-async function renderPasswordResetRequestPage() {
-	render(
+async function renderPasswordResetRequestPage(
+	recoilState?: (mutableSnapshot: MutableSnapshot) => void
+) {
+	renderWithRecoilRoot(
 		<MemoryRouter>
 			<PasswordResetRequestPage />
-		</MemoryRouter>
+		</MemoryRouter>,
+		recoilState
 	);
 	await waitFor(() => expect(ContributorsService.get).toHaveBeenCalled());
 	await waitFor(() =>

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
@@ -14,11 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import Form from 'Common/AuthTemplate/Form/Form';
 import InputEmail from 'Common/InputEmail/InputEmail';
 import InputTeamName from 'Common/InputTeamName/InputTeamName';
+import ConfigurationService from 'Services/Api/ConfigurationService';
 import TeamService from 'Services/Api/TeamService';
 
 import './PasswordResetRequestPage.scss';
@@ -31,19 +33,18 @@ interface ValueAndValidity {
 }
 
 function PasswordResetRequestPage(): JSX.Element {
-	const [shouldShowSent, setShouldShowSent] = useState(false);
-
+	const [emailFromAddress, setEmailFromAddress] = useState<string>('');
+	const [requestSent, setRequestSent] = useState<boolean>(false);
 	const [teamName, setTeamName] = useState<ValueAndValidity>(
 		blankValueWithValidity
 	);
 	const [email, setEmail] = useState<ValueAndValidity>(blankValueWithValidity);
-
 	const [errorMessages, setErrorMessages] = useState<string[]>([]);
 
 	function submitRequest() {
 		if (!!teamName && !!email) {
 			TeamService.sendPasswordResetLink(teamName.value, email.value)
-				.then(() => setShouldShowSent(true))
+				.then(() => setRequestSent(true))
 				.catch(() =>
 					setErrorMessages([
 						'Team name or email is incorrect. Please try again.',
@@ -56,41 +57,67 @@ function PasswordResetRequestPage(): JSX.Element {
 		return !teamName.validity || !email.validity;
 	}
 
+	useEffect(() => {
+		if (!emailFromAddress) {
+			ConfigurationService.get().then((config) =>
+				setEmailFromAddress(config.email_from_address)
+			);
+		}
+	});
+
 	return (
-		<AuthTemplate
-			header="Reset your Password"
-			subHeader={
-				<p className="password-reset-description">
-					Enter the Team Name <u>and</u> email associated with your team's
-					account and we’ll send an email with instructions to reset your
-					password.
-				</p>
-			}
-			className="password-reset-request-page"
-		>
-			<Form
-				submitButtonText="Send reset link"
-				onSubmit={submitRequest}
-				errorMessages={errorMessages}
-				disableSubmitBtn={disableSubmitButton()}
-			>
-				<InputTeamName
-					value={teamName.value}
-					onChange={(name, isValid) => {
-						setTeamName({ value: name, validity: isValid });
-						setErrorMessages([]);
-					}}
-				/>
-				<InputEmail
-					value={email.value}
-					onChange={(email, isValid) => {
-						setEmail({ value: email, validity: isValid });
-						setErrorMessages([]);
-					}}
-				/>
-			</Form>
-			{shouldShowSent && <div className="success-indicator">Link Sent!</div>}
-		</AuthTemplate>
+		<>
+			{!requestSent && (
+				<AuthTemplate
+					header="Reset your Password"
+					subHeader={
+						<p className="password-reset-description">
+							Enter the Team Name <u>and</u> email associated with your team's
+							account and we’ll send an email with instructions to reset your
+							password.
+						</p>
+					}
+					className="password-reset-request-page"
+				>
+					<Form
+						submitButtonText="Send reset link"
+						onSubmit={submitRequest}
+						errorMessages={errorMessages}
+						disableSubmitBtn={disableSubmitButton()}
+					>
+						<InputTeamName
+							value={teamName.value}
+							onChange={(name, isValid) => {
+								setTeamName({ value: name, validity: isValid });
+								setErrorMessages([]);
+							}}
+						/>
+						<InputEmail
+							value={email.value}
+							onChange={(email, isValid) => {
+								setEmail({ value: email, validity: isValid });
+								setErrorMessages([]);
+							}}
+						/>
+					</Form>
+				</AuthTemplate>
+			)}
+			{requestSent && (
+				<AuthTemplate header="Check your Mail!">
+					<p>
+						We’ve sent an email to {email.value} with password reset
+						instructions.
+					</p>
+					<p>
+						If an email doesn't show up soon, check your spam folder. We sent it
+						from {emailFromAddress}.
+					</p>
+					<Link className="login-button-link" to="/login">
+						Return to Login
+					</Link>
+				</AuthTemplate>
+			)}
+		</>
 	);
 }
 

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
@@ -115,6 +115,7 @@ function PasswordResetRequestPage(): JSX.Element {
 				<AuthTemplate
 					header="Check your Mail!"
 					className="password-reset-request-page"
+					showGithubLink={false}
 				>
 					<div className="paragraph-1-container">
 						<CheckedCheckboxIcon

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
@@ -23,6 +23,8 @@ import InputTeamName from 'Common/InputTeamName/InputTeamName';
 import ConfigurationService from 'Services/Api/ConfigurationService';
 import TeamService from 'Services/Api/TeamService';
 
+import { LOGIN_PAGE_PATH } from '../../RouteConstants';
+
 import './PasswordResetRequestPage.scss';
 
 const blankValueWithValidity = { value: '', validity: false };
@@ -103,7 +105,10 @@ function PasswordResetRequestPage(): JSX.Element {
 				</AuthTemplate>
 			)}
 			{requestSent && (
-				<AuthTemplate header="Check your Mail!">
+				<AuthTemplate
+					header="Check your Mail!"
+					className="password-reset-request-page"
+				>
 					<p>
 						We’ve sent an email to {email.value} with password reset
 						instructions.
@@ -112,7 +117,7 @@ function PasswordResetRequestPage(): JSX.Element {
 						If an email doesn't show up soon, check your spam folder. We sent it
 						from {emailFromAddress}.
 					</p>
-					<Link className="login-button-link" to="/login">
+					<Link className="login-button-link" to={LOGIN_PAGE_PATH}>
 						Return to Login
 					</Link>
 				</AuthTemplate>

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
@@ -16,14 +16,17 @@
  */
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import CheckedCheckboxIcon from 'Assets/CheckedCheckboxIcon';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import Form from 'Common/AuthTemplate/Form/Form';
 import InputEmail from 'Common/InputEmail/InputEmail';
 import InputTeamName from 'Common/InputTeamName/InputTeamName';
+import { useRecoilValue } from 'recoil';
+import { LOGIN_PAGE_PATH } from 'RouteConstants';
 import ConfigurationService from 'Services/Api/ConfigurationService';
 import TeamService from 'Services/Api/TeamService';
-
-import { LOGIN_PAGE_PATH } from '../../RouteConstants';
+import { ThemeState } from 'State/ThemeState';
+import Theme from 'Types/Theme';
 
 import './PasswordResetRequestPage.scss';
 
@@ -37,11 +40,15 @@ interface ValueAndValidity {
 function PasswordResetRequestPage(): JSX.Element {
 	const [emailFromAddress, setEmailFromAddress] = useState<string>('');
 	const [requestSent, setRequestSent] = useState<boolean>(false);
+	const [errorMessages, setErrorMessages] = useState<string[]>([]);
+
 	const [teamName, setTeamName] = useState<ValueAndValidity>(
 		blankValueWithValidity
 	);
 	const [email, setEmail] = useState<ValueAndValidity>(blankValueWithValidity);
-	const [errorMessages, setErrorMessages] = useState<string[]>([]);
+
+	const theme = useRecoilValue(ThemeState);
+	const checkboxIconColor = theme === Theme.DARK ? '#1abc9c' : '#16a085';
 
 	function submitRequest() {
 		if (!!teamName && !!email) {
@@ -109,11 +116,17 @@ function PasswordResetRequestPage(): JSX.Element {
 					header="Check your Mail!"
 					className="password-reset-request-page"
 				>
-					<p>
-						We’ve sent an email to {email.value} with password reset
-						instructions.
-					</p>
-					<p>
+					<div className="paragraph-1-container">
+						<CheckedCheckboxIcon
+							color={checkboxIconColor}
+							className="checkbox-icon"
+						/>
+						<p className="paragraph-1">
+							We’ve sent an email to {email.value} with password reset
+							instructions.
+						</p>
+					</div>
+					<p className="paragraph-2">
 						If an email doesn't show up soon, check your spam folder. We sent it
 						from {emailFromAddress}.
 					</p>

--- a/ui/src/App/ResetPassword/ResetPasswordPage.scss
+++ b/ui/src/App/ResetPassword/ResetPasswordPage.scss
@@ -52,54 +52,7 @@
 		}
 
 		.login-button-link {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			width: 100%;
-			min-width: 125px;
-			height: 45px;
-			margin-top: 2rem;
-			padding: 0 24px;
-
-			color: main.$gray-1;
-
-			font-family: inherit;
-			font-weight: 700;
-			font-size: 1rem;
-			white-space: nowrap;
-			text-transform: capitalize;
-			text-decoration: none;
-
-			background-color: main.$dark-turquoise;
-
-			border: 0;
-			border-radius: 6px;
-			box-shadow: none;
-			cursor: pointer;
-
-			&:disabled {
-				cursor: initial;
-				opacity: 0.3;
-			}
-
-			&:hover:not(:disabled),
-			&:focus:not(:disabled) {
-				background-color: main.$turquoise;
-			}
-		}
-	}
-}
-
-@include main.dark-theme {
-	.success-feedback-container {
-		.login-button-link {
-			color: main.$asphalt;
-			background-color: main.$turquoise;
-
-			&:hover,
-			&:focus {
-				background-color: main.$dark-turquoise;
-			}
+			@include main.button-primary;
 		}
 	}
 }

--- a/ui/src/Assets/CheckedCheckboxIcon.tsx
+++ b/ui/src/Assets/CheckedCheckboxIcon.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface Props {
+	color: string;
+	className?: string;
+}
+
+function CheckedCheckboxIcon({ color, className }: Props) {
+	return (
+		<svg
+			role="presentation"
+			width="36"
+			height="28"
+			viewBox="0 0 36 28"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			className={className}
+		>
+			<path
+				data-testid="checkedCheckboxIcon"
+				d="M24.7049 25.2053H3.29443V3.79482H24.7049V3.79753L27.5 1.00247V1H0.5V28H27.5V14.9658L24.7049 17.7601V25.2053Z"
+				fill={color}
+			/>
+			<path
+				d="M31.4035 0L16.9595 14.0395L9.59502 6.8813L5.5 10.862L16.9599 22L35.5 3.98073L31.4035 0Z"
+				fill={color}
+			/>
+		</svg>
+	);
+}
+
+export default CheckedCheckboxIcon;

--- a/ui/src/Common/AuthTemplate/AuthTemplate.tsx
+++ b/ui/src/Common/AuthTemplate/AuthTemplate.tsx
@@ -28,10 +28,17 @@ type AuthTemplateProps = React.PropsWithChildren<{
 	header: React.ReactNode;
 	subHeader?: React.ReactNode;
 	className?: string;
+	showGithubLink?: boolean;
 }>;
 
 export default function AuthTemplate(props: AuthTemplateProps): JSX.Element {
-	const { header, subHeader, children, className } = props;
+	const {
+		header,
+		subHeader,
+		children,
+		className,
+		showGithubLink = true,
+	} = props;
 
 	return (
 		<main className={classNames('auth-template', className)}>
@@ -43,15 +50,17 @@ export default function AuthTemplate(props: AuthTemplateProps): JSX.Element {
 				</div>
 				<div className="auth-template-content">{children}</div>
 				<div className="auth-template-footer">
-					<a
-						className="github-link"
-						target="_blank"
-						rel="noopener noreferrer"
-						href="https://github.com/FordLabs/retroquest"
-					>
-						<i className="fab fa-github" aria-hidden="true" />
-						<span>Github</span>
-					</a>
+					{showGithubLink && (
+						<a
+							className="github-link"
+							target="_blank"
+							rel="noopener noreferrer"
+							href="https://github.com/FordLabs/retroquest"
+						>
+							<i className="fab fa-github" aria-hidden="true" />
+							<span>Github</span>
+						</a>
+					)}
 				</div>
 			</div>
 			<Contributors />

--- a/ui/src/Services/Api/ConfigurationService.ts
+++ b/ui/src/Services/Api/ConfigurationService.ts
@@ -16,13 +16,10 @@
  */
 
 import axios from 'axios';
-
-interface Config {
-	survey_link_href: string;
-}
+import EnvironmentConfig from 'Types/EnvironmentConfig';
 
 const configurationService = {
-	get(): Promise<Config> {
+	get(): Promise<EnvironmentConfig> {
 		return axios.get('/api/config').then((response) => response.data);
 	},
 };

--- a/ui/src/Services/Api/__mocks__/ConfigurationService.ts
+++ b/ui/src/Services/Api/__mocks__/ConfigurationService.ts
@@ -15,8 +15,12 @@
  * limitations under the License.
  */
 
+import EnvironmentConfig from 'Types/EnvironmentConfig';
+
 const configurationService = {
-	get: jest.fn().mockResolvedValue({ survey_link_href: 'mockSurveyLinkHref' }),
+	get: jest.fn().mockResolvedValue({
+		email_from_address: 'mock@email.com',
+	} as EnvironmentConfig),
 };
 
 export default configurationService;

--- a/ui/src/Styles/_buttons.scss
+++ b/ui/src/Styles/_buttons.scss
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use 'colors';
+
+@mixin button-defaults {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 125px;
+	height: 45px;
+	padding: 0 24px;
+
+	font-family: inherit;
+	font-weight: 700;
+	font-size: 1rem;
+	white-space: nowrap;
+	text-transform: capitalize;
+
+	border: 0;
+	border-radius: 6px;
+	box-shadow: none;
+	cursor: pointer;
+}
+
+@mixin button-primary {
+	@include button-defaults;
+
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	min-width: 125px;
+	height: 45px;
+	margin-top: 2rem;
+	padding: 0 24px;
+
+	color: colors.$white;
+
+	font-family: inherit;
+	font-weight: 700;
+	font-size: 1rem;
+	white-space: nowrap;
+	text-transform: capitalize;
+	text-decoration: none;
+
+	background-color: colors.$dark-turquoise;
+	border: 0;
+	border-radius: 6px;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.16), 0 2px 4px rgba(0, 0, 0, 0.12),
+		0 1px 8px rgba(0, 0, 0, 0.1);
+	cursor: pointer;
+
+	&:disabled {
+		cursor: initial;
+		opacity: 0.3;
+	}
+
+	&:hover:not(:disabled),
+	&:focus:not(:disabled) {
+		background-color: colors.$turquoise;
+	}
+
+	.dark-theme & {
+		color: colors.$asphalt;
+		background-color: colors.$turquoise;
+
+		&:hover:not(:disabled),
+		&:focus:not(:disabled) {
+			background-color: colors.$dark-turquoise;
+		}
+	}
+}

--- a/ui/src/Styles/_colors.scss
+++ b/ui/src/Styles/_colors.scss
@@ -22,6 +22,7 @@ $gray-1: #ecf0f1;
 $gray-2: #ecf0f1ad;
 $gray-3: #95a5a6;
 $dark-gray: #64717d;
+$light-gray: #b2bbc5;
 
 $green: #2ecc71;
 $dark-green: #27ae60;

--- a/ui/src/Styles/_mixins.scss
+++ b/ui/src/Styles/_mixins.scss
@@ -131,23 +131,3 @@
 		}
 	}
 }
-
-@mixin button-defaults {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	min-width: 125px;
-	height: 45px;
-	padding: 0 24px;
-
-	font-family: inherit;
-	font-weight: 700;
-	font-size: 1rem;
-	white-space: nowrap;
-	text-transform: capitalize;
-
-	border: 0;
-	border-radius: 6px;
-	box-shadow: none;
-	cursor: pointer;
-}

--- a/ui/src/Styles/main.scss
+++ b/ui/src/Styles/main.scss
@@ -19,6 +19,7 @@
 @forward 'mixins';
 @forward 'sizes';
 @forward 'functions';
+@forward 'buttons';
 
 @use 'colors';
 

--- a/ui/src/Types/EnvironmentConfig.ts
+++ b/ui/src/Types/EnvironmentConfig.ts
@@ -15,15 +15,8 @@
  * limitations under the License.
  */
 
-package com.ford.labs.retroquest.config;
-
-import lombok.Data;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-@Component
-@Data
-public class EnvironmentConfiguration {
-    @Value("${retroquest.email.from-address}")
-    String email_from_address = "";
+interface EnvironmentConfig {
+	email_from_address: string;
 }
+
+export default EnvironmentConfig;


### PR DESCRIPTION
## Overview
Updated the confirmation message for the reset password request page. It now shows a message saying an email was sent, to what email it was sent too, and what email it was sent from.

### Demo
<img width="1613" alt="Screen Shot 2022-09-21 at 1 32 29 PM" src="https://user-images.githubusercontent.com/17144844/191572318-6c4f20dd-f7d4-4c20-bfd8-a66708acdf8d.png">
 an issue, please [link it](https://help.github.com/articles/autolinked-references-and-urls/). 

## Testing Instructions
1) Go to the password reset request page: http://localhost:3000/request-password-reset
2) Submit a valid request
3) Ensure that the new page shows the mocks, and has the correct emails in it

