### PR TITLE
Add login recovery settings buttons & confirmation modals

### DIFF
--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
@@ -17,7 +17,7 @@
 import React, { useEffect, useState } from 'react';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import Form from 'Common/AuthTemplate/Form/Form';
-import CheckYourMailConfirmation from 'Common/CheckYourMailConfirmation/CheckYourMailConfirmation';
+import CheckYourMailConfirmationPage from 'Common/CheckYourMailConfirmationPage/CheckYourMailConfirmationPage';
 import InputEmail from 'Common/InputEmail/InputEmail';
 import InputTeamName from 'Common/InputTeamName/InputTeamName';
 import LinkTertiary from 'Common/LinkTertiary/LinkTertiary';
@@ -100,7 +100,7 @@ function PasswordResetRequestPage(): JSX.Element {
 				</AuthTemplate>
 			)}
 			{emailSent && (
-				<CheckYourMailConfirmation
+				<CheckYourMailConfirmationPage
 					paragraph1={`We’ve sent an email to ${email} with password reset instructions.`}
 					paragraph2={`If an email doesn't show up soon, check your spam folder. We sent it from ${emailFromAddress}.`}
 				/>

--- a/ui/src/App/RecoverTeamName/RecoverTeamNamePage.tsx
+++ b/ui/src/App/RecoverTeamName/RecoverTeamNamePage.tsx
@@ -18,7 +18,7 @@
 import React, { useEffect, useState } from 'react';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import Form from 'Common/AuthTemplate/Form/Form';
-import CheckYourMailConfirmation from 'Common/CheckYourMailConfirmation/CheckYourMailConfirmation';
+import CheckYourMailConfirmationPage from 'Common/CheckYourMailConfirmationPage/CheckYourMailConfirmationPage';
 import InputEmail from 'Common/InputEmail/InputEmail';
 import ConfigurationService from 'Services/Api/ConfigurationService';
 
@@ -69,7 +69,7 @@ function RecoverTeamNamePage() {
 				</AuthTemplate>
 			)}
 			{emailSent && (
-				<CheckYourMailConfirmation
+				<CheckYourMailConfirmationPage
 					paragraph1={`If any RetroQuest teams are registered to ${recoveryEmail}, we’ve sent a list of all team names that are connected to the email address.`}
 					paragraph2={`If an email doesn’t show up soon, check your spam folder. We sent it from ${emailFromAddress}.`}
 				/>

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/AccountTab.spec.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/AccountTab.spec.tsx
@@ -26,6 +26,7 @@ import AccountTab from './AccountTab';
 
 describe('Account Tab', () => {
 	const addBoardOwnersFormTitle = 'Add Board Owners';
+	const boardOwnersFormTitle = 'Board Owners';
 	let activeTeam: Team;
 
 	beforeEach(() => {
@@ -43,6 +44,7 @@ describe('Account Tab', () => {
 		});
 
 		expect(await screen.findByText(addBoardOwnersFormTitle)).toBeDefined();
+		expect(screen.queryByText(boardOwnersFormTitle)).toBeNull();
 	});
 
 	it('should NOT show "Add Board Owners" form if team has a primary email', () => {
@@ -52,6 +54,7 @@ describe('Account Tab', () => {
 		});
 
 		expect(screen.queryByText(addBoardOwnersFormTitle)).toBeDefined();
+		expect(screen.getByText(boardOwnersFormTitle)).toBeDefined();
 	});
 
 	it('should NOT show "Add Board Owners" form if team has a secondary email', () => {
@@ -61,6 +64,7 @@ describe('Account Tab', () => {
 		});
 
 		expect(screen.queryByText(addBoardOwnersFormTitle)).toBeDefined();
+		expect(screen.getByText(boardOwnersFormTitle)).toBeDefined();
 	});
 });
 

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/AccountTab.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/AccountTab.tsx
@@ -21,6 +21,7 @@ import { TeamState } from 'State/TeamState';
 import AddBoardOwnersForm, {
 	AddBoardOwnersFormProps,
 } from './AddBoardOwnersForm/AddBoardOwnersForm';
+import BoardOwnersForm from './BoardOwnersForm/BoardOwnersForm';
 
 import './AccountTab.scss';
 
@@ -39,18 +40,13 @@ function AccountTab(props: Props): JSX.Element {
 
 	return (
 		<div className="tab-body account-tab-body" data-testid="accountTab">
-			{!teamHasEmail() && (
+			{teamHasEmail() ? (
+				<BoardOwnersForm />
+			) : (
 				<AddBoardOwnersForm
 					email1={accountTabData?.email1}
 					email2={accountTabData?.email2}
 				/>
-			)}
-			{teamHasEmail() && (
-				<div>
-					<div className="label">Board Owners</div>
-					<div className="team-email">{team.email}</div>
-					<div className="team-email">{team.secondaryEmail}</div>
-				</div>
 			)}
 		</div>
 	);

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.scss
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.scss
@@ -14,10 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const EmailService = {
-	sendPasswordResetEmail: jest.fn().mockResolvedValue(''),
-	sendBoardOwnersResetEmail: jest.fn().mockResolvedValue(''),
-	sendTeamNameRecoveryEmail: jest.fn().mockResolvedValue(''),
-};
 
-export default EmailService;
+.board-owners-form {
+	.label:not(:first-of-type) {
+		margin-top: 2.5rem;
+	}
+}

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.spec.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.spec.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import { mockTeam } from 'Services/Api/__mocks__/TeamService';
+import EmailService from 'Services/Api/EmailService';
+import { TeamState } from 'State/TeamState';
+import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
+
+import BoardOwnersForm from './BoardOwnersForm';
+
+jest.mock('Services/Api/EmailService');
+
+describe('Board Owners Form', () => {
+	it('should render current board owner email addresses', () => {
+		renderWithRecoilRoot(<BoardOwnersForm />, ({ set }) => {
+			set(TeamState, mockTeam);
+		});
+		expect(screen.getByText('a@b.c')).toBeInTheDocument();
+		expect(screen.getByText('d@e.f')).toBeInTheDocument();
+	});
+
+	it('should render section titles', () => {
+		renderWithRecoilRoot(<BoardOwnersForm />);
+		expect(screen.getByText('Change Board Owners')).toBeInTheDocument();
+		expect(screen.getByText('Reset Password')).toBeInTheDocument();
+	});
+
+	it('should send email to all present team emails when user clicks reset password link', async () => {
+		renderWithRecoilRoot(<BoardOwnersForm />, ({ set }) => {
+			set(TeamState, mockTeam);
+		});
+		getSendPasswordEmailButton().click();
+		await waitFor(() =>
+			expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledTimes(2)
+		);
+		expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledWith(
+			mockTeam.name,
+			mockTeam.email
+		);
+		expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledWith(
+			mockTeam.name,
+			mockTeam.secondaryEmail
+		);
+	});
+
+	it('should send email to one team email when user clicks reset password link', async () => {
+		renderWithRecoilRoot(<BoardOwnersForm />, ({ set }) => {
+			set(TeamState, { ...mockTeam, secondaryEmail: '' });
+		});
+		getSendPasswordEmailButton().click();
+		await waitFor(() =>
+			expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledTimes(1)
+		);
+		expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledWith(
+			mockTeam.name,
+			mockTeam.email
+		);
+	});
+
+	it('should send email to all present team emails when user clicks change board owners link', () => {
+		renderWithRecoilRoot(<BoardOwnersForm />, ({ set }) => {
+			set(TeamState, mockTeam);
+		});
+		getSendBoardOwnerEmailButton().click();
+		expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledTimes(2);
+		expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledWith(
+			mockTeam.name,
+			mockTeam.email
+		);
+		expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledWith(
+			mockTeam.name,
+			mockTeam.secondaryEmail
+		);
+	});
+
+	it('should send email to one team email when user clicks change board owners link', () => {
+		renderWithRecoilRoot(<BoardOwnersForm />, ({ set }) => {
+			set(TeamState, { ...mockTeam, secondaryEmail: '' });
+		});
+		getSendBoardOwnerEmailButton().click();
+		expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledTimes(1);
+		expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledWith(
+			mockTeam.name,
+			mockTeam.email
+		);
+	});
+});
+
+function getSendPasswordEmailButton() {
+	return screen.getByText('Send Reset Link');
+}
+
+function getSendBoardOwnerEmailButton() {
+	return screen.getByText('Send Update Email');
+}

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.spec.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.spec.tsx
@@ -167,11 +167,11 @@ describe('Board Owners Form', () => {
 });
 
 function getSendPasswordEmailButton() {
-	return screen.getByText('Send Reset Link');
+	return screen.getByText('Send Password Reset Link');
 }
 
 function getSendBoardOwnerEmailButton() {
-	return screen.getByText('Send Update Email');
+	return screen.getByText('Send Board Owner Update Link');
 }
 
 function renderBoardOwnersForm(team: Team) {

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.spec.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.spec.tsx
@@ -15,21 +15,30 @@
  * limitations under the License.
  */
 
+import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { mockTeam } from 'Services/Api/__mocks__/TeamService';
 import EmailService from 'Services/Api/EmailService';
+import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
 import { TeamState } from 'State/TeamState';
+import Team from 'Types/Team';
+import { RecoilObserver } from 'Utils/RecoilObserver';
 import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
 
+import EmailSentConfirmation from './EmailSentConfirmation/EmailSentConfirmation';
 import BoardOwnersForm from './BoardOwnersForm';
 
 jest.mock('Services/Api/EmailService');
 
+let modalContent: ModalContents | null;
+
 describe('Board Owners Form', () => {
+	beforeEach(() => {
+		modalContent = null;
+	});
+
 	it('should render current board owner email addresses', () => {
-		renderWithRecoilRoot(<BoardOwnersForm />, ({ set }) => {
-			set(TeamState, mockTeam);
-		});
+		renderBoardOwnersForm(mockTeam);
 		expect(screen.getByText('a@b.c')).toBeInTheDocument();
 		expect(screen.getByText('d@e.f')).toBeInTheDocument();
 	});
@@ -40,64 +49,120 @@ describe('Board Owners Form', () => {
 		expect(screen.getByText('Reset Password')).toBeInTheDocument();
 	});
 
-	it('should send email to all present team emails when user clicks reset password link', async () => {
-		renderWithRecoilRoot(<BoardOwnersForm />, ({ set }) => {
-			set(TeamState, mockTeam);
+	describe('Reset Password Section', () => {
+		it('should send email to all present team emails when user clicks reset password link', async () => {
+			renderBoardOwnersForm(mockTeam);
+			getSendPasswordEmailButton().click();
+			await waitFor(() =>
+				expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledTimes(2)
+			);
+			expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledWith(
+				mockTeam.name,
+				mockTeam.email
+			);
+			expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledWith(
+				mockTeam.name,
+				mockTeam.secondaryEmail
+			);
 		});
-		getSendPasswordEmailButton().click();
-		await waitFor(() =>
-			expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledTimes(2)
-		);
-		expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledWith(
-			mockTeam.name,
-			mockTeam.email
-		);
-		expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledWith(
-			mockTeam.name,
-			mockTeam.secondaryEmail
-		);
+
+		it('should send email to one team email when user clicks reset password link', async () => {
+			renderBoardOwnersForm({ ...mockTeam, secondaryEmail: '' });
+			getSendPasswordEmailButton().click();
+			await waitFor(() =>
+				expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledTimes(1)
+			);
+			expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledWith(
+				mockTeam.name,
+				mockTeam.email
+			);
+		});
+
+		describe('should show password reset email sent confirmation after successful submission', () => {
+			it('and message should include 2 email addresses', async () => {
+				renderBoardOwnersForm(mockTeam);
+				getSendPasswordEmailButton().click();
+				await waitFor(() =>
+					expect(modalContent).toEqual({
+						title: 'Check your Mail!',
+						component: (
+							<EmailSentConfirmation paragraph1="We’ve sent an email to a@b.c and d@e.f with password reset instructions." />
+						),
+					})
+				);
+			});
+
+			it('and message should include 1 email address', async () => {
+				renderBoardOwnersForm({ ...mockTeam, secondaryEmail: '' });
+				getSendPasswordEmailButton().click();
+				await waitFor(() =>
+					expect(modalContent).toEqual({
+						title: 'Check your Mail!',
+						component: (
+							<EmailSentConfirmation paragraph1="We’ve sent an email to a@b.c with password reset instructions." />
+						),
+					})
+				);
+			});
+		});
 	});
 
-	it('should send email to one team email when user clicks reset password link', async () => {
-		renderWithRecoilRoot(<BoardOwnersForm />, ({ set }) => {
-			set(TeamState, { ...mockTeam, secondaryEmail: '' });
+	describe('Change Board Owners Section', () => {
+		it('should send email to all present team emails when user clicks change board owners link', async () => {
+			renderBoardOwnersForm(mockTeam);
+			getSendBoardOwnerEmailButton().click();
+			await waitFor(() =>
+				expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledTimes(2)
+			);
+			expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledWith(
+				mockTeam.name,
+				mockTeam.email
+			);
+			expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledWith(
+				mockTeam.name,
+				mockTeam.secondaryEmail
+			);
 		});
-		getSendPasswordEmailButton().click();
-		await waitFor(() =>
-			expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledTimes(1)
-		);
-		expect(EmailService.sendPasswordResetEmail).toHaveBeenCalledWith(
-			mockTeam.name,
-			mockTeam.email
-		);
-	});
 
-	it('should send email to all present team emails when user clicks change board owners link', () => {
-		renderWithRecoilRoot(<BoardOwnersForm />, ({ set }) => {
-			set(TeamState, mockTeam);
+		it('should send email to one team email when user clicks change board owners link', async () => {
+			renderBoardOwnersForm({ ...mockTeam, secondaryEmail: '' });
+			getSendBoardOwnerEmailButton().click();
+			await waitFor(() =>
+				expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledTimes(1)
+			);
+			expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledWith(
+				mockTeam.name,
+				mockTeam.email
+			);
 		});
-		getSendBoardOwnerEmailButton().click();
-		expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledTimes(2);
-		expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledWith(
-			mockTeam.name,
-			mockTeam.email
-		);
-		expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledWith(
-			mockTeam.name,
-			mockTeam.secondaryEmail
-		);
-	});
 
-	it('should send email to one team email when user clicks change board owners link', () => {
-		renderWithRecoilRoot(<BoardOwnersForm />, ({ set }) => {
-			set(TeamState, { ...mockTeam, secondaryEmail: '' });
+		describe('should show board owners email sent confirmation after successful submission', () => {
+			it('and message should include 2 email addresses', async () => {
+				renderBoardOwnersForm(mockTeam);
+				getSendBoardOwnerEmailButton().click();
+				await waitFor(() =>
+					expect(modalContent).toEqual({
+						title: 'Check your Mail!',
+						component: (
+							<EmailSentConfirmation paragraph1="We’ve sent an email to a@b.c and d@e.f with instructions on how to change the Board Owner email addresses." />
+						),
+					})
+				);
+			});
+
+			it('and message should include 1 email address', async () => {
+				renderBoardOwnersForm({ ...mockTeam, secondaryEmail: '' });
+				getSendBoardOwnerEmailButton().click();
+				await waitFor(() =>
+					expect(modalContent).toEqual({
+						title: 'Check your Mail!',
+						component: (
+							<EmailSentConfirmation paragraph1="We’ve sent an email to a@b.c with instructions on how to change the Board Owner email addresses." />
+						),
+					})
+				);
+			});
 		});
-		getSendBoardOwnerEmailButton().click();
-		expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledTimes(1);
-		expect(EmailService.sendBoardOwnersResetEmail).toHaveBeenCalledWith(
-			mockTeam.name,
-			mockTeam.email
-		);
 	});
 });
 
@@ -107,4 +172,21 @@ function getSendPasswordEmailButton() {
 
 function getSendBoardOwnerEmailButton() {
 	return screen.getByText('Send Update Email');
+}
+
+function renderBoardOwnersForm(team: Team) {
+	renderWithRecoilRoot(
+		<>
+			<RecoilObserver
+				recoilState={ModalContentsState}
+				onChange={(value: ModalContents) => {
+					modalContent = value;
+				}}
+			/>
+			<BoardOwnersForm />
+		</>,
+		({ set }) => {
+			set(TeamState, team);
+		}
+	);
 }

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ButtonPrimary from 'Common/ButtonPrimary/ButtonPrimary';
+import { useRecoilValue } from 'recoil';
+import EmailService from 'Services/Api/EmailService';
+import { TeamState } from 'State/TeamState';
+
+import './BoardOwnersForm.scss';
+
+function BoardOwnersForm() {
+	const team = useRecoilValue(TeamState);
+
+	function sendPasswordResetLink() {
+		if (team.email) {
+			EmailService.sendPasswordResetEmail(team.name, team.email).catch(
+				console.error
+			);
+		}
+		if (team.secondaryEmail) {
+			EmailService.sendPasswordResetEmail(team.name, team.secondaryEmail).catch(
+				console.error
+			);
+		}
+	}
+
+	function sendBoardOwnersResetLink() {
+		if (team.email) {
+			EmailService.sendBoardOwnersResetEmail(team.name, team.email).catch(
+				console.error
+			);
+		}
+		if (team.secondaryEmail) {
+			EmailService.sendBoardOwnersResetEmail(
+				team.name,
+				team.secondaryEmail
+			).catch(console.error);
+		}
+	}
+
+	return (
+		<div className="board-owners-form">
+			<div className="label">Board Owners</div>
+			<div className="team-email">{team.email}</div>
+			<div className="team-email">{team.secondaryEmail}</div>
+			<div className="label">Reset Password</div>
+			<p className="description">
+				Need to change the password? No problem, just click the button below and
+				we'll send the board owners a link to reset the password.
+			</p>
+			<ButtonPrimary onClick={sendPasswordResetLink}>
+				Send Reset Link
+			</ButtonPrimary>
+			<div className="label">Change Board Owners</div>
+			<p className="description">
+				Need to change the email addresses associated with this RetroQuest?
+				Click the button below and we’ll email the current board owners a link
+				to make the changes.
+			</p>
+			<ButtonPrimary onClick={sendBoardOwnersResetLink}>
+				Send Update Email
+			</ButtonPrimary>
+		</div>
+	);
+}
+
+export default BoardOwnersForm;

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/BoardOwnersForm.tsx
@@ -83,7 +83,7 @@ function BoardOwnersForm() {
 				we'll send the board owners a link to reset the password.
 			</p>
 			<ButtonPrimary onClick={sendPasswordResetLink}>
-				Send Reset Link
+				Send Password Reset Link
 			</ButtonPrimary>
 			<div className="label">Change Board Owners</div>
 			<p className="description">
@@ -92,7 +92,7 @@ function BoardOwnersForm() {
 				to make the changes.
 			</p>
 			<ButtonPrimary onClick={sendBoardOwnersResetLink}>
-				Send Update Email
+				Send Board Owner Update Link
 			</ButtonPrimary>
 		</div>
 	);

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.scss
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.scss
@@ -15,22 +15,19 @@
  * limitations under the License.
  */
 
-@use '../../Styles/main';
+@use '../../../../../../../Styles/main';
 
-.check-your-mail-confirmation {
-	.auth-sub-heading {
-		display: none;
+.email-sent-confirmation {
+	@include main.white-modal-base;
+	max-width: 33.875rem;
+
+	.email-sent-confirmation-title {
+		@include main.white-modal-title;
 	}
 
 	.paragraph-1-container {
 		display: flex;
 		align-items: center;
-
-		.checkbox-icon {
-			width: 35px;
-			height: 28px;
-			margin: 1rem;
-		}
 
 		.paragraph-1 {
 			flex-basis: fit-content;
@@ -44,13 +41,12 @@
 
 	.paragraph-2 {
 		color: main.$dark-gray;
-		font-weight: bold;
-		text-align: center;
+		font-weight: 600;
 	}
 }
 
 @include main.dark-theme {
-	.check-your-mail-confirmation {
+	.email-sent-confirmation {
 		.paragraph-1 {
 			color: main.$sea-foam;
 		}

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.spec.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.spec.tsx
@@ -30,7 +30,7 @@ jest.mock('Services/Api/ConfigurationService');
 describe('Email Sent Confirmation Modal', () => {
 	let modalContent: ModalContents | null;
 
-	it('should paragraph 1 as passed down as a prop', async () => {
+	it('should show paragraph 1 text as what was passed down as a prop', async () => {
 		renderWithRecoilRoot(<EmailSentConfirmation paragraph1="Test Paragraph" />);
 		await waitForConfigurationCall();
 		expect(screen.getByText('Test Paragraph')).toBeInTheDocument();

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.spec.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.spec.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConfigurationService from 'Services/Api/ConfigurationService';
+import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
+import { RecoilObserver } from 'Utils/RecoilObserver';
+import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
+
+import EmailSentConfirmation from './EmailSentConfirmation';
+
+jest.mock('Services/Api/ConfigurationService');
+
+describe('Email Sent Confirmation Modal', () => {
+	let modalContent: ModalContents | null;
+
+	it('should paragraph 1 as passed down as a prop', async () => {
+		renderWithRecoilRoot(<EmailSentConfirmation paragraph1="Test Paragraph" />);
+		await waitForConfigurationCall();
+		expect(screen.getByText('Test Paragraph')).toBeInTheDocument();
+	});
+
+	it('should show "email sent from address" in paragraph 2', async () => {
+		renderWithRecoilRoot(<EmailSentConfirmation paragraph1="" />);
+		await waitForConfigurationCall();
+		expect(
+			screen.getByText(
+				'If an email doesn’t show up soon, check your spam folder. We sent it from mock_email_from_address@email.com.'
+			)
+		).toBeInTheDocument();
+	});
+
+	it('should close modal when close button is clicked', async () => {
+		renderWithRecoilRoot(
+			<>
+				<RecoilObserver
+					recoilState={ModalContentsState}
+					onChange={(value: ModalContents) => {
+						modalContent = value;
+					}}
+				/>
+				<EmailSentConfirmation paragraph1="" />
+			</>,
+			({ set }) => {
+				set(ModalContentsState, { title: 'Test', component: <></> });
+			}
+		);
+		await waitForConfigurationCall();
+		userEvent.click(screen.getByText('Close'));
+		await waitFor(() => expect(modalContent).toBeNull());
+	});
+});
+
+async function waitForConfigurationCall() {
+	await waitFor(() => expect(ConfigurationService.get).toHaveBeenCalled());
+}

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.tsx
@@ -17,7 +17,7 @@
 
 import React, { useEffect, useState } from 'react';
 import ButtonPrimary from 'Common/ButtonPrimary/ButtonPrimary';
-import TealCheckedCheckboxIcon from 'Common/TealCheckedCheckboxIcon/TealCheckedCheckboxIcon';
+import ThemedCheckboxIcon from 'Common/ThemedCheckboxIcon/ThemedCheckboxIcon';
 import { useSetRecoilState } from 'recoil';
 import ConfigurationService from 'Services/Api/ConfigurationService';
 import { ModalContentsState } from 'State/ModalContentsState';
@@ -49,7 +49,7 @@ function EmailSentConfirmation(props: Props) {
 		<div className="email-sent-confirmation">
 			<div className="email-sent-confirmation-title">Check your Mail!</div>
 			<div className="paragraph-1-container">
-				<TealCheckedCheckboxIcon />
+				<ThemedCheckboxIcon />
 				<p className="paragraph-1">{paragraph1}</p>
 			</div>
 			<p className="paragraph-2">

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import ButtonPrimary from 'Common/ButtonPrimary/ButtonPrimary';
+import TealCheckedCheckboxIcon from 'Common/TealCheckedCheckboxIcon/TealCheckedCheckboxIcon';
+import { useSetRecoilState } from 'recoil';
+import ConfigurationService from 'Services/Api/ConfigurationService';
+import { ModalContentsState } from 'State/ModalContentsState';
+
+import './EmailSentConfirmation.scss';
+
+interface Props {
+	paragraph1: string;
+}
+
+function EmailSentConfirmation(props: Props) {
+	const { paragraph1 } = props;
+
+	const setModalContents = useSetRecoilState(ModalContentsState);
+
+	const [emailFromAddress, setEmailFromAddress] = useState<string>('');
+
+	const closeModal = () => setModalContents(null);
+
+	useEffect(() => {
+		if (!emailFromAddress) {
+			ConfigurationService.get().then((config) =>
+				setEmailFromAddress(config.email_from_address)
+			);
+		}
+	});
+
+	return (
+		<div className="email-sent-confirmation">
+			<div className="email-sent-confirmation-title">Check your Mail!</div>
+			<div className="paragraph-1-container">
+				<TealCheckedCheckboxIcon />
+				<p className="paragraph-1">{paragraph1}</p>
+			</div>
+			<p className="paragraph-2">
+				If an email doesn’t show up soon, check your spam folder. We sent it
+				from {emailFromAddress}.
+			</p>
+			<ButtonPrimary onClick={closeModal}>Close</ButtonPrimary>
+		</div>
+	);
+}
+
+export default EmailSentConfirmation;

--- a/ui/src/App/Team/TeamHeader/Settings/Settings.scss
+++ b/ui/src/App/Team/TeamHeader/Settings/Settings.scss
@@ -22,7 +22,8 @@
 	flex-direction: column;
 	width: 100%;
 	height: auto;
-	padding: 24px;
+	margin: .5rem 0 3rem;
+	padding: 3rem 3.5rem 4.5rem;
 
 	font-size: 1rem;
 
@@ -33,8 +34,9 @@
 	position: relative;
 
 	@include main.breakpoint-medium {
-		width: 450px;
+		width: 34.5rem;
 		min-height: 450px;
+		margin: auto;
 	}
 
 	.settings-title {

--- a/ui/src/App/Team/TeamHeader/Settings/Settings.scss
+++ b/ui/src/App/Team/TeamHeader/Settings/Settings.scss
@@ -18,18 +18,11 @@
 @use '../../../../Styles/main';
 
 .settings {
+	@include main.white-modal-base;
+
 	display: flex;
 	flex-direction: column;
-	width: 100%;
-	height: auto;
-	margin: .5rem 0 3rem;
-	padding: 3rem 3.5rem 4.5rem;
-
-	font-size: 1rem;
-
-	background-color: main.$white;
-	border-radius: 6px;
-	box-shadow: 0 19px 38px rgba(main.$black, 0.3);
+	margin: 0.5rem 0 3rem;
 
 	position: relative;
 
@@ -40,20 +33,7 @@
 	}
 
 	.settings-title {
-		width: 100%;
-		margin-bottom: 0.5rem;
-
-		font-weight: bold;
-
-		font-size: 2rem;
-		text-align: center;
-		text-transform: capitalize;
-
-		cursor: default;
-
-		@include main.breakpoint-medium {
-			font-size: 2.5rem;
-		}
+		@include main.white-modal-title;
 	}
 
 	.settings-subtitle {

--- a/ui/src/Common/CheckYourMailConfirmationPage/CheckYourMailConfirmationPage.scss
+++ b/ui/src/Common/CheckYourMailConfirmationPage/CheckYourMailConfirmationPage.scss
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../../Styles/main';
+
+.check-your-mail-confirmation {
+	.auth-sub-heading {
+		display: none;
+	}
+
+	.paragraph-1-container {
+		display: flex;
+		align-items: center;
+
+		.paragraph-1 {
+			flex-basis: fit-content;
+			flex-basis: -moz-fit-content;
+			margin-top: 1rem;
+
+			color: main.$teal;
+			font-weight: bold;
+		}
+	}
+
+	.paragraph-2 {
+		color: main.$dark-gray;
+		font-weight: bold;
+		text-align: center;
+	}
+}
+
+@include main.dark-theme {
+	.check-your-mail-confirmation {
+		.paragraph-1 {
+			color: main.$sea-foam;
+		}
+
+		.paragraph-2 {
+			color: main.$light-gray;
+		}
+	}
+}

--- a/ui/src/Common/CheckYourMailConfirmationPage/CheckYourMailConfirmationPage.tsx
+++ b/ui/src/Common/CheckYourMailConfirmationPage/CheckYourMailConfirmationPage.tsx
@@ -15,27 +15,21 @@
  * limitations under the License.
  */
 import React from 'react';
-import CheckedCheckboxIcon from 'Assets/CheckedCheckboxIcon';
-import { useRecoilValue } from 'recoil';
 import { LOGIN_PAGE_PATH } from 'RouteConstants';
-import { ThemeState } from 'State/ThemeState';
-import Theme from 'Types/Theme';
 
 import AuthTemplate from '../AuthTemplate/AuthTemplate';
 import LinkPrimary from '../LinkPrimary/LinkPrimary';
+import TealCheckedCheckboxIcon from '../TealCheckedCheckboxIcon/TealCheckedCheckboxIcon';
 
-import './CheckYourMailConfirmation.scss';
+import './CheckYourMailConfirmationPage.scss';
 
 interface Props {
 	paragraph1: string;
 	paragraph2: string;
 }
 
-function CheckYourMailConfirmation(props: Props) {
+function CheckYourMailConfirmationPage(props: Props) {
 	const { paragraph1, paragraph2 } = props;
-
-	const theme = useRecoilValue(ThemeState);
-	const checkboxIconColor = theme === Theme.DARK ? '#1abc9c' : '#16a085';
 
 	return (
 		<AuthTemplate
@@ -44,10 +38,7 @@ function CheckYourMailConfirmation(props: Props) {
 			showGithubLink={false}
 		>
 			<div className="paragraph-1-container">
-				<CheckedCheckboxIcon
-					color={checkboxIconColor}
-					className="checkbox-icon"
-				/>
+				<TealCheckedCheckboxIcon />
 				<p className="paragraph-1">{paragraph1}</p>
 			</div>
 			<p className="paragraph-2">{paragraph2}</p>
@@ -58,4 +49,4 @@ function CheckYourMailConfirmation(props: Props) {
 	);
 }
 
-export default CheckYourMailConfirmation;
+export default CheckYourMailConfirmationPage;

--- a/ui/src/Common/CheckYourMailConfirmationPage/CheckYourMailConfirmationPage.tsx
+++ b/ui/src/Common/CheckYourMailConfirmationPage/CheckYourMailConfirmationPage.tsx
@@ -19,7 +19,7 @@ import { LOGIN_PAGE_PATH } from 'RouteConstants';
 
 import AuthTemplate from '../AuthTemplate/AuthTemplate';
 import LinkPrimary from '../LinkPrimary/LinkPrimary';
-import TealCheckedCheckboxIcon from '../TealCheckedCheckboxIcon/TealCheckedCheckboxIcon';
+import ThemedCheckboxIcon from '../ThemedCheckboxIcon/ThemedCheckboxIcon';
 
 import './CheckYourMailConfirmationPage.scss';
 
@@ -38,7 +38,7 @@ function CheckYourMailConfirmationPage(props: Props) {
 			showGithubLink={false}
 		>
 			<div className="paragraph-1-container">
-				<TealCheckedCheckboxIcon />
+				<ThemedCheckboxIcon />
 				<p className="paragraph-1">{paragraph1}</p>
 			</div>
 			<p className="paragraph-2">{paragraph2}</p>

--- a/ui/src/Common/Modal/Modal.scss
+++ b/ui/src/Common/Modal/Modal.scss
@@ -28,6 +28,8 @@
 
 .modal-container {
 	display: flex;
+	overflow: scroll;
+
 	z-index: 2;
 
 	&[aria-hidden='true'] {
@@ -43,7 +45,6 @@
 		height: 100%;
 		margin: auto;
 		padding: 0 0.8rem;
-		overflow: scroll;
 
 		color: main.$asphalt;
 		font-family: 'Quicksand', sans-serif;
@@ -56,7 +57,6 @@
 		@include main.breakpoint-medium {
 			width: unset;
 			height: unset;
-			overflow: unset;
 		}
 
 		&.super-size {

--- a/ui/src/Common/Modal/Modal.scss
+++ b/ui/src/Common/Modal/Modal.scss
@@ -40,8 +40,10 @@
 
 	.modal-content {
 		width: 100%;
+		height: 100%;
 		margin: auto;
 		padding: 0 0.8rem;
+		overflow: scroll;
 
 		color: main.$asphalt;
 		font-family: 'Quicksand', sans-serif;
@@ -53,6 +55,8 @@
 
 		@include main.breakpoint-medium {
 			width: unset;
+			height: unset;
+			overflow: unset;
 		}
 
 		&.super-size {

--- a/ui/src/Common/TealCheckedCheckboxIcon/TealCheckedCheckboxIcon.scss
+++ b/ui/src/Common/TealCheckedCheckboxIcon/TealCheckedCheckboxIcon.scss
@@ -1,0 +1,22 @@
+/*
+* Copyright (c) 2022 Ford Motor Company
+* All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+.checked-checkbox-icon {
+	width: 35px;
+	height: 28px;
+	margin: 1rem;
+}

--- a/ui/src/Common/TealCheckedCheckboxIcon/TealCheckedCheckboxIcon.spec.tsx
+++ b/ui/src/Common/TealCheckedCheckboxIcon/TealCheckedCheckboxIcon.spec.tsx
@@ -16,19 +16,16 @@
  */
 
 import { MemoryRouter } from 'react-router-dom';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { MutableSnapshot } from 'recoil';
-import ContributorsService from 'Services/Api/ContributorsService';
 import { ThemeState } from 'State/ThemeState';
 import Theme from 'Types/Theme';
 import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
 
-import CheckYourMailConfirmation from './CheckYourMailConfirmation';
+import TealCheckedCheckboxIcon from './TealCheckedCheckboxIcon';
 
-jest.mock('Services/Api/ContributorsService');
-
-describe('Check Your Mail Confirmation', () => {
-	it('should render checkbox in confirmation screen as dark turquoise in light mode', async () => {
+describe('Teal Checked Checkbox Icon', () => {
+	it('should render checkbox icon as dark turquoise in light mode', async () => {
 		await renderCheckYourMailConfirmation(({ set }) => {
 			set(ThemeState, Theme.LIGHT);
 		});
@@ -38,7 +35,7 @@ describe('Check Your Mail Confirmation', () => {
 		expect(checkedCheckboxIcon.getAttribute('fill')).toBe('#16a085');
 	});
 
-	it('should render checkbox in confirmation screen as light turquoise in dark mode', async () => {
+	it('should render checkbox icon as light turquoise in dark mode', async () => {
 		await renderCheckYourMailConfirmation(({ set }) => {
 			set(ThemeState, Theme.DARK);
 		});
@@ -54,9 +51,8 @@ async function renderCheckYourMailConfirmation(
 ) {
 	renderWithRecoilRoot(
 		<MemoryRouter>
-			<CheckYourMailConfirmation paragraph1="" paragraph2="" />
+			<TealCheckedCheckboxIcon />
 		</MemoryRouter>,
 		recoilState
 	);
-	await waitFor(() => expect(ContributorsService.get).toHaveBeenCalled());
 }

--- a/ui/src/Common/TealCheckedCheckboxIcon/TealCheckedCheckboxIcon.tsx
+++ b/ui/src/Common/TealCheckedCheckboxIcon/TealCheckedCheckboxIcon.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import CheckedCheckboxIcon from 'Assets/CheckedCheckboxIcon';
+import { useRecoilValue } from 'recoil';
+import { ThemeState } from 'State/ThemeState';
+import Theme from 'Types/Theme';
+
+import './TealCheckedCheckboxIcon.scss';
+
+function TealCheckedCheckboxIcon() {
+	const theme = useRecoilValue(ThemeState);
+	const checkboxIconColor = theme === Theme.DARK ? '#1abc9c' : '#16a085';
+
+	return (
+		<CheckedCheckboxIcon
+			color={checkboxIconColor}
+			className="checked-checkbox-icon"
+		/>
+	);
+}
+
+export default TealCheckedCheckboxIcon;

--- a/ui/src/Common/ThemedCheckboxIcon/ThemedCheckboxIcon.scss
+++ b/ui/src/Common/ThemedCheckboxIcon/ThemedCheckboxIcon.scss
@@ -15,7 +15,7 @@
 * limitations under the License.
 */
 
-.checked-checkbox-icon {
+.themed-checkbox-icon {
 	width: 35px;
 	height: 28px;
 	margin: 1rem;

--- a/ui/src/Common/ThemedCheckboxIcon/ThemedCheckboxIcon.spec.tsx
+++ b/ui/src/Common/ThemedCheckboxIcon/ThemedCheckboxIcon.spec.tsx
@@ -22,7 +22,7 @@ import { ThemeState } from 'State/ThemeState';
 import Theme from 'Types/Theme';
 import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
 
-import TealCheckedCheckboxIcon from './TealCheckedCheckboxIcon';
+import ThemedCheckboxIcon from './ThemedCheckboxIcon';
 
 describe('Teal Checked Checkbox Icon', () => {
 	it('should render checkbox icon as dark turquoise in light mode', async () => {
@@ -51,7 +51,7 @@ async function renderCheckYourMailConfirmation(
 ) {
 	renderWithRecoilRoot(
 		<MemoryRouter>
-			<TealCheckedCheckboxIcon />
+			<ThemedCheckboxIcon />
 		</MemoryRouter>,
 		recoilState
 	);

--- a/ui/src/Common/ThemedCheckboxIcon/ThemedCheckboxIcon.tsx
+++ b/ui/src/Common/ThemedCheckboxIcon/ThemedCheckboxIcon.tsx
@@ -21,18 +21,18 @@ import { useRecoilValue } from 'recoil';
 import { ThemeState } from 'State/ThemeState';
 import Theme from 'Types/Theme';
 
-import './TealCheckedCheckboxIcon.scss';
+import './ThemedCheckboxIcon.scss';
 
-function TealCheckedCheckboxIcon() {
+function ThemedCheckboxIcon() {
 	const theme = useRecoilValue(ThemeState);
 	const checkboxIconColor = theme === Theme.DARK ? '#1abc9c' : '#16a085';
 
 	return (
 		<CheckedCheckboxIcon
 			color={checkboxIconColor}
-			className="checked-checkbox-icon"
+			className="themed-checkbox-icon"
 		/>
 	);
 }
 
-export default TealCheckedCheckboxIcon;
+export default ThemedCheckboxIcon;

--- a/ui/src/Services/Api/ApiConstants.ts
+++ b/ui/src/Services/Api/ApiConstants.ts
@@ -18,10 +18,6 @@
 export const TEAM_API_PATH = '/api/team';
 export const CHANGE_EMAIL_API_PATH = '/api/team/email/reset';
 export const CHANGE_PASSWORD_API_PATH = '/api/team/password/reset';
-export const EMAIL_PASSWORD_REQUEST_API_PATH =
-	'/api/email/password-reset-request';
-export const EMAIL_TEAM_NAME_RECOVERY_API_PATH =
-	'/api/email/recover-team-names';
 export const LOGIN_API_PATH = `${TEAM_API_PATH}/login`;
 export const getTeamNameApiPath = (teamId: string) =>
 	`${TEAM_API_PATH}/${teamId}/name`;

--- a/ui/src/Services/Api/EmailService.spec.ts
+++ b/ui/src/Services/Api/EmailService.spec.ts
@@ -43,4 +43,18 @@ describe('Email Service', () => {
 			);
 		});
 	});
+
+	describe('sendBoardOwnersResetEmail', () => {
+		it('should send email reset link', async () => {
+			await EmailService.sendBoardOwnersResetEmail('Team Name', 'a@b.c');
+
+			expect(axios.post).toHaveBeenCalledWith(
+				'/api/email/email-reset-request',
+				{
+					teamName: 'Team Name',
+					email: 'a@b.c',
+				}
+			);
+		});
+	});
 });

--- a/ui/src/Services/Api/EmailService.ts
+++ b/ui/src/Services/Api/EmailService.ts
@@ -17,26 +17,25 @@
 
 import axios, { AxiosResponse } from 'axios';
 
-import {
-	EMAIL_PASSWORD_REQUEST_API_PATH,
-	EMAIL_TEAM_NAME_RECOVERY_API_PATH,
-} from './ApiConstants';
+const baseEmailPath = '/api/email';
 
 const EmailService = {
 	sendTeamNameRecoveryEmail(recoveryEmail: string): Promise<AxiosResponse> {
-		return axios.post(EMAIL_TEAM_NAME_RECOVERY_API_PATH, {
-			recoveryEmail: recoveryEmail,
-		});
+		const url = `${baseEmailPath}/recover-team-names`;
+		return axios.post(url, { recoveryEmail });
 	},
 
 	sendPasswordResetEmail(
 		teamName: string,
 		email: string
 	): Promise<AxiosResponse> {
-		return axios.post(EMAIL_PASSWORD_REQUEST_API_PATH, {
-			teamName: teamName,
-			email: email,
-		});
+		const url = `${baseEmailPath}/password-reset-request`;
+		return axios.post(url, { teamName, email });
+	},
+
+	sendBoardOwnersResetEmail(teamName: string, email: string) {
+		const url = `${baseEmailPath}/email-reset-request`;
+		return axios.post(url, { teamName, email });
 	},
 };
 

--- a/ui/src/Styles/_modal.scss
+++ b/ui/src/Styles/_modal.scss
@@ -1,0 +1,48 @@
+/*
+* Copyright (c) 2022 Ford Motor Company
+* All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+@use 'colors';
+@use 'mixins';
+
+@mixin white-modal-base {
+	width: 100%;
+	height: auto;
+	padding: 3rem 3.5rem 4.5rem;
+
+	font-size: 1rem;
+
+	background-color: colors.$white;
+	border-radius: 6px;
+	box-shadow: 0 19px 38px rgba(colors.$black, 0.3);
+}
+
+@mixin white-modal-title {
+	width: 100%;
+	margin-bottom: 0.5rem;
+
+	font-weight: bold;
+
+	font-size: 2rem;
+	text-align: center;
+	text-transform: capitalize;
+
+	cursor: default;
+
+	@include mixins.breakpoint-medium {
+		font-size: 2.5rem;
+	}
+}

--- a/ui/src/Styles/main.scss
+++ b/ui/src/Styles/main.scss
@@ -20,6 +20,7 @@
 @forward 'sizes';
 @forward 'functions';
 @forward 'buttons';
+@forward 'modal';
 
 @use 'colors';
 


### PR DESCRIPTION
## What was done
- [x] Added links in the Settings>Account modal to allow users to get sent an email to reset their password or reset their email addresses
- [x] Added confirmation modals for either of those buttons so the user knows their email was sent succesfully 

### Demo
<img width="582" alt="Screen Shot 2022-10-13 at 1 18 39 PM" src="https://user-images.githubusercontent.com/17144844/195665197-2eead5a1-7c0b-47ff-93cc-f610c33fc7f0.png">
<img width="573" alt="Screen Shot 2022-10-13 at 1 37 54 PM" src="https://user-images.githubusercontent.com/17144844/195667150-fe5c8f39-1704-41a4-963a-a94ba0e2af79.png">
<img width="568" alt="Screen Shot 2022-10-13 at 1 38 02 PM" src="https://user-images.githubusercontent.com/17144844/195667156-bf68cd06-80a0-4d8d-8261-c71d4039a862.png">

## Testing Instructions
1) Go to Settings>Account for a team that has at least one email
2) Click on the "Send Password Reset Link" link and ensure it makes an api call or two (one for each email the team has) and shows the corresponding confirmation modal. Clicking close on that modal should close the entire modal.
3) Click on the "Send Board Owner Update Link" link and ensure it makes an api call or two (one for each email the team has) and shows the corresponding confirmation modal. Clicking close on that modal should close the entire modal.