### PR TITLE
Turn of JSESSIONID usage

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/security/WebSecurityConfig.java
+++ b/api/src/main/java/com/ford/labs/retroquest/security/WebSecurityConfig.java
@@ -26,6 +26,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
@@ -66,7 +67,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         }
 
         httpSecurity
-            .authorizeRequests()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and().authorizeRequests()
             .antMatchers("/**").permitAll()
             .anyRequest().authenticated()
             .and().exceptionHandling(e -> e.authenticationEntryPoint(new HttpStatusEntryPoint(UNAUTHORIZED)))

--- a/ui/cypress/e2e/archivist-journey.spec.ts
+++ b/ui/cypress/e2e/archivist-journey.spec.ts
@@ -118,12 +118,15 @@ function shouldBeOnArchivesPage(teamId: string) {
 }
 
 function getColumnsForTeam(teamId: string): Chainable<Column[]> {
-	return cy
-		.request({
-			url: `/api/team/${teamId}/columns`,
-			method: 'GET',
-		})
-		.then((response) => response.body as Column[]);
+	return cy.getCookie('token').then((cookie) => {
+		return cy
+			.request({
+				url: `/api/team/${teamId}/columns`,
+				method: 'GET',
+				headers: { Authorization: 'Bearer ' + cookie.value },
+			})
+			.then((response) => response.body as Column[]);
+	});
 }
 
 function addThoughtToTeam(
@@ -134,17 +137,20 @@ function addThoughtToTeam(
 	topic: ThoughtTopic,
 	columnId: number
 ) {
-	cy.request({
-		url: `/api/team/${teamId}/thought`,
-		failOnStatusCode: false,
-		method: 'POST',
-		body: {
-			message,
-			hearts,
-			discussed,
-			topic,
-			columnId,
-		},
+	cy.getCookie('token').then((cookie) => {
+		cy.request({
+			url: `/api/team/${teamId}/thought`,
+			failOnStatusCode: false,
+			method: 'POST',
+			headers: { Authorization: 'Bearer ' + cookie.value },
+			body: {
+				message,
+				hearts,
+				discussed,
+				topic,
+				columnId,
+			},
+		});
 	});
 }
 
@@ -153,23 +159,29 @@ function addCompletedActionItemToTeam(
 	task: string,
 	assignee: string
 ) {
-	cy.request({
-		url: `/api/team/${teamId}/action-item/`,
-		method: 'POST',
-		body: {
-			task,
-			completed: true,
-			assignee,
-			dateCreated: new Date(),
-			archived: true,
-		},
+	cy.getCookie('token').then((cookie) => {
+		cy.request({
+			url: `/api/team/${teamId}/action-item`,
+			method: 'POST',
+			headers: { Authorization: 'Bearer ' + cookie.value },
+			body: {
+				task,
+				completed: true,
+				assignee,
+				dateCreated: new Date(),
+				archived: true,
+			},
+		});
 	});
 }
 
 function archiveBoard(teamId: string) {
-	cy.request({
-		url: `/api/team/${teamId}/end-retro`,
-		method: 'PUT',
-		body: {},
+	cy.getCookie('token').then((cookie) => {
+		cy.request({
+			url: `/api/team/${teamId}/end-retro`,
+			method: 'PUT',
+			headers: { Authorization: 'Bearer ' + cookie.value },
+			body: {},
+		});
 	});
 }

--- a/ui/src/Services/Api/BoardService.spec.ts
+++ b/ui/src/Services/Api/BoardService.spec.ts
@@ -44,6 +44,7 @@ describe('Board Service', () => {
 			BoardService.archiveRetro(teamId);
 			expect(axios.put).toHaveBeenCalledWith(
 				`/api/team/${teamId}/end-retro`,
+				undefined,
 				mockConfig
 			);
 		});

--- a/ui/src/Services/Api/BoardService.ts
+++ b/ui/src/Services/Api/BoardService.ts
@@ -46,7 +46,7 @@ export enum SortOrder {
 const BoardService = {
 	archiveRetro(teamId: string): Promise<void> {
 		const url = `/api/team/${teamId}/end-retro`;
-		return axios.put(url, getAuthConfig());
+		return axios.put(url, undefined, getAuthConfig());
 	},
 
 	getBoards(

--- a/ui/src/Services/Api/TeamService.spec.ts
+++ b/ui/src/Services/Api/TeamService.spec.ts
@@ -134,6 +134,9 @@ describe('Team Service', () => {
 
 			expect(actualResponse).toBe(expectedCSVData);
 			expect(axios.get).toHaveBeenCalledWith(`/api/team/${teamId}/csv`, {
+				headers: {
+					Authorization: 'Bearer fake-token',
+				},
 				responseType: 'blob',
 				timeout: 30000,
 			});

--- a/ui/src/Services/Api/TeamService.ts
+++ b/ui/src/Services/Api/TeamService.ts
@@ -119,6 +119,7 @@ const TeamService = {
 		const url = getCSVApiPath(teamId);
 		return axios
 			.get(url, {
+				...getAuthConfig(),
 				responseType: 'blob',
 				timeout: 30000,
 			})

--- a/ui/src/Services/Api/ThoughtService.spec.ts
+++ b/ui/src/Services/Api/ThoughtService.spec.ts
@@ -88,6 +88,7 @@ describe('Thought Service', () => {
 			ThoughtService.upvoteThought(teamId, thoughtId);
 			expect(axios.put).toHaveBeenCalledWith(
 				`/api/team/${teamId}/thought/${thoughtId}/heart`,
+				undefined,
 				mockConfig
 			);
 		});

--- a/ui/src/Services/Api/ThoughtService.ts
+++ b/ui/src/Services/Api/ThoughtService.ts
@@ -16,9 +16,8 @@
  */
 
 import axios from 'axios';
-
-import CreateThoughtRequest from '../../Types/CreateThoughtRequest';
-import Thought from '../../Types/Thought';
+import CreateThoughtRequest from 'Types/CreateThoughtRequest';
+import Thought from 'Types/Thought';
 
 import { getThoughtApiPath } from './ApiConstants';
 import getAuthConfig from './getAuthConfig';
@@ -46,7 +45,7 @@ const ThoughtService = {
 
 	upvoteThought(teamId: string, thoughtId: number): Promise<void> {
 		const url = `${getThoughtApiPath(teamId)}/${thoughtId}/heart`;
-		return axios.put(url, getAuthConfig());
+		return axios.put(url, undefined, getAuthConfig());
 	},
 
 	updateDiscussionStatus(


### PR DESCRIPTION
## Overview
The app was unintentionally relying on both a JSESSIONID and a Jwt token for authentication. This caused the app to not be fully logged out when clicking the log out button as the JSESSIONID was still present.

### What was done:
- [x] This PR turns of Spring session creation so there is now no JSESSIONID being set.
- [x] There were some axios calls being made that the axios config was added in the position of `data` vs `config`. That got fixed so that all calls that need authorization are authorized by the jwt token being in the header authorization field.

## Testing Instructions
1) Ensure all api calls being made that require auth *do* have an authorization property in the header, and do *not* have a JSESSIONID cookie