### PR TITLE
Move logout button

### DIFF
--- a/ui/cypress/e2e/retro-member-journey.spec.ts
+++ b/ui/cypress/e2e/retro-member-journey.spec.ts
@@ -211,6 +211,21 @@ describe('Retro Member Journey', () => {
 			.should('eq', 201);
 	});
 
+	it('Log Out Button', () => {
+		cy.findByText('Log Out').click();
+
+		cy.log('**Should be on Login page with pre-populated team name**');
+
+		const LoginPagePathWithTeamId =
+			Cypress.config().baseUrl +
+			getLoginPagePathWithTeamId(teamCredentials.teamId);
+		cy.url().should('eq', LoginPagePathWithTeamId);
+
+		cy.contains('Log in to your Team!').should('exist');
+
+		cy.getCookie(TOKEN_KEY).should('not.exist');
+	});
+
 	it('Navigate between columns on mobile', () => {
 		cy.viewport(414, 736);
 
@@ -313,24 +328,6 @@ describe('Retro Member Journey', () => {
 				purpleBoxShadow
 			);
 			cy.get(darkThemeClass).should('not.exist');
-		});
-
-		it('Account Tab: Log out', () => {
-			cy.get('@accountTab').click().should('have.class', 'selected');
-			cy.get('@stylesTab').should('not.have.class', 'selected');
-
-			cy.findByText('Logout').click();
-
-			cy.log('**Should be on Login page with pre-populated team name**');
-
-			const LoginPagePathWithTeamId =
-				Cypress.config().baseUrl +
-				getLoginPagePathWithTeamId(teamCredentials.teamId);
-			cy.url().should('eq', LoginPagePathWithTeamId);
-
-			cy.contains('Log in to your Team!').should('exist');
-
-			cy.getCookie(TOKEN_KEY).should('not.exist');
 		});
 	});
 

--- a/ui/src/App/Team/Retro/RetroPage.spec.tsx
+++ b/ui/src/App/Team/Retro/RetroPage.spec.tsx
@@ -25,11 +25,16 @@ import renderWithRecoilRoot from '../../../Utils/renderWithRecoilRoot';
 
 import RetroPage from './RetroPage';
 
-jest.mock('../../../Services/Api/ColumnService');
-jest.mock('../../../Services/Api/ThoughtService');
-jest.mock('../../../Services/Api/ActionItemService');
-jest.mock('../../../Services/Websocket/WebSocketService');
-jest.mock('../../../Services/Websocket/WebSocketController');
+jest.mock('Hooks/useAuth', () => {
+	return jest.fn(() => ({
+		logout: jest.fn(),
+	}));
+});
+jest.mock('Services/Api/ColumnService');
+jest.mock('Services/Api/ThoughtService');
+jest.mock('Services/Api/ActionItemService');
+jest.mock('Services/Websocket/WebSocketService');
+jest.mock('Services/Websocket/WebSocketController');
 
 jest.setTimeout(60000);
 
@@ -38,7 +43,7 @@ const mockThoughtMessageHandler = jest.fn();
 const mockActionItemMessageHandler = jest.fn();
 const mockEndRetroMessageHandler = jest.fn();
 
