### PR TITLE
Update nav button styles

### DIFF
--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.scss
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.scss
@@ -39,7 +39,7 @@
 		.paragraph-1 {
 			margin-top: 1rem;
 
-			color: main.$dark-turquoise;
+			color: main.$teal;
 			font-weight: bold;
 		}
 	}
@@ -58,7 +58,7 @@
 		}
 
 		.paragraph-1 {
-			color: main.$turquoise;
+			color: main.$sea-foam;
 		}
 
 		.paragraph-2 {

--- a/ui/src/App/Team/Archives/ArchivesSubheader/ArchivesSubheader.scss
+++ b/ui/src/App/Team/Archives/ArchivesSubheader/ArchivesSubheader.scss
@@ -29,7 +29,15 @@
 		}
 
 		.active {
-			color: main.$purple;
+			color: main.$teal;
+		}
+	}
+}
+
+@include main.dark-theme {
+	.archives-subheader-links {
+		.active {
+			color: main.$sea-foam;
 		}
 	}
 }

--- a/ui/src/App/Team/Archives/ArchivesSubheader/ArchivesSubheader.tsx
+++ b/ui/src/App/Team/Archives/ArchivesSubheader/ArchivesSubheader.tsx
@@ -17,9 +17,9 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
+import ButtonSubheader from 'Common/ButtonSubheader/ButtonSubheader';
 import { useSetRecoilState } from 'recoil';
-
-import { ArchivedBoardState } from '../../../../State/ArchivedBoardState';
+import { ArchivedBoardState } from 'State/ArchivedBoardState';
 
 import './ArchivesSubheader.scss';
 
