### PR TITLE
Update password reset email text

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/email/EmailService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/email/EmailService.java
@@ -66,23 +66,18 @@ public class EmailService {
 			RequestPasswordResetRequest requestPasswordResetRequest
 	) {
 		return (
-			"Hi there! \n" +
-			"We’ve received a request to reset the password for the " +
+			"Hey there! \n" +
+			"You recently requested to reset your password for your RetroQuest account " +
 			requestPasswordResetRequest.getTeamName() +
-			" RetroQuest account associated with the email address " +
+			" associated with your email account " +
 			requestPasswordResetRequest.getEmail() +
-			". No changes have been made to your account yet. \r\n" +
-			"You can reset the password by clicking the link below: \r\n" +
+			". No changes have been made to the account yet. \r\n" +
+			"Use the link below to reset your password. This link is only valid for the next 10 minutes. \r\n" +
 			appBaseUrl +
 			"/password/reset?token=" +
 			passwordResetToken.getResetToken() +
 			"\r\n" +
-			"This link will expire in 10 minutes. After 10 minutes, you must submit a new password reset request at " +
-			"\r\n" +
-			appBaseUrl +
-			"/request-password-reset ." +
-			"\r\n" +
-			"If you didn’t make this request, you can safely ignore this email. \r\n"
+			"Thanks, \r\n The RetroQuest Team \r\n"
 		);
 	}
 }

--- a/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/team/TeamController.java
@@ -113,7 +113,7 @@ public class TeamController {
             passwordResetRepository.save(passwordResetToken);
 
             emailService.sendUnencryptedEmail(
-                    "Your password reset link from RetroQuest!",
+                    "Your Password Reset Link From RetroQuest!",
                     emailService.getPasswordResetMessage(passwordResetToken, requestPasswordResetRequest),
                     requestPasswordResetRequest.getEmail()
             );

--- a/api/src/test/java/com/ford/labs/retroquest/api/TeamApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/TeamApiTest.java
@@ -238,7 +238,7 @@ class TeamApiTest extends ApiTestBase {
         assertThat(actualToken.getDateCreated()).isNotNull();
         assertThat(actualToken.getResetToken()).isNotBlank();
 
-        verify(emailService).sendUnencryptedEmail("Your password reset link from RetroQuest!", "expectedMessage", "e@ma.il");
+        verify(emailService).sendUnencryptedEmail("Your Password Reset Link From RetroQuest!", "expectedMessage", "e@ma.il");
     }
 
     @Test
@@ -258,7 +258,7 @@ class TeamApiTest extends ApiTestBase {
         assertThat(actualToken.getDateCreated()).isNotNull();
         assertThat(actualToken.getResetToken()).isNotBlank();
 
-        verify(emailService).sendUnencryptedEmail("Your password reset link from RetroQuest!", "expectedMessage", "seconde@ma.il");
+        verify(emailService).sendUnencryptedEmail("Your Password Reset Link From RetroQuest!", "expectedMessage", "seconde@ma.il");
     }
 
     @Test
@@ -278,7 +278,7 @@ class TeamApiTest extends ApiTestBase {
         assertThat(actualToken.getDateCreated()).isNotNull();
         assertThat(actualToken.getResetToken()).isNotBlank();
 
-        verify(emailService).sendUnencryptedEmail("Your password reset link from RetroQuest!", "expectedMessage", "SecondE@MA.il");
+        verify(emailService).sendUnencryptedEmail("Your Password Reset Link From RetroQuest!", "expectedMessage", "SecondE@MA.il");
     }
 
     @Test

--- a/api/src/test/java/com/ford/labs/retroquest/email/EmailServiceTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/email/EmailServiceTest.java
@@ -54,30 +54,25 @@ class EmailServiceTest {
     }
 
     @Test
-    void shouldTheMessage(){
+    void shouldGetThePasswordResetMessage(){
         JavaMailSender mockSender = Mockito.mock(JavaMailSender.class);
         EmailService underTest = new EmailService(mockSender);
         ReflectionTestUtils.setField(underTest, "emailEnabled", true);
         ReflectionTestUtils.setField(underTest, "appBaseUrl", "something.com");
 
-        String actual = underTest.getPasswordResetMessage(new PasswordResetToken("t0k3n", new Team("teamUri", "teamUri", "passw0rD1"), LocalDateTime.now(), 600), new RequestPasswordResetRequest("teamUri", "e@ma.il"));
+        String actual = underTest.getPasswordResetMessage(new PasswordResetToken("t0k3n", new Team("team-name", "Team Name", "passw0rD1"), LocalDateTime.now(), 600), new RequestPasswordResetRequest("Team Name", "e@ma.il"));
 
-        assertThat(actual).isEqualTo(			"Hi there! \n" +
-                "We’ve received a request to reset the password for the " +
-                "teamUri" +
-                " RetroQuest account associated with the email address " +
+        assertThat(actual).isEqualTo(
+        "Hey there! \n" +
+                "You recently requested to reset your password for your RetroQuest account " +
+                "Team Name" +
+                " associated with your email account " +
                 "e@ma.il" +
-                ". No changes have been made to your account yet. \r\n" +
-                "You can reset the password by clicking the link below: \r\n" +
-                "something.com" +
-                "/password/reset?token=" +
-                "t0k3n" +
+                ". No changes have been made to the account yet. \r\n" +
+                "Use the link below to reset your password. This link is only valid for the next 10 minutes. \r\n" +
+                "something.com/password/reset?token=t0k3n" +
                 "\r\n" +
-                "This link will expire in 10 minutes. After 10 minutes, you must submit a new password reset request at " +
-                "\r\n" +
-                "something.com" +
-                "/request-password-reset ." +
-                "\r\n" +
-                "If you didn’t make this request, you can safely ignore this email. \r\n");
+                "Thanks, \r\n The RetroQuest Team \r\n"
+        );
     }
 }


### PR DESCRIPTION
## Overview
Update password reset email text to:

```
Hey there!
You recently requested to reset your password for your RetroQuest account {{teamName}} associated with your email account {{email}}. No changes have been made to the account yet.
Use the link below to reset your password. This link is only valid for the next 10 minutes. {{passwordResetUrl}}
Thanks, 
The RetroQuest Team
```

## Testing Instructions
**Must test in dev** and ensure email is being received in the expected format.