### PR TITLE
Expired Email Link Page

### DIFF
--- a/ui/cypress/e2e/login-recovery.spec.ts
+++ b/ui/cypress/e2e/login-recovery.spec.ts
@@ -51,6 +51,15 @@ describe('Login Recovery', () => {
 				ensureTeamEmailsGotSavedToDB(teamCredentials);
 			});
 		});
+
+		it('Redirect to "Expired Link" page when token is invalid', () => {
+			cy.visit(`/email/reset?token=invalid-token`);
+
+			cy.findByText('Expired Link').should('exist');
+			cy.findByText('You can request a new link in the settings menu.').should(
+				'exist'
+			);
+		});
 	});
 });
 

--- a/ui/src/App/App.tsx
+++ b/ui/src/App/App.tsx
@@ -22,14 +22,16 @@ import { useRecoilValue } from 'recoil';
 import { getThemeClassFromUserSettings, ThemeState } from 'State/ThemeState';
 
 import {
-	EXPIRED_LINK_PATH,
+	EXPIRED_EMAIL_RESET_LINK_PATH,
+	EXPIRED_PASSWORD_RESET_LINK_PATH,
 	PASSWORD_RESET_REQUEST_PATH,
 	RECOVER_TEAM_NAME_PATH,
 } from '../RouteConstants';
 
 import ChangeTeamDetailsPage from './ChangeTeamDetails/ChangeTeamDetailsPage';
 import CreateTeamPage from './CreateTeam/CreateTeamPage';
-import ExpiredLinkPage from './ExpiredLinkPage/ExpiredLinkPage';
+import ExpiredResetBoardOwnersLinkPage from './ExpiredResetBoardOwnersLinkPage/ExpiredResetBoardOwnersLinkPage';
+import ExpiredResetPasswordLinkPage from './ExpiredResetPasswordLinkPage/ExpiredResetPasswordLinkPage';
 import LoginPage from './Login/LoginPage';
 import PasswordResetRequestPage from './PasswordResetRequest/PasswordResetRequestPage';
 import RecoverTeamNamePage from './RecoverTeamName/RecoverTeamNamePage';