@@ -41,24 +41,24 @@ function ArchivesSubheader(props: Props): JSX.Element {
 		<div className="archives-subheader">
 			<ul className="archives-subheader-links">
 				<li>
-					<button
-						className={classNames('button button-secondary', {
+					<ButtonSubheader
+						className={classNames({
 							active: !showActionItems,
 						})}
 						onClick={handleThoughtsClick}
 					>
 						Thoughts
-					</button>
+					</ButtonSubheader>
 				</li>
 				<li>
-					<button
-						className={classNames('button button-secondary', {
-							active: !!showActionItems,
+					<ButtonSubheader
+						className={classNames({
+							active: showActionItems,
 						})}
 						onClick={() => setShowActionItems(true)}
 					>
 						Action Items
-					</button>
+					</ButtonSubheader>
 				</li>
 			</ul>
 		</div>

--- a/ui/src/App/Team/Archives/ThoughtArchives/ArchivedBoardsList/ArchivedBoardTile/ArchivedBoardTile.scss
+++ b/ui/src/App/Team/Archives/ThoughtArchives/ArchivedBoardsList/ArchivedBoardTile/ArchivedBoardTile.scss
@@ -51,7 +51,7 @@
 		border-left: 1px solid main.$gray-1;
 
 		&:hover {
-			color: main.$turquoise;
+			color: main.$sea-foam;
 		}
 	}
 }
@@ -70,7 +70,7 @@
 			border-left: 1px solid main.$asphalt;
 
 			&:hover {
-				color: main.$turquoise;
+				color: main.$sea-foam;
 			}
 		}
 	}

--- a/ui/src/App/Team/Retro/RetroSubheader/ArchiveRetroButton/ArchiveRetroButton.scss
+++ b/ui/src/App/Team/Retro/RetroSubheader/ArchiveRetroButton/ArchiveRetroButton.scss
@@ -15,44 +15,28 @@
  * limitations under the License.
  */
 
-@use '../../../../Styles/main';
+@use '../../../../../Styles/main';
 
-.retro-subheader {
-	@include main.subheader;
+.archive-button {
+	@include main.button-defaults;
+	color: main.$white;
+	background-color: main.$asphalt;
 
-	* button {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
-
-	.retro-subheader-container {
-		display: flex;
-		justify-content: right;
-
-		@include main.breakpoint-medium {
-			justify-content: space-between;
-		}
-	}
-
-	.timer {
-		display: none;
-
-		@include main.breakpoint-medium {
-			display: inherit;
-		}
+	&:focus,
+	&:hover {
+		background-color: main.$teal;
 	}
 }
 
-.retro-subheader-links {
-	display: flex;
-	justify-content: flex-end;
-
-	li {
-		width: auto;
-		height: 100%;
-	}
-
+@include main.dark-theme {
 	.archive-button {
-		margin-left: 24px;
+		color: main.$asphalt;
+		background-color: main.$gray-1;
+
+		&:focus,
+		&:hover {
+			color: main.$white;
+			background-color: main.$sea-foam;
+		}
 	}
 }

--- a/ui/src/App/Team/Retro/RetroSubheader/ArchiveRetroButton/ArchiveRetroButton.tsx
+++ b/ui/src/App/Team/Retro/RetroSubheader/ArchiveRetroButton/ArchiveRetroButton.tsx
@@ -15,44 +15,30 @@
  * limitations under the License.
  */
 
-@use '../../../../Styles/main';
+import React from 'react';
+import { useSetRecoilState } from 'recoil';
+import { ModalContentsState } from 'State/ModalContentsState';
 
-.retro-subheader {
-	@include main.subheader;
+import ArchiveRetroDialog from '../ArchiveRetroConfirmation/ArchiveRetroConfirmation';
 
-	* button {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
+import './ArchiveRetroButton.scss';
 
-	.retro-subheader-container {
-		display: flex;
-		justify-content: right;
+function ArchiveRetroButton() {
+	const setModalContents = useSetRecoilState(ModalContentsState);
 
-		@include main.breakpoint-medium {
-			justify-content: space-between;
-		}
-	}
-
-	.timer {
-		display: none;
-
-		@include main.breakpoint-medium {
-			display: inherit;
-		}
-	}
+	return (
+		<button
+			className="archive-button"
+			onClick={() =>
+				setModalContents({
+					title: 'Archive Retro',
+					component: <ArchiveRetroDialog />,
+				})
+			}
+		>
+			Archive Retro
+		</button>
+	);
 }
 
-.retro-subheader-links {
-	display: flex;
-	justify-content: flex-end;
-
-	li {
-		width: auto;
-		height: 100%;
-	}
-
-	.archive-button {
-		margin-left: 24px;
-	}
-}
+export default ArchiveRetroButton;

--- a/ui/src/App/Team/Retro/RetroSubheader/RetroSubheader.tsx
+++ b/ui/src/App/Team/Retro/RetroSubheader/RetroSubheader.tsx
@@ -16,6 +16,7 @@
  */
 
 import React from 'react';
+import ButtonSubheader from 'Common/ButtonSubheader/ButtonSubheader';
 import Timer from 'Common/Timer/Timer';
 import fileSaver from 'file-saver';
 import useAuth from 'Hooks/useAuth';
@@ -24,7 +25,7 @@ import TeamService from 'Services/Api/TeamService';
 import { ModalContentsState } from 'State/ModalContentsState';
 import { TeamState } from 'State/TeamState';
 
-import ArchiveRetroDialog from './ArchiveRetroConfirmation/ArchiveRetroConfirmation';
+import ArchiveRetroButton from './ArchiveRetroButton/ArchiveRetroButton';
 import FeedbackForm from './FeedbackForm/FeedbackForm';
 
 import './RetroSubheader.scss';
@@ -47,49 +48,36 @@ function RetroSubheader(): JSX.Element {
 				<Timer />
 				<ul className="retro-subheader-links">
 					<li>
-						<button
-							className="feedback-button button button-secondary-old"
+						<ButtonSubheader
 							onClick={() =>
 								setModalContents({
 									component: <FeedbackForm />,
 									title: 'Feedback',
 								})
 							}
+							fontAwesomeIconClasses="far fa-comments"
 						>
-							<span className="button-text">Give Feedback</span>
-							<i className="far fa-comments button-icon" aria-hidden="true" />
-						</button>
+							Give Feedback
+						</ButtonSubheader>
 					</li>
 					<li>
-						<button
-							className="download-csv-button button button-secondary-old"
+						<ButtonSubheader
 							onClick={downloadCSV}
+							fontAwesomeIconClasses="fas fa-download"
 						>
-							<span className="button-text">Download CSV</span>
-							<i className="fas fa-download button-icon" aria-hidden="true" />
-						</button>
+							Download CSV
+						</ButtonSubheader>
 					</li>
 					<li>
-						<button
-							className="download-csv-button button button-secondary-old"
+						<ButtonSubheader
 							onClick={logout}
+							fontAwesomeIconClasses="fa-solid fa-arrow-right-from-bracket"
 						>
-							<span className="button-text">Log Out</span>
-							<i className="fas fa-download button-icon" aria-hidden="true" />
-						</button>
+							Log Out
+						</ButtonSubheader>
 					</li>
 					<li>
-						<button
-							className="archive-button button button-primary-old"
-							onClick={() =>
-								setModalContents({
-									title: 'Archive Retro',
-									component: <ArchiveRetroDialog />,
-								})
-							}
-						>
-							Archive Retro
-						</button>
+						<ArchiveRetroButton />
 					</li>
 				</ul>
 			</div>

--- a/ui/src/App/Team/TeamHeader/Settings/Settings.scss
+++ b/ui/src/App/Team/TeamHeader/Settings/Settings.scss
@@ -107,7 +107,7 @@
 
 		&.selected {
 			color: main.$white;
-			background-color: main.$dark-turquoise;
+			background-color: main.$teal;
 		}
 
 		&:not(:last-child) {
@@ -145,7 +145,7 @@
 
 		&.selected {
 			color: main.$black-asphalt;
-			background-color: main.$turquoise;
+			background-color: main.$sea-foam;
 		}
 	}
 }

--- a/ui/src/App/Team/TeamHeader/Settings/StylesTab/StylesTab.scss
+++ b/ui/src/App/Team/TeamHeader/Settings/StylesTab/StylesTab.scss
@@ -60,7 +60,7 @@
 			cursor: pointer;
 
 			&.selected {
-				box-shadow: 0 0 0 8px main.$dark-turquoise;
+				box-shadow: 0 0 0 8px main.$teal;
 			}
 		}
 

--- a/ui/src/App/Team/TeamHeader/TeamHeader.scss
+++ b/ui/src/App/Team/TeamHeader/TeamHeader.scss
@@ -54,11 +54,12 @@
 	}
 
 	.settings-button {
+		color: main.$asphalt;
 		font-size: 1.3rem;
 
 		&:hover,
 		&:focus {
-			color: main.$purple;
+			color: main.$teal;
 		}
 	}
 }
@@ -67,6 +68,15 @@
 	.header {
 		.right-content {
 			color: main.$gray-1;
+		}
+	}
+
+	.settings-button {
+		color: main.$white;
+
+		&:hover,
+		&:focus {
+			color: main.$sea-foam;
 		}
 	}
 }

--- a/ui/src/App/Team/TeamHeader/TeamHeader.tsx
+++ b/ui/src/App/Team/TeamHeader/TeamHeader.tsx
@@ -16,13 +16,13 @@
  */
 
 import React from 'react';
-import { NavLink } from 'react-router-dom';
 import Header from 'Common/Header/Header';
 import useTeamFromRoute from 'Hooks/useTeamFromRoute';
 import { useSetRecoilState } from 'recoil';
 import { ModalContentsState } from 'State/ModalContentsState';
 
 import Settings from './Settings/Settings';
+import TeamHeaderNavLink from './TeamHeaderNavLink/TeamHeaderNavLink';
 
 import './TeamHeader.scss';
 
@@ -46,16 +46,12 @@ function TeamHeader() {
 			<>
 				<nav className="center-content">
 					{LINKS.map((link) => (
-						<NavLink
+						<TeamHeaderNavLink
 							to={`/team/${team.id}${link.path}`}
 							key={link.path}
-							className={({ isActive }) =>
-								'nav-link button' + (isActive ? ' selected' : '')
-							}
-							end
 						>
 							{link.label}
-						</NavLink>
+						</TeamHeaderNavLink>
 					))}
 				</nav>
 				<div className="right-content">

--- a/ui/src/App/Team/TeamHeader/TeamHeaderNavLink/TeamHeaderNavLink.scss
+++ b/ui/src/App/Team/TeamHeader/TeamHeaderNavLink/TeamHeaderNavLink.scss
@@ -15,58 +15,32 @@
  * limitations under the License.
  */
 
-@use '../../../Styles/main';
+@use '../../../../Styles/main';
 
-.header {
-	@include main.site-max-width;
+.team-header-nav-link {
+	@include main.button-defaults;
 
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	height: 42px;
+	height: 28px;
 
-	position: relative;
+	color: rgba(main.$asphalt, 0.4);
+	font-size: 1.1rem;
+	text-decoration: none;
 
-	@include main.breakpoint-medium {
-		height: 64px;
-	}
+	border-radius: 32px;
 
-	.center-content {
-		display: none;
-		flex: 1;
-		align-items: center;
-		justify-content: center;
-
-		@include main.breakpoint-medium {
-			display: flex;
-		}
-	}
-
-	.right-content {
-		display: flex;
-		flex: initial;
-		align-items: center;
-		justify-content: flex-end;
-
-		@include main.breakpoint-medium {
-			flex: 1;
-		}
-	}
-
-	.settings-button {
-		font-size: 1.3rem;
-
-		&:hover,
-		&:focus {
-			color: main.$purple;
-		}
+	&.selected {
+		color: main.$asphalt;
+		background-color: rgba(main.$asphalt, 0.2);
 	}
 }
 
 @include main.dark-theme {
-	.header {
-		.right-content {
+	.team-header-nav-link {
+		color: rgba(main.$gray-1, 0.4);
+
+		&.selected {
 			color: main.$gray-1;
+			background-color: rgba(main.$gray-1, 0.2);
 		}
 	}
 }

--- a/ui/src/App/Team/TeamHeader/TeamHeaderNavLink/TeamHeaderNavLink.tsx
+++ b/ui/src/App/Team/TeamHeader/TeamHeaderNavLink/TeamHeaderNavLink.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+import { NavLink } from 'react-router-dom';
+
+import './TeamHeaderNavLink.scss';
+
+interface Props {
+	to: string;
+	key: string;
+	children: ReactNode;
+}
+
+function TeamHeaderNavLink(props: Props) {
+	const { to, key, children } = props;
+
+	return (
+		<NavLink
+			to={to}
+			key={key}
+			className={({ isActive }) =>
+				'team-header-nav-link' + (isActive ? ' selected' : '')
+			}
+			end
+		>
+			{children}
+		</NavLink>
+	);
+}
+
+export default TeamHeaderNavLink;

--- a/ui/src/Common/AuthTemplate/AuthTemplate.scss
+++ b/ui/src/Common/AuthTemplate/AuthTemplate.scss
@@ -77,12 +77,12 @@
 		text-align: left;
 
 		a {
-			color: main.$dark-turquoise;
+			color: main.$teal;
 			font-weight: 500;
 
 			&:hover,
 			&:focus {
-				color: main.$turquoise;
+				color: main.$sea-foam;
 			}
 		}
 	}
@@ -112,11 +112,11 @@
 			font-size: 1.2rem;
 
 			a {
-				color: main.$turquoise;
+				color: main.$sea-foam;
 
 				&:hover,
 				&:focus {
-					color: main.$dark-turquoise;
+					color: main.$teal;
 				}
 			}
 		}

--- a/ui/src/Common/ButtonSubheader/ButtonSubheader.scss
+++ b/ui/src/Common/ButtonSubheader/ButtonSubheader.scss
@@ -15,44 +15,44 @@
  * limitations under the License.
  */
 
-@use '../../../../Styles/main';
+@use '../../Styles/main';
 
-.retro-subheader {
-	@include main.subheader;
+.subheader-button {
+	@include main.button-defaults;
 
-	* button {
-		margin-top: 0;
-		margin-bottom: 0;
+	min-width: auto;
+	height: 2.81rem;
+	padding: 0 1.7rem;
+
+	&:focus,
+	&:hover {
+		color: main.$teal;
 	}
 
-	.retro-subheader-container {
-		display: flex;
-		justify-content: right;
+	.button-icon {
+		display: block;
 
 		@include main.breakpoint-medium {
-			justify-content: space-between;
+			display: none;
 		}
 	}
 
-	.timer {
+	.button-text {
 		display: none;
 
 		@include main.breakpoint-medium {
-			display: inherit;
+			display: initial;
 		}
 	}
 }
 
-.retro-subheader-links {
-	display: flex;
-	justify-content: flex-end;
+@include main.dark-theme {
+	.subheader-button {
+		color: main.$white;
 
-	li {
-		width: auto;
-		height: 100%;
-	}
-
-	.archive-button {
-		margin-left: 24px;
+		&:focus,
+		&:hover {
+			color: main.$sea-foam;
+		}
 	}
 }

--- a/ui/src/Common/ButtonSubheader/ButtonSubheader.tsx
+++ b/ui/src/Common/ButtonSubheader/ButtonSubheader.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ButtonHTMLAttributes } from 'react';
+import classnames from 'classnames';
+
+import './ButtonSubheader.scss';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+	fontAwesomeIconClasses?: string;
+}
+
+function ButtonSubheader(props: Props) {
+	const { fontAwesomeIconClasses, className, children, ...buttonProps } = props;
+
+	return (
+		<button
+			className={classnames('subheader-button', className)}
+			{...buttonProps}
+		>
+			<span className="button-text">{children}</span>
+			{fontAwesomeIconClasses && (
+				<i
+					className={classnames(fontAwesomeIconClasses, 'button-icon')}
+					aria-hidden="true"
+				/>
+			)}
+		</button>
+	);
+}
+
+export default ButtonSubheader;

--- a/ui/src/Common/FormTemplate/FormTemplate.tsx
+++ b/ui/src/Common/FormTemplate/FormTemplate.tsx
@@ -18,8 +18,7 @@
 import React, { FormEventHandler } from 'react';
 import classnames from 'classnames';
 
-import ButtonPrimary from '../ButtonPrimary/ButtonPrimary';
-import ButtonSecondary from '../ButtonSecondary/ButtonSecondary';
+import { PrimaryButton, SecondaryButton } from '../Buttons/Button';
 
 import './FormTemplate.scss';
 
@@ -63,16 +62,16 @@ function FormTemplate(props: Props) {
 				{children}
 			</div>
 			<div className="form-template-footer">
-				<ButtonSecondary
+				<SecondaryButton
 					type="button"
 					className="form-template-button"
 					onClick={onCancel}
 				>
 					{cancelButtonText}
-				</ButtonSecondary>
-				<ButtonPrimary type="submit" className="form-template-button">
+				</SecondaryButton>
+				<PrimaryButton type="submit" className="form-template-button">
 					{submitButtonText}
-				</ButtonPrimary>
+				</PrimaryButton>
 			</div>
 		</form>
 	);

--- a/ui/src/Common/FormTemplate/FormTemplate.tsx
+++ b/ui/src/Common/FormTemplate/FormTemplate.tsx
@@ -18,7 +18,8 @@
 import React, { FormEventHandler } from 'react';
 import classnames from 'classnames';
 
-import { PrimaryButton, SecondaryButton } from '../Buttons/Button';
+import ButtonPrimary from '../ButtonPrimary/ButtonPrimary';
+import ButtonSecondary from '../ButtonSecondary/ButtonSecondary';
 
 import './FormTemplate.scss';
 
@@ -62,16 +63,16 @@ function FormTemplate(props: Props) {
 				{children}
 			</div>
 			<div className="form-template-footer">
-				<SecondaryButton
+				<ButtonSecondary
 					type="button"
 					className="form-template-button"
 					onClick={onCancel}
 				>
 					{cancelButtonText}
-				</SecondaryButton>
-				<PrimaryButton type="submit" className="form-template-button">
+				</ButtonSecondary>
+				<ButtonPrimary type="submit" className="form-template-button">
 					{submitButtonText}
-				</PrimaryButton>
+				</ButtonPrimary>
 			</div>
 		</form>
 	);

--- a/ui/src/Common/Input/Input.scss
+++ b/ui/src/Common/Input/Input.scss
@@ -58,7 +58,7 @@
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 2px main.$dark-turquoise;
+			box-shadow: 0 0 0 2px main.$teal;
 		}
 	}
 
@@ -86,7 +86,7 @@
 			box-shadow: 0 0 0 1px main.$gray-3;
 
 			&:focus {
-				box-shadow: 0 0 0 2px main.$turquoise;
+				box-shadow: 0 0 0 2px main.$sea-foam;
 			}
 		}
 

--- a/ui/src/Styles/_buttons.scss
+++ b/ui/src/Styles/_buttons.scss
@@ -50,7 +50,7 @@ $box-shadow: 0 1px 2px rgba(0, 0, 0, 0.16), 0 2px 4px rgba(0, 0, 0, 0.12),
 
 	text-decoration: none;
 
-	background-color: colors.$dark-turquoise;
+	background-color: colors.$teal;
 	box-shadow: $box-shadow;
 
 	&:disabled {
@@ -60,16 +60,16 @@ $box-shadow: 0 1px 2px rgba(0, 0, 0, 0.16), 0 2px 4px rgba(0, 0, 0, 0.12),
 
 	&:hover:not(:disabled),
 	&:focus:not(:disabled) {
-		background-color: colors.$turquoise;
+		background-color: colors.$sea-foam;
 	}
 
 	.dark-theme & {
 		color: colors.$asphalt;
-		background-color: colors.$turquoise;
+		background-color: colors.$sea-foam;
 
 		&:hover:not(:disabled),
 		&:focus:not(:disabled) {
-			background-color: colors.$dark-turquoise;
+			background-color: colors.$teal;
 		}
 	}
 }
@@ -79,25 +79,25 @@ $box-shadow: 0 1px 2px rgba(0, 0, 0, 0.16), 0 2px 4px rgba(0, 0, 0, 0.12),
 	width: 100%;
 	margin: 0.5rem auto 0;
 
-	color: colors.$dark-turquoise;
+	color: colors.$teal;
 
-	border: 2px solid colors.$dark-turquoise;
+	border: 2px solid colors.$teal;
 	box-shadow: $box-shadow;
 
 	&:focus,
 	&:hover {
 		color: colors.$white;
-		background-color: colors.$dark-turquoise;
+		background-color: colors.$teal;
 	}
 
 	.dark-theme & {
-		color: colors.$turquoise;
-		border: 2px solid colors.$turquoise;
+		color: colors.$sea-foam;
+		border: 2px solid colors.$sea-foam;
 
 		&:hover:not(:disabled),
 		&:focus:not(:disabled) {
-			background-color: colors.$turquoise;
-			border: 2px solid colors.$turquoise;
+			background-color: colors.$sea-foam;
+			border: 2px solid colors.$sea-foam;
 		}
 	}
 }
@@ -105,21 +105,21 @@ $box-shadow: 0 1px 2px rgba(0, 0, 0, 0.16), 0 2px 4px rgba(0, 0, 0, 0.12),
 @mixin button-tertiary {
 	margin: 1rem auto;
 
-	color: colors.$dark-turquoise;
+	color: colors.$teal;
 	font-weight: bold;
 
 	&:hover,
 	&:focus {
-		color: colors.$turquoise;
+		color: colors.$sea-foam;
 	}
 
 	.dark-theme & {
 		margin: 1rem auto 0;
-		color: colors.$turquoise;
+		color: colors.$sea-foam;
 
 		&:hover,
 		&:focus {
-			color: colors.$dark-turquoise;
+			color: colors.$teal;
 		}
 	}
 }

--- a/ui/src/Styles/_colors.scss
+++ b/ui/src/Styles/_colors.scss
@@ -42,8 +42,8 @@ $asphalt: #34495e;
 $dark-asphalt: #2c3e50;
 $black-asphalt: #21303d;
 
-$turquoise: #1abc9c;
-$dark-turquoise: #16a085;
+$sea-foam: #1abc9c;
+$teal: #16a085;
 
 $purple: #a56de2;
 $dark-purple: #8e44ad;

--- a/ui/src/Styles/_mixins.scss
+++ b/ui/src/Styles/_mixins.scss
@@ -111,7 +111,7 @@
 	.success-indicator {
 		margin: 1rem 0 2rem;
 
-		color: colors.$dark-turquoise;
+		color: colors.$teal;
 		font-family: 'Quicksand', serif;
 		font-weight: 700;
 		font-size: 20px;


### PR DESCRIPTION
## Overview
- Updated the retro page nav to use the teal/sea-foam colors instead of purple
- Componentized the nav links and nav buttons because I was having style scoping issues.
- Renamed color variables: `$dark-turquoise` is now `$teal` and `$turquoise` is now `$sea-foam`
- Fixed the logout button icon in mobile (was previously the same as the download csv icon)

### Demo
<img width="1519" alt="Screen Shot 2022-10-04 at 12 00 31 PM" src="https://user-images.githubusercontent.com/17144844/193868453-e8a92a4b-082d-4f1c-a522-f15c23c3553e.png">
<img width="1497" alt="Screen Shot 2022-10-04 at 12 00 14 PM" src="https://user-images.githubusercontent.com/17144844/193868458-d4d26fd5-82c7-4196-9eaa-721b9257e095.png">

## Testing Instructions
1) Go to the Retro Page in both light and dark mode. Ensure there is no longer purple in the nav and styles are updated.