### PR TITLE
Add Board Owners Confirmation Modal

### DIFF
--- a/ui/cypress/e2e/retro-facilitator-journey.spec.ts
+++ b/ui/cypress/e2e/retro-facilitator-journey.spec.ts
@@ -301,10 +301,10 @@ describe('Retro Facilitator Journey', () => {
 				secondaryEmail
 			);
 
-			cy.findByText('Add Email').click();
-
-			cy.findByText('Board Owners').should('exist');
-			cy.findByText('Add Board Owners').should('not.exist');
+			shouldSuccessfullyConfirmAndSaveEmailChanges([
+				primaryEmail,
+				secondaryEmail,
+			]);
 			cy.contains(primaryEmail).should('exist');
 			cy.contains(secondaryEmail).should('exist');
 		});
@@ -315,12 +315,29 @@ describe('Retro Facilitator Journey', () => {
 
 			cy.findByLabelText('Email Address 1').type(primaryEmail);
 
-			cy.findByText('Add Email').click();
-
-			cy.findByText('Board Owners').should('exist');
-			cy.findByText('Add Board Owners').should('not.exist');
+			shouldSuccessfullyConfirmAndSaveEmailChanges([primaryEmail]);
 			cy.contains(primaryEmail).should('exist');
 			cy.contains(secondaryEmail).should('not.exist');
+		});
+
+		it('Start adding two email addresses to team and then cancel action', () => {
+			createTeamWithNoEmailsAndLogin();
+			goToAccountSettings();
+
+			cy.findByLabelText('Email Address 1').type(primaryEmail);
+			cy.findByLabelText('Second Teammate’s Email (optional)').type(
+				secondaryEmail
+			);
+
+			cy.findByText('Add Email').click();
+			cy.findByText('Cancel').click();
+
+			cy.findByLabelText('Email Address 1').should('have.value', primaryEmail);
+			cy.findByLabelText('Second Teammate’s Email (optional)').should(
+				'have.value',
+				secondaryEmail
+			);
+			cy.findByText('Add Email').should('be.enabled');
 		});
 	});
 
@@ -332,6 +349,22 @@ describe('Retro Facilitator Journey', () => {
 		cy.get('@modal').should('not.exist');
 	};
 });
+
+function shouldSuccessfullyConfirmAndSaveEmailChanges(
+	expectedEmailAddresses: string[]
+) {
+	cy.findByText('Add Email').click();
+
+	cy.contains('Add Board Owners?').should('exist');
+	cy.findByText(
+		'These emails will be the board owners for everyone at Team With No Email.'
+	).should('exist');
+	expectedEmailAddresses.forEach((email) => {
+		cy.contains(email).should('exist');
+	});
+
+	cy.contains('Yes, Add Board Owners').click();
+}
 
 function createTeamWithNoEmailsAndLogin() {
 	const teamName = 'Team With No Email';

--- a/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackForm.scss
+++ b/ui/src/App/Team/Retro/RetroSubheader/FeedbackForm/FeedbackForm.scss
@@ -124,19 +124,5 @@
 				border-bottom-color: rgba(main.$gray-1, 0.15);
 			}
 		}
-
-		.button-secondary {
-			border-top: 0;
-		}
-
-		.button-primary {
-			color: main.$white;
-			background-color: main.$blue;
-
-			&:hover,
-			&:focus {
-				background-color: main.$purple;
-			}
-		}
 	}
 }

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/AccountTab.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/AccountTab.tsx
@@ -18,11 +18,19 @@
 import { useRecoilValue } from 'recoil';
 import { TeamState } from 'State/TeamState';
 
-import AddBoardOwnersForm from './AddBoardOwnersForm/AddBoardOwnersForm';
+import AddBoardOwnersForm, {
+	AddBoardOwnersFormProps,
+} from './AddBoardOwnersForm/AddBoardOwnersForm';
 
 import './AccountTab.scss';
 