@@ -59,7 +61,14 @@ function App() {
 				<Route path="/create" element={<CreateTeamPage />} />
 				<Route path="/email/reset" element={<ChangeTeamDetailsPage />} />
 				<Route path="/password/reset" element={<ResetPasswordPage />} />
-				<Route path={EXPIRED_LINK_PATH} element={<ExpiredLinkPage />} />
+				<Route
+					path={EXPIRED_PASSWORD_RESET_LINK_PATH}
+					element={<ExpiredResetPasswordLinkPage />}
+				/>
+				<Route
+					path={EXPIRED_EMAIL_RESET_LINK_PATH}
+					element={<ExpiredResetBoardOwnersLinkPage />}
+				/>
 				<Route
 					path={PASSWORD_RESET_REQUEST_PATH}
 					element={<PasswordResetRequestPage />}

--- a/ui/src/App/ExpiredResetBoardOwnersLinkPage/ExpiredResetBoardOwnersLinkPage.scss
+++ b/ui/src/App/ExpiredResetBoardOwnersLinkPage/ExpiredResetBoardOwnersLinkPage.scss
@@ -18,6 +18,10 @@
 @use '../../Styles/main';
 
 .expired-link-page {
+	.auth-sub-heading {
+		display: none;
+	}
+
 	.paragraph-1-container {
 		display: flex;
 		align-items: center;

--- a/ui/src/App/ExpiredResetBoardOwnersLinkPage/ExpiredResetBoardOwnersLinkPage.spec.tsx
+++ b/ui/src/App/ExpiredResetBoardOwnersLinkPage/ExpiredResetBoardOwnersLinkPage.spec.tsx
@@ -19,40 +19,37 @@ import { MemoryRouter } from 'react-router-dom';
 import { screen, waitFor } from '@testing-library/react';
 import { MutableSnapshot } from 'recoil';
 import ContributorsService from 'Services/Api/ContributorsService';
-import PasswordResetTokenService from 'Services/Api/PasswordResetTokenService';
+import EmailResetTokenService from 'Services/Api/EmailResetTokenService';
 import { ThemeState } from 'State/ThemeState';
 import Theme from 'Types/Theme';
 import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
 
-import ExpiredLinkPage from './ExpiredLinkPage';
+import ExpiredResetBoardOwnersLinkPage from './ExpiredResetBoardOwnersLinkPage';
 
 jest.mock('Services/Api/ContributorsService');
 jest.mock('Services/Api/TeamService');
-jest.mock('Services/Api/PasswordResetTokenService');
+jest.mock('Services/Api/EmailResetTokenService');
 
-describe('Expired Link Page', () => {
-	it('should render header and link to reset password page', async () => {
+describe('Expired Reset Board Owners Link Page', () => {
+	it('should render header and link to login page', async () => {
 		await renderExpiredLinkPage();
 		expect(screen.getByText('Expired Link')).toBeDefined();
-		let resetPasswordPageLink = screen.getByText('Reset my Password');
-		expect(resetPasswordPageLink).toBeDefined();
-		expect(resetPasswordPageLink).toHaveAttribute(
-			'href',
-			'/request-password-reset'
-		);
+		const returnToLoginLink = screen.getByText('Return to Login');
+		expect(returnToLoginLink).toBeDefined();
+		expect(returnToLoginLink).toHaveAttribute('href', '/login');
 	});
 
 	it('should show token lifetime in page description', async () => {
-		PasswordResetTokenService.getResetTokenLifetime = jest
+		EmailResetTokenService.getResetTokenLifetime = jest
 			.fn()
 			.mockResolvedValue(600);
 		await renderExpiredLinkPage();
 		await waitFor(() =>
-			expect(PasswordResetTokenService.getResetTokenLifetime).toHaveBeenCalled()
+			expect(EmailResetTokenService.getResetTokenLifetime).toHaveBeenCalled()
 		);
 		expect(
 			screen.getByText(
-				'For your safety, our password reset link is only valid for 10 minutes.'
+				'For your safety, our board owner reset link is only valid for 10 minutes.'
 			)
 		).toBeDefined();
 	});
@@ -81,7 +78,7 @@ async function renderExpiredLinkPage(
 ) {
 	renderWithRecoilRoot(
 		<MemoryRouter>
-			<ExpiredLinkPage />
+			<ExpiredResetBoardOwnersLinkPage />
 		</MemoryRouter>,
 		recoilState
 	);

--- a/ui/src/App/ExpiredResetBoardOwnersLinkPage/ExpiredResetBoardOwnersLinkPage.tsx
+++ b/ui/src/App/ExpiredResetBoardOwnersLinkPage/ExpiredResetBoardOwnersLinkPage.tsx
@@ -20,21 +20,21 @@ import ErrorStopSignIcon from 'Assets/ErrorStopSignIcon';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import LinkPrimary from 'Common/LinkPrimary/LinkPrimary';
 import { useRecoilValue } from 'recoil';
-import { PASSWORD_RESET_REQUEST_PATH } from 'RouteConstants';
-import PasswordResetTokenService from 'Services/Api/PasswordResetTokenService';
+import { LOGIN_PAGE_PATH } from 'RouteConstants';
+import EmailResetTokenService from 'Services/Api/EmailResetTokenService';
 import { ThemeState } from 'State/ThemeState';
 import Theme from 'Types/Theme';
 
-import './ExpiredLinkPage.scss';
+import './ExpiredResetBoardOwnersLinkPage.scss';
 
-function ExpiredLinkPage() {
+function ExpiredResetBoardOwnersLinkPage() {
 	const theme = useRecoilValue(ThemeState);
 	const checkboxIconColor = theme === Theme.DARK ? '#c0392b' : '#e74c3c';
 
 	const [resetTokenLifetime, setResetTokenLifetime] = useState<number>(600);
 
 	useEffect(() => {
-		PasswordResetTokenService.getResetTokenLifetime().then((seconds) => {
+		EmailResetTokenService.getResetTokenLifetime().then((seconds) => {
 			setResetTokenLifetime(Math.floor(seconds / 60));
 		});
 	}, []);
@@ -51,21 +51,18 @@ function ExpiredLinkPage() {
 					className="checkbox-icon"
 				/>
 				<p className="paragraph-1">
-					For your safety, our password reset link is only valid for{' '}
+					For your safety, our board owner reset link is only valid for{' '}
 					{resetTokenLifetime} minutes.
 				</p>
 			</div>
 			<p className="paragraph-2">
-				Fear not! Click here to request a fresh, new reset link.
+				You can request a new link in the settings menu.
 			</p>
-			<LinkPrimary
-				to={PASSWORD_RESET_REQUEST_PATH}
-				className="reset-password-link"
-			>
-				Reset my Password
+			<LinkPrimary to={LOGIN_PAGE_PATH} className="reset-password-link">
+				Return to Login
 			</LinkPrimary>
 		</AuthTemplate>
 	);
 }
 
-export default ExpiredLinkPage;
+export default ExpiredResetBoardOwnersLinkPage;

--- a/ui/src/App/ExpiredResetPasswordLinkPage/ExpiredResetPasswordLinkPage.scss
+++ b/ui/src/App/ExpiredResetPasswordLinkPage/ExpiredResetPasswordLinkPage.scss
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../../Styles/main';
+
+.expired-link-page {
+	.auth-sub-heading {
+		display: none;
+	}
+
+	.paragraph-1-container {
+		display: flex;
+		align-items: center;
+
+		.checkbox-icon {
+			width: 3rem;
+			margin: 1rem;
+		}
+
+		.paragraph-1 {
+			max-width: 20rem;
+
+			color: main.$red;
+			font-weight: 600;
+		}
+	}
+
+	.paragraph-2 {
+		margin-bottom: 0.5rem;
+
+		color: main.$dark-gray;
+		font-weight: 600;
+	}
+}
+
+@include main.dark-theme {
+	.expired-link-page {
+		.paragraph-1 {
+			color: main.$dark-red;
+		}
+
+		.paragraph-2 {
+			color: main.$light-gray;
+		}
+	}
+}

--- a/ui/src/App/ExpiredResetPasswordLinkPage/ExpiredResetPasswordLinkPage.spec.tsx
+++ b/ui/src/App/ExpiredResetPasswordLinkPage/ExpiredResetPasswordLinkPage.spec.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MemoryRouter } from 'react-router-dom';
+import { screen, waitFor } from '@testing-library/react';
+import { MutableSnapshot } from 'recoil';
+import ContributorsService from 'Services/Api/ContributorsService';
+import PasswordResetTokenService from 'Services/Api/PasswordResetTokenService';
+import { ThemeState } from 'State/ThemeState';
+import Theme from 'Types/Theme';
+import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
+
+import ExpiredResetPasswordLinkPage from './ExpiredResetPasswordLinkPage';
+
+jest.mock('Services/Api/ContributorsService');
+jest.mock('Services/Api/TeamService');
+jest.mock('Services/Api/PasswordResetTokenService');
+
+describe('Expired Reset Password Link Page', () => {
+	it('should render header and link to reset password page', async () => {
+		await renderExpiredLinkPage();
+		expect(screen.getByText('Expired Link')).toBeDefined();
+		let resetPasswordPageLink = screen.getByText('Reset my Password');
+		expect(resetPasswordPageLink).toBeDefined();
+		expect(resetPasswordPageLink).toHaveAttribute(
+			'href',
+			'/request-password-reset'
+		);
+	});
+
+	it('should show token lifetime in page description', async () => {
+		PasswordResetTokenService.getResetTokenLifetime = jest
+			.fn()
+			.mockResolvedValue(600);
+		await renderExpiredLinkPage();
+		await waitFor(() =>
+			expect(PasswordResetTokenService.getResetTokenLifetime).toHaveBeenCalled()
+		);
+		expect(
+			screen.getByText(
+				'For your safety, our password reset link is only valid for 10 minutes.'
+			)
+		).toBeDefined();
+	});
+
+	it('should render error stop sign icon in confirmation screen as red in light mode', async () => {
+		await renderExpiredLinkPage(({ set }) => {
+			set(ThemeState, Theme.LIGHT);
+		});
+
+		const errorStopSignIcon = await screen.findByTestId('errorStopSignIcon');
+		expect(errorStopSignIcon.getAttribute('fill')).toBe('#e74c3c');
+	});
+
+	it('should render checkbox in confirmation screen as light turquoise in dark mode', async () => {
+		await renderExpiredLinkPage(({ set }) => {
+			set(ThemeState, Theme.DARK);
+		});
+
+		const errorStopSignIcon = await screen.findByTestId('errorStopSignIcon');
+		expect(errorStopSignIcon.getAttribute('fill')).toBe('#c0392b');
+	});
+});
+
+async function renderExpiredLinkPage(
+	recoilState?: (mutableSnapshot: MutableSnapshot) => void
+) {
+	renderWithRecoilRoot(
+		<MemoryRouter>
+			<ExpiredResetPasswordLinkPage />
+		</MemoryRouter>,
+		recoilState
+	);
+
+	await waitFor(() => expect(ContributorsService.get).toBeCalledTimes(1));
+}

--- a/ui/src/App/ExpiredResetPasswordLinkPage/ExpiredResetPasswordLinkPage.tsx
+++ b/ui/src/App/ExpiredResetPasswordLinkPage/ExpiredResetPasswordLinkPage.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import ErrorStopSignIcon from 'Assets/ErrorStopSignIcon';
+import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
+import LinkPrimary from 'Common/LinkPrimary/LinkPrimary';
+import { useRecoilValue } from 'recoil';
+import { PASSWORD_RESET_REQUEST_PATH } from 'RouteConstants';
+import PasswordResetTokenService from 'Services/Api/PasswordResetTokenService';
+import { ThemeState } from 'State/ThemeState';
+import Theme from 'Types/Theme';
+
+import './ExpiredResetPasswordLinkPage.scss';
+
+function ExpiredResetPasswordLinkPage() {
+	const theme = useRecoilValue(ThemeState);
+	const checkboxIconColor = theme === Theme.DARK ? '#c0392b' : '#e74c3c';
+
+	const [resetTokenLifetime, setResetTokenLifetime] = useState<number>(600);
+
+	useEffect(() => {
+		PasswordResetTokenService.getResetTokenLifetime().then((seconds) => {
+			setResetTokenLifetime(Math.floor(seconds / 60));
+		});
+	}, []);
+
+	return (
+		<AuthTemplate
+			header="Expired Link"
+			className="expired-link-page"
+			showGithubLink={false}
+		>
+			<div className="paragraph-1-container">
+				<ErrorStopSignIcon
+					color={checkboxIconColor}
+					className="checkbox-icon"
+				/>
+				<p className="paragraph-1">
+					For your safety, our password reset link is only valid for{' '}
+					{resetTokenLifetime} minutes.
+				</p>
+			</div>
+			<p className="paragraph-2">
+				Fear not! Click here to request a fresh, new reset link.
+			</p>
+			<LinkPrimary
+				to={PASSWORD_RESET_REQUEST_PATH}
+				className="reset-password-link"
+			>
+				Reset my Password
+			</LinkPrimary>
+		</AuthTemplate>
+	);
+}
+
+export default ExpiredResetPasswordLinkPage;

--- a/ui/src/App/ResetPassword/ResetPasswordPage.spec.tsx
+++ b/ui/src/App/ResetPassword/ResetPasswordPage.spec.tsx
@@ -35,12 +35,12 @@ jest.mock('react-router-dom', () => ({
 
 describe('Reset Password Page', () => {
 	it('should have RetroQuest header', () => {
-		renderWithToken('');
+		renderWithToken();
 		expect(screen.getByText('RetroQuest')).toBeDefined();
 	});
 
 	it('should have a field for new password, a disabled submit button, and a return to login link', async () => {
-		renderWithToken('');
+		renderWithToken();
 		expect(screen.getByLabelText('New Password')).toBeInTheDocument();
 		const submitButton = screen.getByText('Reset Password');
 		expect(submitButton).toBeDisabled();
@@ -60,8 +60,25 @@ describe('Reset Password Page', () => {
 					PasswordResetTokenService.checkIfResetTokenIsValid
 				).toHaveBeenCalledWith('expired-token')
 			);
-			expect(mockedUsedNavigate).toHaveBeenCalledWith('/expired-link');
-			expect(screen.queryByText('Reset Your Password')).toBeInTheDocument();
+			expect(mockedUsedNavigate).toHaveBeenCalledWith(
+				'/password/reset/expired-link'
+			);
+		});
+
+		it('should navigate to Expired Token page if token is not present in url', async () => {
+			PasswordResetTokenService.checkIfResetTokenIsValid = jest
+				.fn()
+				.mockResolvedValue(false);
+
+			renderWithToken();
+			await waitFor(() =>
+				expect(
+					PasswordResetTokenService.checkIfResetTokenIsValid
+				).toHaveBeenCalledWith('invalid')
+			);
+			expect(mockedUsedNavigate).toHaveBeenCalledWith(
+				'/password/reset/expired-link'
+			);
 		});
 
 		it('should check if token is valid and stay on page if it is valid', async () => {
@@ -76,12 +93,11 @@ describe('Reset Password Page', () => {
 				).toHaveBeenCalledWith('valid-token')
 			);
 			expect(mockedUsedNavigate).not.toHaveBeenCalled();
-			expect(screen.getByText('Reset Your Password')).toBeInTheDocument();
 		});
 	});
 
 	it('should enable submit button once user types valid password', () => {
-		renderWithToken('');
+		renderWithToken();
 		typeIntoNewPasswordField('invalidpassword');
 		const submitButton = screen.getByText('Reset Password');
 		expect(submitButton).toBeDisabled();
@@ -90,7 +106,7 @@ describe('Reset Password Page', () => {
 	});
 
 	it('should send passwords to the backend on submission', async () => {
-		renderWithToken('');
+		renderWithToken();
 		submitValidForm();
 
 		await waitFor(() =>
@@ -114,7 +130,7 @@ describe('Reset Password Page', () => {
 	});
 
 	it('should not send to the API if there is no password', () => {
-		renderWithToken('');
+		renderWithToken();
 		submitValidForm('');
 		expect(TeamService.setPasswordWithResetToken).toHaveBeenCalledTimes(0);
 	});
@@ -150,7 +166,7 @@ function typeIntoNewPasswordField(password: string = 'P@ssw0rd') {
 	});
 }
 
-function renderWithToken(token: string) {
+function renderWithToken(token: string = '') {
 	const initialEntry =
 		token !== '' ? '/password/reset?token=' + token : '/password/reset';
 	renderWithRecoilRoot(

--- a/ui/src/App/ResetPassword/ResetPasswordPage.tsx
+++ b/ui/src/App/ResetPassword/ResetPasswordPage.tsx
@@ -25,14 +25,18 @@ import LinkTertiary from 'Common/LinkTertiary/LinkTertiary';
 import PasswordResetTokenService from 'Services/Api/PasswordResetTokenService';
 import TeamService from 'Services/Api/TeamService';
 
-import { EXPIRED_LINK_PATH, LOGIN_PAGE_PATH } from '../../RouteConstants';
+import {
+	EXPIRED_PASSWORD_RESET_LINK_PATH,
+	LOGIN_PAGE_PATH,
+} from '../../RouteConstants';
 
 import './ResetPasswordPage.scss';
 
 function ResetPasswordPage(): JSX.Element {
 	const { search } = useLocation();
 	const navigate = useNavigate();
-	const passwordResetToken = new URLSearchParams(search).get('token') || '';
+	const passwordResetToken =
+		new URLSearchParams(search).get('token') || 'invalid';
 
 	const [newPassword, setNewPassword] = useState<string>('');
 	const [isFormSubmitted, setIsFormSubmitted] = useState(false);
@@ -50,7 +54,7 @@ function ResetPasswordPage(): JSX.Element {
 	useEffect(() => {
 		PasswordResetTokenService.checkIfResetTokenIsValid(passwordResetToken).then(
 			(isValidToken) => {
-				if (!isValidToken) navigate(EXPIRED_LINK_PATH);
+				if (!isValidToken) navigate(EXPIRED_PASSWORD_RESET_LINK_PATH);
 			}
 		);
 	}, [navigate, passwordResetToken]);

--- a/ui/src/RouteConstants.ts
+++ b/ui/src/RouteConstants.ts
@@ -20,7 +20,8 @@ export const REQUEST_PASSWORD_RESET_PAGE_PATH = '/request-password-reset';
 export const LOGIN_PAGE_PATH = '/login';
 export const PASSWORD_RESET_REQUEST_PATH = '/request-password-reset';
 export const RECOVER_TEAM_NAME_PATH = '/recover-team-name';
-export const EXPIRED_LINK_PATH = '/expired-link';
+export const EXPIRED_PASSWORD_RESET_LINK_PATH = '/password/reset/expired-link';
+export const EXPIRED_EMAIL_RESET_LINK_PATH = '/email/reset/expired-link';
 export const getLoginPagePathWithTeamId = (teamId: string) =>
 	`${LOGIN_PAGE_PATH}/${teamId}`;
 


### PR DESCRIPTION
## What was done
- [x] Redirect to the expired email link page when user goes to the update board owners page with an expired or invalid token

### Demo
<img width="1704" alt="Screen Shot 2022-10-12 at 2 21 28 PM" src="https://user-images.githubusercontent.com/17144844/195418935-5608e542-551b-439a-8df3-4707cb9974ca.png">

## Testing Instructions
1) Go to `localhost:3000/email/reset?token=invalid-token` and ensure you are redirected to the expired link page pictured above
2) Go to `localhost:3000/email/reset` (no token at all) and ensure you are redirected to the expired link page pictured above