### PR TITLE
Token expired page

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/team/ResetTokenStatusRequest.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/ResetTokenStatusRequest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.team;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder=true)
+public class ResetTokenStatusRequest {
+    private String resetToken;
+}

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
@@ -27,6 +27,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.coyote.Response;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -116,6 +118,12 @@ public class TeamController {
     public boolean checkResetTokenStatus(@RequestBody ResetTokenStatusRequest resetTokenStatusRequest) {
         PasswordResetToken passwordResetToken = passwordResetRepository.findByResetToken(resetTokenStatusRequest.getResetToken());
         return passwordResetToken != null && !passwordResetToken.isExpired();
+    }
+
+    @GetMapping("/password/reset/token-lifetime-seconds")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
+    public ResponseEntity<Integer> getResetTokenValiditySeconds(@Value("${retroquest.password.reset.token-lifetime-seconds:600}") int tokenSeconds){
+        return ResponseEntity.ok(tokenSeconds);
     }
 
     @GetMapping(value = "/team/{teamId}/csv", produces = "application/board.csv")

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
@@ -112,6 +112,13 @@ public class TeamController {
         passwordResetRepository.delete(passwordResetToken);
     }
 
+    @PostMapping("/password/reset/is-valid")
+    public boolean checkResetTokenStatus(@RequestBody ResetTokenStatusRequest resetTokenStatusRequest) {
+        PasswordResetToken passwordResetToken = passwordResetRepository.findByResetToken(resetTokenStatusRequest.getResetToken());
+        if (passwordResetToken == null) return false;
+        return !passwordResetToken.isExpired();
+    }
+
     @GetMapping(value = "/team/{teamId}/csv", produces = "application/board.csv")
     @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
     @Operation(summary = "downloads a team board", description = "downloadTeamBoard")

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
@@ -115,8 +115,7 @@ public class TeamController {
     @PostMapping("/password/reset/is-valid")
     public boolean checkResetTokenStatus(@RequestBody ResetTokenStatusRequest resetTokenStatusRequest) {
         PasswordResetToken passwordResetToken = passwordResetRepository.findByResetToken(resetTokenStatusRequest.getResetToken());
-        if (passwordResetToken == null) return false;
-        return !passwordResetToken.isExpired();
+        return passwordResetToken != null && !passwordResetToken.isExpired();
     }
 
     @GetMapping(value = "/team/{teamId}/csv", produces = "application/board.csv")

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -23,6 +23,9 @@ retroquest:
   email:
     from-address: rq@test.com
     is-enabled: true
+  password:
+    reset:
+      token-lifetime-seconds: 600
 
 spring:
   data:

--- a/api/src/test/java/com/ford/labs/retroquest/api/TeamApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/TeamApiTest.java
@@ -29,13 +29,16 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MvcResult;
 
+import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Objects;
@@ -160,6 +163,12 @@ class TeamApiTest extends ApiTestBase {
         assertThat(team.getEmail()).isEqualTo(VALID_EMAIL);
         assertThat(team.getSecondaryEmail()).isEqualTo(expectedSecondaryEmail);
         assertThat(mvcResult.getResponse().getContentAsString()).isNotNull();
+    }
+
+    @Test
+    public void shouldReportCorrectPasswordTokenExpirationTime() throws Exception {
+        MvcResult mvcResult = mockMvc.perform(get("/api/password/reset/token-lifetime-seconds")).andExpect(status().isOk()).andReturn();
+        assertThat(mvcResult.getResponse().getContentAsString()).isEqualTo("600");
     }
 
     @Test

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -23,6 +23,9 @@ retroquest:
   email:
     from-address: test@mail.com
     is-enabled: true
+  password:
+    reset:
+      token-lifetime-seconds: 600
 
 spring:
   data:

--- a/ui/src/App/App.tsx
+++ b/ui/src/App/App.tsx
@@ -17,13 +17,15 @@
 
 import React, { useEffect } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
+import Modal from 'Common/Modal/Modal';
 import { useRecoilValue } from 'recoil';
+import { getThemeClassFromUserSettings, ThemeState } from 'State/ThemeState';
 
-import Modal from '../Common/Modal/Modal';
-import { getThemeClassFromUserSettings, ThemeState } from '../State/ThemeState';
+import { EXPIRED_LINK_PATH, PASSWORD_RESET_PATH } from '../RouteConstants';
 
 import ChangeTeamDetailsPage from './ChangeTeamDetails/ChangeTeamDetailsPage';
 import CreateTeamPage from './CreateTeam/CreateTeamPage';
+import ExpiredLinkPage from './ExpiredLinkPage/ExpiredLinkPage';
 import LoginPage from './Login/LoginPage';
 import PasswordResetRequestPage from './PasswordResetRequest/PasswordResetRequestPage';
 import ResetPasswordPage from './ResetPassword/ResetPasswordPage';
@@ -35,8 +37,6 @@ import TeamPages from './Team/TeamPages';
 import '@fortawesome/fontawesome-free/css/all.css';
 import '../Styles/main.scss';
 import './App.scss';
-
-export const PASSWORD_RESET_ROUTE = '/request-password-reset';
 
 function App() {
 	const theme = useRecoilValue(ThemeState);
@@ -54,8 +54,9 @@ function App() {
 				<Route path="/create" element={<CreateTeamPage />} />
 				<Route path="/email/reset" element={<ChangeTeamDetailsPage />} />
 				<Route path="/password/reset" element={<ResetPasswordPage />} />
+				<Route path={EXPIRED_LINK_PATH} element={<ExpiredLinkPage />} />
 				<Route
-					path={PASSWORD_RESET_ROUTE}
+					path={PASSWORD_RESET_PATH}
 					element={<PasswordResetRequestPage />}
 				/>
 				<Route path="/team/:teamId" element={<TeamPages />}>

--- a/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.scss
+++ b/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.scss
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../../Styles/main';
+
+.expired-link-page {
+	.paragraph-1-container {
+		display: flex;
+		align-items: center;
+
+		.checkbox-icon {
+			width: 35px;
+			height: 28px;
+			margin: 1rem;
+		}
+
+		.paragraph-1 {
+			color: main.$red;
+		}
+	}
+
+	.paragraph-2 {
+		margin-bottom: 0;
+		color: main.$dark-gray;
+	}
+
+	.reset-password-link {
+		@include main.button-primary;
+	}
+}
+
+@include main.dark-theme {
+	.expired-link-page {
+		.paragraph-1 {
+			color: main.$dark-red;
+		}
+
+		.paragraph-2 {
+			color: main.$light-gray;
+		}
+	}
+}

--- a/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.spec.tsx
+++ b/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.spec.tsx
@@ -18,21 +18,40 @@
 import { MemoryRouter } from 'react-router-dom';
 import { screen, waitFor } from '@testing-library/react';
 import { MutableSnapshot } from 'recoil';
-
-import ContributorsService from '../../Services/Api/ContributorsService';
-import { ThemeState } from '../../State/ThemeState';
-import Theme from '../../Types/Theme';
-import renderWithRecoilRoot from '../../Utils/renderWithRecoilRoot';
+import ContributorsService from 'Services/Api/ContributorsService';
+import TeamService from 'Services/Api/TeamService';
+import { ThemeState } from 'State/ThemeState';
+import Theme from 'Types/Theme';
+import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
 
 import ExpiredLinkPage from './ExpiredLinkPage';
 
 jest.mock('Services/Api/ContributorsService');
+jest.mock('Services/Api/TeamService');
 
 describe('Expired Link Page', () => {
 	it('should render header and link to reset password page', async () => {
 		await renderExpiredLinkPage();
 		expect(screen.getByText('Expired Link')).toBeDefined();
-		expect(screen.getByText('Reset my Password')).toBeDefined();
+		let resetPasswordPageLink = screen.getByText('Reset my Password');
+		expect(resetPasswordPageLink).toBeDefined();
+		expect(resetPasswordPageLink).toHaveAttribute(
+			'href',
+			'/request-password-reset'
+		);
+	});
+
+	it('should show token lifetime in page description', async () => {
+		TeamService.getResetTokenLifetime = jest.fn().mockResolvedValue(600);
+		await renderExpiredLinkPage();
+		await waitFor(() =>
+			expect(TeamService.getResetTokenLifetime).toHaveBeenCalled()
+		);
+		expect(
+			screen.getByText(
+				'For your safety, our password reset link is only valid for 10 minutes.'
+			)
+		).toBeDefined();
 	});
 
 	it('should render error stop sign icon in confirmation screen as red in light mode', async () => {

--- a/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.spec.tsx
+++ b/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.spec.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MemoryRouter } from 'react-router-dom';
+import { screen, waitFor } from '@testing-library/react';
+import { MutableSnapshot } from 'recoil';
+
+import ContributorsService from '../../Services/Api/ContributorsService';
+import { ThemeState } from '../../State/ThemeState';
+import Theme from '../../Types/Theme';
+import renderWithRecoilRoot from '../../Utils/renderWithRecoilRoot';
+
+import ExpiredLinkPage from './ExpiredLinkPage';
+
+jest.mock('Services/Api/ContributorsService');
+
+describe('Expired Link Page', () => {
+	it('should render header and link to reset password page', async () => {
+		await renderExpiredLinkPage();
+		expect(screen.getByText('Expired Link')).toBeDefined();
+		expect(screen.getByText('Reset my Password')).toBeDefined();
+	});
+
+	it('should render error stop sign icon in confirmation screen as red in light mode', async () => {
+		await renderExpiredLinkPage(({ set }) => {
+			set(ThemeState, Theme.LIGHT);
+		});
+
+		const errorStopSignIcon = await screen.findByTestId('errorStopSignIcon');
+		expect(errorStopSignIcon.getAttribute('fill')).toBe('#e74c3c');
+	});
+
+	it('should render checkbox in confirmation screen as light turquoise in dark mode', async () => {
+		await renderExpiredLinkPage(({ set }) => {
+			set(ThemeState, Theme.DARK);
+		});
+
+		const errorStopSignIcon = await screen.findByTestId('errorStopSignIcon');
+		expect(errorStopSignIcon.getAttribute('fill')).toBe('#c0392b');
+	});
+});
+
+async function renderExpiredLinkPage(
+	recoilState?: (mutableSnapshot: MutableSnapshot) => void
+) {
+	renderWithRecoilRoot(
+		<MemoryRouter>
+			<ExpiredLinkPage />
+		</MemoryRouter>,
+		recoilState
+	);
+
+	await waitFor(() => expect(ContributorsService.get).toBeCalledTimes(1));
+}

--- a/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.tsx
+++ b/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.tsx
@@ -15,21 +15,29 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import ErrorStopSignIcon from 'Assets/ErrorStopSignIcon';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import { useRecoilValue } from 'recoil';
 import { PASSWORD_RESET_PATH } from 'RouteConstants';
-
-import ErrorStopSignIcon from '../../Assets/ErrorStopSignIcon';
-import { ThemeState } from '../../State/ThemeState';
-import Theme from '../../Types/Theme';
+import TeamService from 'Services/Api/TeamService';
+import { ThemeState } from 'State/ThemeState';
+import Theme from 'Types/Theme';
 
 import './ExpiredLinkPage.scss';
 
 function ExpiredLinkPage() {
 	const theme = useRecoilValue(ThemeState);
 	const checkboxIconColor = theme === Theme.DARK ? '#c0392b' : '#e74c3c';
+
+	const [resetTokenLifetime, setResetTokenLifetime] = useState<number>(600);
+
+	useEffect(() => {
+		TeamService.getResetTokenLifetime().then((seconds) => {
+			setResetTokenLifetime(Math.floor(seconds / 60));
+		});
+	}, []);
 
 	return (
 		<AuthTemplate
@@ -43,8 +51,8 @@ function ExpiredLinkPage() {
 					className="checkbox-icon"
 				/>
 				<p className="paragraph-1">
-					For your safety, our password reset link is only valid for 10 minutes.
-					instructions.
+					For your safety, our password reset link is only valid for{' '}
+					{resetTokenLifetime} minutes.
 				</p>
 			</div>
 			<p className="paragraph-2">

--- a/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.tsx
+++ b/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.tsx
@@ -15,18 +15,44 @@
  * limitations under the License.
  */
 
+import React from 'react';
 import { Link } from 'react-router-dom';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
+import { useRecoilValue } from 'recoil';
 import { PASSWORD_RESET_PATH } from 'RouteConstants';
 
+import ErrorStopSignIcon from '../../Assets/ErrorStopSignIcon';
+import { ThemeState } from '../../State/ThemeState';
+import Theme from '../../Types/Theme';
+
+import './ExpiredLinkPage.scss';
+
 function ExpiredLinkPage() {
+	const theme = useRecoilValue(ThemeState);
+	const checkboxIconColor = theme === Theme.DARK ? '#c0392b' : '#e74c3c';
+
 	return (
-		<AuthTemplate header="Expired Link">
-			<p>
-				For your safety, our password reset link is only valid for 10 minutes.
+		<AuthTemplate
+			header="Expired Link"
+			className="expired-link-page"
+			showGithubLink={false}
+		>
+			<div className="paragraph-1-container">
+				<ErrorStopSignIcon
+					color={checkboxIconColor}
+					className="checkbox-icon"
+				/>
+				<p className="paragraph-1">
+					For your safety, our password reset link is only valid for 10 minutes.
+					instructions.
+				</p>
+			</div>
+			<p className="paragraph-2">
+				Fear not! Click here to request a fresh, new reset link.
 			</p>
-			<p>Fear not! Click here to request a fresh, new reset link.</p>
-			<Link to={PASSWORD_RESET_PATH}>Reset my Password</Link>
+			<Link to={PASSWORD_RESET_PATH} className="reset-password-link">
+				Reset my Password
+			</Link>
 		</AuthTemplate>
 	);
 }

--- a/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.tsx
+++ b/ui/src/App/ExpiredLinkPage/ExpiredLinkPage.tsx
@@ -15,15 +15,20 @@
  * limitations under the License.
  */
 
-const TeamService = {
-	login: jest.fn().mockResolvedValue(''),
-	create: jest.fn().mockResolvedValue(''),
-	getTeamName: jest.fn().mockResolvedValue('Active Team Name'),
-	getCSV: jest.fn().mockResolvedValue('column 1, column 2'),
-	setEmails: jest.fn().mockResolvedValue(''),
-	setPassword: jest.fn().mockResolvedValue(''),
-	sendPasswordResetLink: jest.fn().mockResolvedValue(''),
-	checkIfResetTokenIsValid: jest.fn().mockResolvedValue(true),
-};
+import { Link } from 'react-router-dom';
+import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
+import { PASSWORD_RESET_PATH } from 'RouteConstants';
 
-export default TeamService;
+function ExpiredLinkPage() {
+	return (
+		<AuthTemplate header="Expired Link">
+			<p>
+				For your safety, our password reset link is only valid for 10 minutes.
+			</p>
+			<p>Fear not! Click here to request a fresh, new reset link.</p>
+			<Link to={PASSWORD_RESET_PATH}>Reset my Password</Link>
+		</AuthTemplate>
+	);
+}
+
+export default ExpiredLinkPage;

--- a/ui/src/App/Login/LoginPage.tsx
+++ b/ui/src/App/Login/LoginPage.tsx
@@ -18,15 +18,13 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import Form from 'Common/AuthTemplate/Form/Form';
+import HorizontalRuleWithText from 'Common/HorizontalRuleWithText/HorizontalRuleWithText';
 import InputPassword from 'Common/InputPassword/InputPassword';
 import InputTeamName from 'Common/InputTeamName/InputTeamName';
 import useAuth from 'Hooks/useAuth';
 import useTeamFromRoute from 'Hooks/useTeamFromRoute';
-import { CREATE_TEAM_PAGE_PATH } from 'RouteConstants';
+import { CREATE_TEAM_PAGE_PATH, PASSWORD_RESET_PATH } from 'RouteConstants';
 import TeamService from 'Services/Api/TeamService';
-
-import HorizontalRuleWithText from '../../Common/HorizontalRuleWithText/HorizontalRuleWithText';
-import { PASSWORD_RESET_ROUTE } from '../App';
 
 import './LoginPage.scss';
 
@@ -82,10 +80,10 @@ function LoginPage(): JSX.Element {
 					validateInput={false}
 				/>
 			</Form>
-			<Link to={PASSWORD_RESET_ROUTE} className="forgot-login-link">
+			<Link to={PASSWORD_RESET_PATH} className="forgot-login-link">
 				Forgot your login info?
 			</Link>
-			<HorizontalRuleWithText text={'or'} />
+			<HorizontalRuleWithText text="or" />
 			<Link to={CREATE_TEAM_PAGE_PATH} className={'link-secondary'}>
 				Create new team
 			</Link>

--- a/ui/src/App/ResetPassword/ResetPasswordPage.spec.tsx
+++ b/ui/src/App/ResetPassword/ResetPasswordPage.spec.tsx
@@ -24,24 +24,54 @@ import ResetPasswordPage from './ResetPasswordPage';
 
 jest.mock('Services/Api/TeamService');
 
+const mockedUsedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+	...(jest.requireActual('react-router-dom') as any),
+	useNavigate: () => mockedUsedNavigate,
+}));
+
 describe('Reset Password Page', () => {
 	it('should have retroquest header', () => {
 		renderWithToken('');
 		expect(screen.getByText('RetroQuest')).toBeDefined();
 	});
 
-	it('should have "Return to Login" link', () => {
+	it('should have a field for new password, a disabled submit button, and a return to login link', async () => {
 		renderWithToken('');
+		expect(screen.getByLabelText('New Password')).toBeInTheDocument();
+		const submitButton = screen.getByText('Reset Password');
+		expect(submitButton).toBeDisabled();
 		const loginLink = screen.getByText('Return to Login');
 		expect(loginLink).toHaveAttribute('href', '/login');
 	});
 
-	it('should have a field for password and password confirmation, plus a disabled submit button', async () => {
-		renderWithToken('');
-		expect(screen.getByLabelText('New Password')).toBeInTheDocument();
-		const submitButton = screen.getByText('Reset Password');
-		expect(submitButton).toBeInTheDocument();
-		expect(submitButton).toBeDisabled();
+	describe('Token Validity', () => {
+		it('should check if token is valid and navigate to Expired Token page if token is invalid', async () => {
+			TeamService.checkIfResetTokenIsValid = jest.fn().mockResolvedValue(false);
+
+			renderWithToken('expired-token');
+			await waitFor(() =>
+				expect(TeamService.checkIfResetTokenIsValid).toHaveBeenCalledWith(
+					'expired-token'
+				)
+			);
+			expect(mockedUsedNavigate).toHaveBeenCalledWith('/expired-link');
+			expect(screen.queryByText('Reset Your Password')).toBeInTheDocument();
+		});
+
+		it('should check if token is valid and stay on page if it is valid', async () => {
+			TeamService.checkIfResetTokenIsValid = jest.fn().mockResolvedValue(true);
+
+			renderWithToken('valid-token');
+			await waitFor(() =>
+				expect(TeamService.checkIfResetTokenIsValid).toHaveBeenCalledWith(
+					'valid-token'
+				)
+			);
+			expect(mockedUsedNavigate).not.toHaveBeenCalled();
+			expect(screen.getByText('Reset Your Password')).toBeInTheDocument();
+		});
 	});
 
 	it('should enable submit button once user types valid password', () => {

--- a/ui/src/Assets/ErrorStopSignIcon.tsx
+++ b/ui/src/Assets/ErrorStopSignIcon.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface Props {
+	color: string;
+	className?: string;
+}
+
+function ErrorStopSignIcon({ color, className }: Props) {
+	return (
+		<svg
+			role="presentation"
+			width="36"
+			height="35"
+			viewBox="0 0 36 35"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			className={className}
+		>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M30.3812 29.8812C33.5484 26.7139 35.5 22.3312 35.5 17.5C35.5 12.6688 33.5483 8.28631 30.3812 5.11884C27.2139 1.95161 22.8312 0 18 0C13.1688 0 8.78631 1.95167 5.61884 5.11884C2.45161 8.28607 0.5 12.6688 0.5 17.5C0.5 22.3312 2.45167 26.7137 5.61884 29.8812C8.78607 33.0484 13.1688 35 18 35C22.8312 35 27.2137 33.0483 30.3812 29.8812ZM20.3675 24.2506C20.3675 22.9388 19.3118 21.8832 18.0001 21.8832C16.6883 21.8832 15.6006 22.9388 15.6006 24.2506C15.6006 25.5623 16.6883 26.65 18.0001 26.65C19.3119 26.65 20.3675 25.5624 20.3675 24.2506ZM18.0001 19.4837C17.1363 19.4837 16.4964 18.7799 16.4004 17.8841L15.6006 10.7498C15.4727 9.50199 16.7844 8.35038 18.0001 8.35038C19.2159 8.35038 20.5274 9.50224 20.3675 10.7498L19.5997 17.8841C19.5037 18.7799 18.8639 19.4837 18.0001 19.4837Z"
+				fill={color}
+				data-testid="errorStopSignIcon"
+			/>
+		</svg>
+	);
+}
+
+export default ErrorStopSignIcon;

--- a/ui/src/RouteConstants.ts
+++ b/ui/src/RouteConstants.ts
@@ -18,6 +18,8 @@
 export const CREATE_TEAM_PAGE_PATH = '/create';
 export const REQUEST_PASSWORD_RESET_PAGE_PATH = '/request-password-reset';
 export const LOGIN_PAGE_PATH = '/login';
+export const PASSWORD_RESET_PATH = '/request-password-reset';
+export const EXPIRED_LINK_PATH = '/expired-link';
 export const getLoginPagePathWithTeamId = (teamId: string) =>
 	`${LOGIN_PAGE_PATH}/${teamId}`;
 

--- a/ui/src/Services/Api/ApiConstants.ts
+++ b/ui/src/Services/Api/ApiConstants.ts
@@ -18,6 +18,8 @@
 export const CREATE_TEAM_API_PATH = '/api/team';
 export const CHANGE_EMAIL_API_PATH = '/api/email/reset';
 export const CHANGE_PASSWORD_API_PATH = '/api/password/reset';
+export const RESET_TOKEN_LIFETIME_API_PATH =
+	'/api/password/reset/token-lifetime-seconds';
 export const RESET_TOKEN_STATUS_API_PATH = '/api/password/reset/is-valid';
 export const PASSWORD_REQUEST_API_PATH = '/api/password/request-reset';
 export const LOGIN_API_PATH = `${CREATE_TEAM_API_PATH}/login`;

--- a/ui/src/Services/Api/ApiConstants.ts
+++ b/ui/src/Services/Api/ApiConstants.ts
@@ -18,6 +18,7 @@
 export const CREATE_TEAM_API_PATH = '/api/team';
 export const CHANGE_EMAIL_API_PATH = '/api/email/reset';
 export const CHANGE_PASSWORD_API_PATH = '/api/password/reset';
+export const RESET_TOKEN_STATUS_API_PATH = '/api/password/reset/is-valid';
 export const PASSWORD_REQUEST_API_PATH = '/api/password/request-reset';
 export const LOGIN_API_PATH = `${CREATE_TEAM_API_PATH}/login`;
 export const getTeamNameApiPath = (teamId: string) =>

--- a/ui/src/Services/Api/TeamService.spec.ts
+++ b/ui/src/Services/Api/TeamService.spec.ts
@@ -133,6 +133,30 @@ describe('Team Service', () => {
 		});
 	});
 
+	describe('checkIfResetTokenIsValid', () => {
+		it('should return true when token is valid', async () => {
+			axios.post = jest.fn().mockResolvedValue({ data: true });
+			const isValidToken = await TeamService.checkIfResetTokenIsValid(
+				'valid-token'
+			);
+			expect(axios.post).toHaveBeenCalledWith('/api/password/reset/is-valid', {
+				resetToken: 'valid-token',
+			});
+			expect(isValidToken).toBeTruthy();
+		});
+
+		it('should return true when token is invalid', async () => {
+			axios.post = jest.fn().mockResolvedValue({ data: false });
+			const isValidToken = await TeamService.checkIfResetTokenIsValid(
+				'invalid-token'
+			);
+			expect(axios.post).toHaveBeenCalledWith('/api/password/reset/is-valid', {
+				resetToken: 'invalid-token',
+			});
+			expect(isValidToken).toBeFalsy();
+		});
+	});
+
 	describe('onResponseInterceptRejection', () => {
 		let location: (string | Location) & Location;
 		let mockAssign = jest.fn();

--- a/ui/src/Services/Api/TeamService.spec.ts
+++ b/ui/src/Services/Api/TeamService.spec.ts
@@ -157,6 +157,14 @@ describe('Team Service', () => {
 		});
 	});
 
+	describe('getResetTokenLifetime', () => {
+		it('should get the lifetime of the reset token', async () => {
+			axios.get = jest.fn().mockResolvedValue({ data: 500 });
+			const actualTokenLifetime = await TeamService.getResetTokenLifetime();
+			expect(actualTokenLifetime).toBe(500);
+		});
+	});
+
 	describe('onResponseInterceptRejection', () => {
 		let location: (string | Location) & Location;
 		let mockAssign = jest.fn();

--- a/ui/src/Services/Api/TeamService.ts
+++ b/ui/src/Services/Api/TeamService.ts
@@ -32,6 +32,7 @@ import {
 	getTeamNameApiPath,
 	LOGIN_API_PATH,
 	PASSWORD_REQUEST_API_PATH,
+	RESET_TOKEN_LIFETIME_API_PATH,
 	RESET_TOKEN_STATUS_API_PATH,
 } from './ApiConstants';
 
@@ -120,6 +121,12 @@ const TeamService = {
 				responseType: 'blob',
 				timeout: 30000,
 			})
+			.then((response) => response.data);
+	},
+
+	getResetTokenLifetime(): Promise<number> {
+		return axios
+			.get(RESET_TOKEN_LIFETIME_API_PATH)
 			.then((response) => response.data);
 	},
 

--- a/ui/src/Services/Api/TeamService.ts
+++ b/ui/src/Services/Api/TeamService.ts
@@ -32,6 +32,7 @@ import {
 	getTeamNameApiPath,
 	LOGIN_API_PATH,
 	PASSWORD_REQUEST_API_PATH,
+	RESET_TOKEN_STATUS_API_PATH,
 } from './ApiConstants';
 
 export interface AuthResponse {
@@ -90,6 +91,14 @@ const TeamService = {
 			teamName: teamName,
 			email: email,
 		});
+	},
+
+	checkIfResetTokenIsValid(resetToken: string): Promise<boolean> {
+		return axios
+			.post(RESET_TOKEN_STATUS_API_PATH, {
+				resetToken: resetToken,
+			})
+			.then((res) => res.data);
 	},
 
 	setPassword(password: string, token: string): Promise<AxiosResponse> {

--- a/ui/src/Services/Api/__mocks__/TeamService.ts
+++ b/ui/src/Services/Api/__mocks__/TeamService.ts
@@ -24,6 +24,7 @@ const TeamService = {
 	setPassword: jest.fn().mockResolvedValue(''),
 	sendPasswordResetLink: jest.fn().mockResolvedValue(''),
 	checkIfResetTokenIsValid: jest.fn().mockResolvedValue(true),
+	getResetTokenLifetime: jest.fn().mockResolvedValue(800),
 };
 
 export default TeamService;


### PR DESCRIPTION
## Overview
- [x] Created Token Expiration Page
- [x] Had the token lifetime on said page come from the backend to ensure that if someone changes the reset token lifetime that the token expiration page reflects that 

## Testing Instructions
1) Ensure going to `localhost:3000/password/reset?token=invalid-token` (the password reset page with an invalid token) redirects you to the token expired page

<img width="1699" alt="Screen Shot 2022-09-22 at 3 39 13 PM" src="https://user-images.githubusercontent.com/74197928/191836205-a75f79e4-6a7a-4900-936f-f97662499bec.png">