-jest.mock('../../../Hooks/useWebSocketMessageHandler', () => {
+jest.mock('Hooks/useWebSocketMessageHandler', () => {
 	return () => ({
 		columnMessageHandler: mockColumnMessageHandler,
 		thoughtMessageHandler: mockThoughtMessageHandler,

--- a/ui/src/App/Team/Retro/RetroSubheader/RetroSubheader.spec.tsx
+++ b/ui/src/App/Team/Retro/RetroSubheader/RetroSubheader.spec.tsx
@@ -17,23 +17,27 @@
 
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import fileSaver from 'file-saver';
 import { RecoilRoot } from 'recoil';
-
-import TeamService from '../../../../Services/Api/TeamService';
-import {
-	ModalContents,
-	ModalContentsState,
-} from '../../../../State/ModalContentsState';
-import { TeamState } from '../../../../State/TeamState';
-import Team from '../../../../Types/Team';
-import { RecoilObserver } from '../../../../Utils/RecoilObserver';
+import TeamService from 'Services/Api/TeamService';
+import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
+import { TeamState } from 'State/TeamState';
+import Team from 'Types/Team';
+import { RecoilObserver } from 'Utils/RecoilObserver';
 
 import ArchiveRetroConfirmation from './ArchiveRetroConfirmation/ArchiveRetroConfirmation';
 import FeedbackForm from './FeedbackForm/FeedbackForm';
 import RetroSubheader from './RetroSubheader';
 
-jest.mock('../../../../Services/Api/TeamService');
+const mockLogout = jest.fn();
+
+jest.mock('Hooks/useAuth', () => {
+	return jest.fn(() => ({
+		logout: mockLogout,
+	}));
+});
+jest.mock('Services/Api/TeamService');
 jest.mock('file-saver');
 
 const team: Team = {
@@ -100,6 +104,15 @@ describe('Retro Subheader', () => {
 					'my-team-board.csv'
 				)
 			);
+		});
+	});
+
+	describe('Log Out Button', () => {
+		it('should logout', () => {
+			userEvent.click(screen.getByText('Log Out'));
+
+			expect(mockLogout).toHaveBeenCalledTimes(1);
+			expect(modalContent).toBeNull();
 		});
 	});
 

--- a/ui/src/App/Team/Retro/RetroSubheader/RetroSubheader.tsx
+++ b/ui/src/App/Team/Retro/RetroSubheader/RetroSubheader.tsx
@@ -18,6 +18,7 @@
 import React from 'react';
 import Timer from 'Common/Timer/Timer';
 import fileSaver from 'file-saver';
+import useAuth from 'Hooks/useAuth';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import TeamService from 'Services/Api/TeamService';
 import { ModalContentsState } from 'State/ModalContentsState';
@@ -29,6 +30,8 @@ import FeedbackForm from './FeedbackForm/FeedbackForm';
 import './RetroSubheader.scss';
 
 function RetroSubheader(): JSX.Element {
+	const { logout } = useAuth();
+
 	const setModalContents = useSetRecoilState(ModalContentsState);
 	const team = useRecoilValue(TeamState);
 
@@ -63,6 +66,15 @@ function RetroSubheader(): JSX.Element {
 							onClick={downloadCSV}
 						>
 							<span className="button-text">Download CSV</span>
+							<i className="fas fa-download button-icon" aria-hidden="true" />
+						</button>
+					</li>
+					<li>
+						<button
+							className="download-csv-button button button-secondary-old"
+							onClick={logout}
+						>
+							<span className="button-text">Log Out</span>
 							<i className="fas fa-download button-icon" aria-hidden="true" />
 						</button>
 					</li>

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/AccountTab.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/AccountTab.tsx
@@ -15,31 +15,10 @@
  * limitations under the License.
  */
 
-import * as React from 'react';
-import { PrimaryButton } from 'Common/Buttons/Button';
-import useAuth from 'Hooks/useAuth';
-import { useSetRecoilState } from 'recoil';
-import { ModalContentsState } from 'State/ModalContentsState';
-
 import './AccountTab.scss';
 
 function AccountTab(): JSX.Element {
-	const { logout } = useAuth();
-	const setModalContents = useSetRecoilState(ModalContentsState);
-
-	return (
-		<div className="tab-body account-tab-body">
-			<PrimaryButton
-				onClick={() => {
-					logout();
-					setModalContents(null);
-				}}
-				className="logout-button"
-			>
-				Logout
-			</PrimaryButton>
-		</div>
-	);
+	return <div className="tab-body account-tab-body"></div>;
 }
 
 export default AccountTab;

--- a/ui/src/App/Team/TeamHeader/Settings/Settings.spec.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/Settings.spec.tsx
@@ -18,22 +18,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { RecoilRoot } from 'recoil';
-import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
-import { RecoilObserver } from 'Utils/RecoilObserver';
+import { ModalContentsState } from 'State/ModalContentsState';
 
 import Settings from './Settings';
 
-const mockLogout = jest.fn();
-
-jest.mock('../../../../Hooks/useAuth', () => {
-	return jest.fn(() => ({
-		logout: mockLogout,
-	}));
-});
-
 describe('Settings', () => {
-	let modalContent: ModalContents | null;
-
 	beforeEach(() => {
 		jest.clearAllMocks();
 
@@ -46,12 +35,6 @@ describe('Settings', () => {
 					});
 				}}
 			>
-				<RecoilObserver
-					recoilState={ModalContentsState}
-					onChange={(value: ModalContents) => {
-						modalContent = value;
-					}}
-				/>
 				<Settings />
 			</RecoilRoot>
 		);
@@ -88,17 +71,6 @@ describe('Settings', () => {
 			expect(systemSettingsThemeButton).toHaveClass('selected');
 			expect(lightThemeButton).not.toHaveClass('selected');
 			expect(darkThemeButton).not.toHaveClass('selected');
-		});
-	});
-
-	describe('Account Tab', () => {
-		it('should logout', () => {
-			expect(modalContent).not.toBeNull();
-			userEvent.click(screen.getByText('Account'));
-			userEvent.click(screen.getByText('Logout'));
-
-			expect(mockLogout).toHaveBeenCalledTimes(1);
-			expect(modalContent).toBeNull();
 		});
 	});
 

--- a/ui/src/App/Team/TeamHeader/Settings/Settings.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/Settings.tsx
@@ -49,12 +49,12 @@ export function Settings() {
 					>
 						Styles
 					</button>
-					<button
-						className={classnames('tab', { selected: accountTabIsActive() })}
-						onClick={() => setTab(Tabs.ACCOUNT)}
-					>
-						Account
-					</button>
+					{/*<button*/}
+					{/*	className={classnames('tab', { selected: accountTabIsActive() })}*/}
+					{/*	onClick={() => setTab(Tabs.ACCOUNT)}*/}
+					{/*>*/}
+					{/*	Account*/}
+					{/*</button>*/}
 					<button
 						className={classnames('tab', { selected: infoTabIsActive() })}
 						onClick={() => setTab(Tabs.INFO)}


### PR DESCRIPTION
## What was done
- [x] Moved the `Log Out` button out of the settings modal and into the retro page's subheader
- [x] Removed the `Account` tab from the settings modal temporarily until the new account settings are added. 

### Demo
<img width="1501" alt="Screen Shot 2022-09-27 at 5 15 42 PM" src="https://user-images.githubusercontent.com/17144844/192636934-1329d128-3989-4e8d-95cf-2955bc3d3eea.png">

## Testing Instructions
1) Log in and ensure that there is now a log out button on the retro page's subheader.
2) Ensure that when you click it, you are logged out of retroquest
3) Log back in and open the settings menu by clicking on the gear in the upper right hand corner of the retro page.
4) Ensure the account tab in the settings modal is no longer present.