### PR TITLE
Fix login page team name population

### DIFF
--- a/ui/src/App/Login/LoginPage.spec.tsx
+++ b/ui/src/App/Login/LoginPage.spec.tsx
@@ -20,7 +20,6 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { RecoilRoot } from 'recoil';
-import { mockContributors } from 'Services/Api/__mocks__/ContributorsService';
 import { mockTeam } from 'Services/Api/__mocks__/TeamService';
 import ContributorsService from 'Services/Api/ContributorsService';
 import TeamService from 'Services/Api/TeamService';
@@ -29,6 +28,7 @@ import LoginPage from './LoginPage';
 
 jest.mock('Services/Api/ContributorsService');
 jest.mock('Services/Api/TeamService');
+jest.mock('Services/Api/ConfigurationService');
 
 const mockLogin = jest.fn();
 
@@ -38,19 +38,13 @@ jest.mock('Hooks/useAuth', () => {
 	});
 });
 
-jest.mock('Services/Api/ConfigurationService');
-
-describe('LoginPage.spec.tsx', () => {
+describe('Login Page', () => {
 	let container: HTMLElement;
 	let rerender: (ui: ReactElement) => void;
 	const validTeamName = mockTeam.name;
 	const validPassword = 'Password1';
 
 	beforeEach(async () => {
-		ContributorsService.get = jest.fn().mockResolvedValue(mockContributors);
-		TeamService.getTeam = jest.fn().mockResolvedValue(mockTeam);
-		TeamService.login = jest.fn().mockResolvedValue(mockTeam);
-
 		({ container, rerender } = renderComponent());
 
 		await waitFor(() => expect(ContributorsService.get).toHaveBeenCalled());
@@ -90,6 +84,9 @@ describe('LoginPage.spec.tsx', () => {
 					</Routes>
 				</MemoryRouter>
 			</RecoilRoot>
+		);
+		await waitFor(() =>
+			expect(TeamService.getTeamName).toHaveBeenCalledWith(mockTeam.id)
 		);
 		teamNameInput = getTeamNameInput();
 		await waitFor(async () => expect(teamNameInput.value).toBe(mockTeam.name));

--- a/ui/src/App/Login/LoginPage.tsx
+++ b/ui/src/App/Login/LoginPage.tsx
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import Form from 'Common/AuthTemplate/Form/Form';
 import HorizontalRuleWithText from 'Common/HorizontalRuleWithText/HorizontalRuleWithText';
@@ -23,7 +24,6 @@ import InputTeamName from 'Common/InputTeamName/InputTeamName';
 import LinkSecondary from 'Common/LinkSecondary/LinkSecondary';
 import LinkTertiary from 'Common/LinkTertiary/LinkTertiary';
 import useAuth from 'Hooks/useAuth';
-import useTeamFromRoute from 'Hooks/useTeamFromRoute';
 import {
 	CREATE_TEAM_PAGE_PATH,
 	PASSWORD_RESET_REQUEST_PATH,
@@ -33,16 +33,15 @@ import TeamService from 'Services/Api/TeamService';
 import './LoginPage.scss';
 
 function LoginPage(): JSX.Element {
+	const { teamId = '' } = useParams();
+
 	const { login } = useAuth();
-	const team = useTeamFromRoute();
 
 	const [teamName, setTeamName] = useState<string>('');
 	const [password, setPassword] = useState<string>('');
 
 	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const [errorMessages, setErrorMessages] = useState<string[]>([]);
-
-	useEffect(() => setTeamName(team.name), [team.name]);
 
 	function onLoginFormSubmit() {
 		setIsLoading(true);
@@ -56,6 +55,12 @@ function LoginPage(): JSX.Element {
 			})
 			.finally(() => setIsLoading(false));
 	}
+
+	useEffect(() => {
+		if (teamId) {
+			TeamService.getTeamName(teamId).then(setTeamName).catch(console.error);
+		}
+	}, [teamId]);
 
 	return (
 		<AuthTemplate header="Log in to your Team!" className="login-page">

--- a/ui/src/Services/Api/ApiConstants.ts
+++ b/ui/src/Services/Api/ApiConstants.ts
@@ -19,8 +19,6 @@ export const TEAM_API_PATH = '/api/team';
 export const CHANGE_EMAIL_API_PATH = '/api/team/email/reset';
 export const CHANGE_PASSWORD_API_PATH = '/api/team/password/reset';
 export const LOGIN_API_PATH = `${TEAM_API_PATH}/login`;
-export const getTeamNameApiPath = (teamId: string) =>
-	`${TEAM_API_PATH}/${teamId}/name`;
 
 export const CONTRIBUTORS_API_PATH = '/api/contributors';
 export const FEEDBACK_API_PATH = '/api/feedback/';

--- a/ui/src/Services/Api/TeamService.ts
+++ b/ui/src/Services/Api/TeamService.ts
@@ -29,7 +29,6 @@ import {
 	CHANGE_EMAIL_API_PATH,
 	CHANGE_PASSWORD_API_PATH,
 	getCSVApiPath,
-	getTeamNameApiPath,
 	LOGIN_API_PATH,
 	TEAM_API_PATH,
 } from './ApiConstants';
@@ -100,8 +99,8 @@ const TeamService = {
 	},
 
 	getTeamName(teamId: string): Promise<string> {
-		const TEAM_NAME_API_PATH = getTeamNameApiPath(teamId);
-		return axios.get(TEAM_NAME_API_PATH).then((res) => res.data);
+		const url = `${TEAM_API_PATH}/${teamId}/name`;
+		return axios.get(url).then((res) => res.data);
 	},
 
 	updateTeamEmailAddresses(teamId: string, email1: string, email2: string) {

--- a/ui/src/Services/Api/__mocks__/TeamService.ts
+++ b/ui/src/Services/Api/__mocks__/TeamService.ts
@@ -28,7 +28,7 @@ const TeamService = {
 	login: jest.fn().mockResolvedValue(''),
 	create: jest.fn().mockResolvedValue(''),
 	getTeam: jest.fn().mockResolvedValue(mockTeam),
-	getTeamName: jest.fn().mockResolvedValue('Active Team Name'),
+	getTeamName: jest.fn().mockResolvedValue(mockTeam.name),
 	getCSV: jest.fn().mockResolvedValue('column 1, column 2'),
 	updateEmailsWithResetToken: jest.fn().mockResolvedValue(''),
 	setPasswordWithResetToken: jest.fn().mockResolvedValue(''),


### PR DESCRIPTION
… does not require a token

## Overview
I accidentally broke the pre-population of the login page team name by changing it to fetch the whole team from a protected endpoint vs just getting the team name by id from an unprotected endpoint. This reverts that change so the team name can pre-populate on the login page again.

## Testing Instructions
1) Go to `/login/{teamName}` and ensure the team name populates and the call being made to fetch the team name does not have a token cookie or jsessionid being sent along with it.