### PR TITLE
Ensure there can be more than one valid email or password reset token at a time

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/email/EmailController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/email/EmailController.java
@@ -97,6 +97,7 @@ public class EmailController {
     public void requestTeamEmailReset(@RequestBody ResetRequest emailResetRequest){
         Team team = teamService.getTeamByName(emailResetRequest.getTeamName());
         if (team != null && teamService.isEmailOnTeam(team, emailResetRequest.getEmail())) {
+            emailResetTokenService.deleteAllExpiredTokensByTeam(team);
             EmailResetToken emailResetToken = emailResetTokenService.getNewEmailResetToken(team);
 
             emailService.sendUnencryptedEmail(

--- a/api/src/main/java/com/ford/labs/retroquest/email/EmailController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/email/EmailController.java
@@ -80,6 +80,7 @@ public class EmailController {
     public void requestTeamPasswordReset(@RequestBody ResetRequest passwordResetRequest){
         Team team = teamService.getTeamByName(passwordResetRequest.getTeamName());
         if(team != null && teamService.isEmailOnTeam(team, passwordResetRequest.getEmail())) {
+            passwordResetTokenService.deleteAllExpiredTokensByTeam(team);
             PasswordResetToken passwordResetToken = passwordResetTokenService.getNewPasswordResetToken(team);
 
             emailService.sendUnencryptedEmail(

--- a/api/src/main/java/com/ford/labs/retroquest/email_reset_token/EmailResetTokenController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/email_reset_token/EmailResetTokenController.java
@@ -43,7 +43,7 @@ public class EmailResetTokenController {
     @GetMapping("/lifetime-in-seconds")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     @Operation(description = "Get the number of seconds before an email reset token expires")
-    public ResponseEntity<Integer> getResetTokenValiditySeconds(@Value("${retroquest.password.reset.token-lifetime-seconds:600}") int tokenSeconds){
+    public ResponseEntity<Integer> getResetTokenValiditySeconds(@Value("${retroquest.email.reset.token-lifetime-seconds:600}") int tokenSeconds){
         return ResponseEntity.ok(tokenSeconds);
     }
 

--- a/api/src/main/java/com/ford/labs/retroquest/email_reset_token/EmailResetTokenRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/email_reset_token/EmailResetTokenRepository.java
@@ -22,13 +22,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Repository
 public interface EmailResetTokenRepository extends JpaRepository<EmailResetToken, String> {
     EmailResetToken findByTeam(Team team);
 
+    List<EmailResetToken> findAllByTeam(Team team);
+
     EmailResetToken findByResetToken(String resetToken);
 
     @Transactional
-    void deleteAllByTeam(Team team);
+    void deleteByResetToken(String resetToken);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/email_reset_token/EmailResetTokenService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/email_reset_token/EmailResetTokenService.java
@@ -19,6 +19,8 @@ package com.ford.labs.retroquest.email_reset_token;
 import com.ford.labs.retroquest.team.Team;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class EmailResetTokenService {
     private final EmailResetTokenRepository emailResetTokenRepository;
@@ -30,8 +32,16 @@ public class EmailResetTokenService {
     public EmailResetToken getNewEmailResetToken(Team team) {
         EmailResetToken emailResetToken = new EmailResetToken();
         emailResetToken.setTeam(team);
-        emailResetTokenRepository.deleteAllByTeam(team);
         emailResetTokenRepository.save(emailResetToken);
         return emailResetToken;
+    }
+
+    public void deleteAllExpiredTokensByTeam(Team team) {
+        List<EmailResetToken> resetTokens = emailResetTokenRepository.findAllByTeam(team);
+        resetTokens.forEach(token -> {
+            if (token.isExpired()) {
+                emailResetTokenRepository.deleteByResetToken(token.getResetToken());
+            }
+        });
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/password_reset_token/PasswordResetTokenRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/password_reset_token/PasswordResetTokenRepository.java
@@ -22,12 +22,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Repository
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, String> {
     PasswordResetToken findByTeam(Team team);
+    List<PasswordResetToken> findAllByTeam(Team team);
     PasswordResetToken findByResetToken(String resetToken);
 
     @Transactional
-    void deleteAllByTeam(Team team);
+    void deleteByResetToken(String resetToken);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/password_reset_token/PasswordResetTokenService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/password_reset_token/PasswordResetTokenService.java
@@ -19,6 +19,8 @@ package com.ford.labs.retroquest.password_reset_token;
 import com.ford.labs.retroquest.team.Team;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class PasswordResetTokenService {
     private final PasswordResetTokenRepository passwordResetTokenRepository;
@@ -30,8 +32,16 @@ public class PasswordResetTokenService {
     public PasswordResetToken getNewPasswordResetToken(Team team) {
         PasswordResetToken passwordResetToken = new PasswordResetToken();
         passwordResetToken.setTeam(team);
-        passwordResetTokenRepository.deleteAllByTeam(team);
         passwordResetTokenRepository.save(passwordResetToken);
         return passwordResetToken;
+    }
+
+    public void deleteAllExpiredTokensByTeam(Team team) {
+        List<PasswordResetToken> resetTokens = passwordResetTokenRepository.findAllByTeam(team);
+        resetTokens.forEach(token -> {
+            if (token.isExpired()) {
+                passwordResetTokenRepository.deleteByResetToken(token.getResetToken());
+            }
+        });
     }
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -23,6 +23,8 @@ retroquest:
   email:
     from-address: rq@fake.com
     is-enabled: true
+    reset:
+      token-lifetime-seconds: 600
   password:
     reset:
       token-lifetime-seconds: 600

--- a/api/src/test/java/com/ford/labs/retroquest/api/EmailApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/EmailApiTest.java
@@ -177,7 +177,26 @@ public class EmailApiTest extends ApiTestBase {
         mockMvc.perform(post(passwordResetRequestPath).contentType(APPLICATION_JSON).content(objectMapper.writeValueAsBytes(new ResetRequest("TeamName", "e@ma.il"))))
                 .andExpect(status().isOk());
 
-        assertThat(passwordResetTokenRepository.count()).isEqualTo(1);
+        assertThat(passwordResetTokenRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    void password_reset_request__should_send_a_second_password_reset_request_email_and_delete_all_expired_tokens_for_team() throws Exception {
+        Team expectedResetTeam = new Team("teamuri", "TeamName", "%$&357", "e@ma.il");
+        teamRepository.save(expectedResetTeam);
+
+        PasswordResetToken passwordResetToken = new PasswordResetToken();
+        passwordResetToken.setDateCreated(LocalDateTime.MIN);
+        passwordResetToken.setTeam(expectedResetTeam);
+        passwordResetTokenRepository.save(passwordResetToken);
+
+        mockMvc.perform(post(passwordResetRequestPath).contentType(APPLICATION_JSON).content(objectMapper.writeValueAsBytes(new ResetRequest("TeamName", "e@ma.il"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post(passwordResetRequestPath).contentType(APPLICATION_JSON).content(objectMapper.writeValueAsBytes(new ResetRequest("TeamName", "e@ma.il"))))
+                .andExpect(status().isOk());
+
+        assertThat(passwordResetTokenRepository.count()).isEqualTo(2);
     }
 
     @Test

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -23,6 +23,8 @@ retroquest:
   email:
     from-address: test@mail.com
     is-enabled: true
+    reset:
+      token-lifetime-seconds: 600
   password:
     reset:
       token-lifetime-seconds: 600


### PR DESCRIPTION
## Overview
Right now, when a user requests that a reset password or reset board owners email be sent, one is sent to both emails associated with a team. However, when a token is created, it deletes all other tokens for that team which causes the first email being sent to be sent an invalid reset token.

This PR ensure there can be more than one valid email or password reset token at a time. Now when a request is made to reset an email or password, only the expired tokens are removed from the db before creating a new one.

## Testing Instructions
1) Create a team with both a primary and secondary email.
2) Go to Settings>Account and click on the "Send Password Reset Link"
3) Ensure there are now two valid password reset tokens in the db.
4) Go to Settings>Account and click on the "Send Board Owner Update Link"
5) Ensure there are now two valid email reset tokens in the db.
6) After 10 minutes has passed, repeat steps 2-5 and ensure that the old tokens were deleted and two new tokens were created for both the password reset token repository and the email reset token repository