-function AccountTab(): JSX.Element {
+interface Props {
+	accountTabData?: AddBoardOwnersFormProps;
+}
+
+function AccountTab(props: Props): JSX.Element {
+	const { accountTabData } = props;
+
 	const team = useRecoilValue(TeamState);
 
 	function teamHasEmail(): boolean {
@@ -31,7 +39,12 @@ function AccountTab(): JSX.Element {
 
 	return (
 		<div className="tab-body account-tab-body" data-testid="accountTab">
-			{!teamHasEmail() && <AddBoardOwnersForm />}
+			{!teamHasEmail() && (
+				<AddBoardOwnersForm
+					email1={accountTabData?.email1}
+					email2={accountTabData?.email2}
+				/>
+			)}
 			{teamHasEmail() && (
 				<div>
 					<div className="label">Board Owners</div>

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/AddBoardOwnersForm/AddBoardOwnersConfirmationForm/AddBoardOwnersConfirmation.scss
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/AddBoardOwnersForm/AddBoardOwnersConfirmationForm/AddBoardOwnersConfirmation.scss
@@ -15,16 +15,27 @@
  * limitations under the License.
  */
 
-@use '../../../../../Styles/main';
+@use '../../../../../../../Styles/main';
 
-.account-tab-body {
-	.team-email {
-		margin-top: 1rem;
+.add-board-owners-confirmation-form {
+	.board-owners-container {
+		max-width: 26.875rem;
+		height: 9.625rem;
+		margin: 2rem auto 0.5rem;
 
-		font-weight: 600;
-		font-size: 14px;
-		line-height: 18px;
-		letter-spacing: 0;
 		text-align: center;
+
+		border: 2px solid main.$asphalt;
+		border-radius: 5px;
+
+		.board-owners-label {
+			margin: 1rem 0 1.5rem;
+			font-size: 1.5rem;
+		}
+
+		.team-email {
+			margin: 1rem;
+			font-size: 0.875rem;
+		}
 	}
 }

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/AddBoardOwnersForm/AddBoardOwnersConfirmationForm/AddBoardOwnersConfirmationForm.spec.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/AddBoardOwnersForm/AddBoardOwnersConfirmationForm/AddBoardOwnersConfirmationForm.spec.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockTeam } from 'Services/Api/__mocks__/TeamService';
+import TeamService from 'Services/Api/TeamService';
+import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
+import { TeamState } from 'State/TeamState';
+import { RecoilObserver } from 'Utils/RecoilObserver';
+import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
+
+import Settings, { SettingsTabs } from '../../../Settings';
+
+import AddBoardOwnersConfirmationForm from './AddBoardOwnersConfirmationForm';
+
+jest.mock('Services/Api/TeamService');
+
+let modalContent: ModalContents | null;
+
+describe('Add Board Owners Confirmation', () => {
+	const team = {
+		...mockTeam,
+		email: '',
+		secondaryEmail: '',
+	};
+	const primaryEmail = 'primary@mail.com';
+	const secondaryEmail = 'secondary@mail.com';
+
+	beforeEach(() => {
+		modalContent = null;
+	});
+
+	it('should render team name based on global team data', () => {
+		renderWithRecoilRoot(
+			<AddBoardOwnersConfirmationForm email1="" />,
+			({ set }) => {
+				set(TeamState, team);
+			}
+		);
+
+		expect(
+			screen.getByText(
+				`These emails will be the board owners for everyone at ${team.name}.`
+			)
+		).toBeInTheDocument();
+	});
+
+	it('should show first and second email passed in as props', () => {
+		renderWithRecoilRoot(
+			<AddBoardOwnersConfirmationForm
+				email1="e@mail.com"
+				email2="e2@mail.com"
+			/>
+		);
+		renderAddBoardOwnersConfirmationForm(primaryEmail, secondaryEmail);
+
+		expect(screen.getByText('e@mail.com')).toBeInTheDocument();
+		expect(screen.getByText('e2@mail.com')).toBeInTheDocument();
+	});
+
+	it('should go back to the settings modal when clicking "Cancel"', async () => {
+		renderAddBoardOwnersConfirmationForm(primaryEmail, secondaryEmail);
+
+		expect(modalContent).not.toBeNull();
+
+		userEvent.click(screen.getByText('Cancel'));
+
+		await waitFor(() =>
+			expect(modalContent).toEqual({
+				title: 'Settings',
+				component: (
+					<Settings
+						activeTab={SettingsTabs.ACCOUNT}
+						accountTabData={{
+							email1: primaryEmail,
+							email2: secondaryEmail,
+						}}
+					/>
+				),
+			})
+		);
+		expect(TeamService.updateTeamEmailAddresses).not.toHaveBeenCalled();
+	});
+
+	it('should save both email addresses when clicking "Yes, Add Board Owners"', async () => {
+		renderAddBoardOwnersConfirmationForm(primaryEmail, secondaryEmail);
+
+		userEvent.click(screen.getByText('Yes, Add Board Owners'));
+
+		await waitFor(() =>
+			expect(TeamService.updateTeamEmailAddresses).toHaveBeenCalledWith(
+				team.id,
+				primaryEmail,
+				secondaryEmail
+			)
+		);
+		await waitFor(() =>
+			expect(modalContent).toEqual({
+				title: 'Settings',
+				component: <Settings activeTab={SettingsTabs.ACCOUNT} />,
+			})
+		);
+	});
+
+	function renderAddBoardOwnersConfirmationForm(
+		primaryEmail: string,
+		secondaryEmail?: string
+	) {
+		renderWithRecoilRoot(
+			<div>
+				<RecoilObserver
+					recoilState={ModalContentsState}
+					onChange={(value: ModalContents) => {
+						modalContent = value;
+					}}
+				/>
+				<AddBoardOwnersConfirmationForm
+					email1={primaryEmail}
+					email2={secondaryEmail}
+				/>
+			</div>,
+			({ set }) => {
+				set(TeamState, team);
+				set(ModalContentsState, {
+					title: 'Dummy Title',
+					component: <div></div>,
+				});
+			}
+		);
+	}
+});

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/AddBoardOwnersForm/AddBoardOwnersConfirmationForm/AddBoardOwnersConfirmationForm.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/AddBoardOwnersForm/AddBoardOwnersConfirmationForm/AddBoardOwnersConfirmationForm.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import FormTemplate from 'Common/FormTemplate/FormTemplate';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import teamService from 'Services/Api/TeamService';
+import { ModalContentsState } from 'State/ModalContentsState';
+import { TeamState } from 'State/TeamState';
+
+import Settings, { SettingsTabs } from '../../../Settings';
+
+import './AddBoardOwnersConfirmation.scss';
+
+interface Props {
+	email1: string;
+	email2?: string;
+}
+
+function AddBoardOwnersConfirmationForm(props: Props) {
+	const { email1, email2 = '' } = props;
+
+	const team = useRecoilValue(TeamState);
+	const setModalContents = useSetRecoilState(ModalContentsState);
+
+	function onSubmit() {
+		teamService
+			.updateTeamEmailAddresses(team.id, email1, email2)
+			.then(() => {
+				setModalContents({
+					title: 'Settings',
+					component: <Settings activeTab={SettingsTabs.ACCOUNT} />,
+				});
+			})
+			.catch(console.error);
+	}
+
+	function onCancel() {
+		setModalContents({
+			title: 'Settings',
+			component: (
+				<Settings
+					activeTab={SettingsTabs.ACCOUNT}
+					accountTabData={{
+						email1,
+						email2,
+					}}
+				/>
+			),
+		});
+	}
+
+	return (
+		<FormTemplate
+			title="Add Board Owners?"
+			subtitle={`These emails will be the board owners for everyone at ${team.name}.`}
+			onSubmit={onSubmit}
+			onCancel={onCancel}
+			cancelButtonText="Cancel"
+			submitButtonText="Yes, Add Board Owners"
+			className="add-board-owners-confirmation-form"
+		>
+			<div className="board-owners-container">
+				<div className="board-owners-label">Board Owners</div>
+				<div className="team-email">{email1}</div>
+				<div className="team-email">{email2}</div>
+			</div>
+		</FormTemplate>
+	);
+}
+
+export default AddBoardOwnersConfirmationForm;

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/AddBoardOwnersForm/AddBoardOwnersForm.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/AddBoardOwnersForm/AddBoardOwnersForm.tsx
@@ -18,9 +18,10 @@
 import { useState } from 'react';
 import Form from 'Common/AuthTemplate/Form/Form';
 import InputEmail from 'Common/InputEmail/InputEmail';
-import { useRecoilValue } from 'recoil';
-import teamService from 'Services/Api/TeamService';
-import { TeamState } from 'State/TeamState';
+import { useSetRecoilState } from 'recoil';
+import { ModalContentsState } from 'State/ModalContentsState';
+
+import AddBoardOwnersConfirmationForm from './AddBoardOwnersConfirmationForm/AddBoardOwnersConfirmationForm';
 
 import './AddBoardOwnersForm.scss';
 
@@ -31,25 +32,34 @@ interface ValueAndValidity {
 	validity: boolean;
 }
 
-function AddBoardOwnersForm() {
-	const team = useRecoilValue(TeamState);
+export interface AddBoardOwnersFormProps {
+	email1?: string;
+	email2?: string;
+}
+
+function AddBoardOwnersForm(props: AddBoardOwnersFormProps) {
+	const { email1 = '', email2 = '' } = props;
+
+	const setModalContents = useSetRecoilState(ModalContentsState);
 
 	const [primaryEmail, setPrimaryEmail] = useState<ValueAndValidity>(
-		blankValueWithValidity
+		email1 ? { value: email1, validity: true } : blankValueWithValidity
 	);
 	const [secondaryEmail, setSecondaryEmail] = useState<ValueAndValidity>({
-		value: '',
+		value: email2,
 		validity: true,
 	});
 
 	function submitForm() {
-		teamService
-			.updateTeamEmailAddresses(
-				team.id,
-				primaryEmail.value,
-				secondaryEmail.value
-			)
-			.catch(console.error);
+		setModalContents({
+			title: 'Add Board Owners?',
+			component: (
+				<AddBoardOwnersConfirmationForm
+					email1={primaryEmail.value}
+					email2={secondaryEmail.value}
+				/>
+			),
+		});
 	}
 
 	return (

--- a/ui/src/App/Team/TeamHeader/Settings/Settings.spec.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/Settings.spec.tsx
@@ -19,27 +19,53 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
 
-import Settings from './Settings';
+import Settings, { SettingsTabs } from './Settings';
 
 describe('Settings', () => {
-	beforeEach(() => {
-		renderWithRecoilRoot(<Settings />);
-	});
-
 	it('should be on the styles tab by default', () => {
+		renderWithRecoilRoot(<Settings />);
 		expect(hasSelectedTabClass(getStylesTab())).toBeTruthy();
 		expect(screen.getByText('Appearance')).toBeInTheDocument();
 		expect(screen.queryByTestId('accountTab')).not.toBeInTheDocument();
 		expect(screen.queryByText('Version:')).not.toBeInTheDocument();
 	});
 
+	it('should start on a different tab if specified via prop', () => {
+		renderWithRecoilRoot(<Settings activeTab={SettingsTabs.ACCOUNT} />);
+		expect(hasSelectedTabClass(getAccountTab())).toBeTruthy();
+		expect(screen.getByText('Add Board Owners')).toBeInTheDocument();
+	});
+
+	it('should pre-populate "Add Board Owners" if emails are passed down via props', () => {
+		renderWithRecoilRoot(
+			<Settings
+				activeTab={SettingsTabs.ACCOUNT}
+				accountTabData={{
+					email1: 'email1@mail.com',
+					email2: 'email2@mail.com',
+				}}
+			/>
+		);
+		expect(hasSelectedTabClass(getAccountTab())).toBeTruthy();
+		expect(screen.getByText('Add Board Owners')).toBeInTheDocument();
+
+		const email1Field = screen.getByLabelText('Email Address 1');
+		expect(email1Field).toHaveValue('email1@mail.com');
+		const email2Field = screen.getByLabelText(
+			'Second Teammate’s Email (optional)'
+		);
+		expect(email2Field).toHaveValue('email2@mail.com');
+	});
+
 	it('should go to the account settings when user clicks on the account tab', () => {
+		renderWithRecoilRoot(<Settings />);
 		userEvent.click(getAccountTab());
 		expect(hasSelectedTabClass(getAccountTab())).toBeTruthy();
 		expect(screen.getByTestId('accountTab')).toBeInTheDocument();
 	});
 
 	it('should go to the styles settings when user clicks on the styles tab', () => {
+		renderWithRecoilRoot(<Settings />);
 		userEvent.click(getAccountTab());
 		const stylesTab = getStylesTab();
 		expect(hasSelectedTabClass(stylesTab)).toBeFalsy();
@@ -49,6 +75,7 @@ describe('Settings', () => {
 	});
 
 	it('should go to the info settings when user clicks on the info tab', () => {
+		renderWithRecoilRoot(<Settings />);
 		const infoTab = getInfoTab();
 		expect(hasSelectedTabClass(infoTab)).toBeFalsy();
 

--- a/ui/src/App/Team/TeamHeader/Settings/Settings.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/Settings.tsx
@@ -19,23 +19,31 @@ import React, { useState } from 'react';
 import classnames from 'classnames';
 
 import AccountTab from './AccountTab/AccountTab';
+import { AddBoardOwnersFormProps } from './AccountTab/AddBoardOwnersForm/AddBoardOwnersForm';
 import InfoTab from './InfoTab/InfoTab';
 import StylesTab from './StylesTab/StylesTab';
 
 import './Settings.scss';
 
-enum Tabs {
+export enum SettingsTabs {
 	STYLES = 'styles',
 	ACCOUNT = 'account',
 	INFO = 'info',
 }
 
-export function Settings() {
-	const [tab, setTab] = useState<Tabs>(Tabs.STYLES);
+interface Props {
+	activeTab?: SettingsTabs;
+	accountTabData?: AddBoardOwnersFormProps;
+}
 
-	const stylesTabIsActive = () => tab === Tabs.STYLES;
-	const accountTabIsActive = () => tab === Tabs.ACCOUNT;
-	const infoTabIsActive = () => tab === Tabs.INFO;
+export function Settings(props: Props) {
+	const { activeTab = SettingsTabs.STYLES, accountTabData } = props;
+
+	const [tab, setTab] = useState<SettingsTabs>(activeTab);
+
+	const stylesTabIsActive = () => tab === SettingsTabs.STYLES;
+	const accountTabIsActive = () => tab === SettingsTabs.ACCOUNT;
+	const infoTabIsActive = () => tab === SettingsTabs.INFO;
 
 	return (
 		<div className="settings">
@@ -45,25 +53,25 @@ export function Settings() {
 				<div className="tab-heading">
 					<button
 						className={classnames('tab', { selected: stylesTabIsActive() })}
-						onClick={() => setTab(Tabs.STYLES)}
+						onClick={() => setTab(SettingsTabs.STYLES)}
 					>
 						Styles
 					</button>
 					<button
 						className={classnames('tab', { selected: accountTabIsActive() })}
-						onClick={() => setTab(Tabs.ACCOUNT)}
+						onClick={() => setTab(SettingsTabs.ACCOUNT)}
 					>
 						Account
 					</button>
 					<button
 						className={classnames('tab', { selected: infoTabIsActive() })}
-						onClick={() => setTab(Tabs.INFO)}
+						onClick={() => setTab(SettingsTabs.INFO)}
 					>
 						Info
 					</button>
 				</div>
 				{stylesTabIsActive() && <StylesTab />}
-				{accountTabIsActive() && <AccountTab />}
+				{accountTabIsActive() && <AccountTab accountTabData={accountTabData} />}
 				{infoTabIsActive() && <InfoTab />}
 			</div>
 		</div>


### PR DESCRIPTION
## What was done
- Added a confirmation modal after user adds emails to team via the "Add Board Owners" form so users can check and make sure their emails are correct
- Added cypress tests to test this flow

### Demo
<img width="834" alt="Screen Shot 2022-10-05 at 10 23 24 AM" src="https://user-images.githubusercontent.com/17144844/194084746-b9b4dfca-56bf-449f-b1da-c70f276e9be0.png">

## Testing Instructions
Locally, you'll have to create a team, then delete the email address from the database manually. After that, log in, go to the settings modal, click account, and fill out the "Add Board Owners" form. Submit the form and ensure that the confirmation modal pops up. Clicking cancel should bring you back to the populated form, and confirming the modal should add the emails in the database and bring you back to the settings modal where you can then see your saved emails.