### PR TITLE
Add flag to turn off email

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/config/EnvironmentConfiguration.java
+++ b/api/src/main/java/com/ford/labs/retroquest/config/EnvironmentConfiguration.java
@@ -26,4 +26,7 @@ import org.springframework.stereotype.Component;
 public class EnvironmentConfiguration {
     @Value("${retroquest.email.from-address}")
     String email_from_address = "";
+
+    @Value("${retroquest.email.is-enabled}")
+    Boolean email_is_enabled;
 }

--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-retroquest:
-  email:
-    is-enabled: false
-
 spring:
   h2:
     console:

--- a/api/src/test/java/com/ford/labs/retroquest/api/ConfigurationApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/ConfigurationApiTest.java
@@ -42,6 +42,6 @@ public class ConfigurationApiTest {
                 .andReturn();
 
         assertThat(mvcResult.getResponse().getContentAsString())
-                .isEqualTo("{\"email_from_address\":\"test@mail.com\"}");
+                .isEqualTo("{\"email_from_address\":\"test@mail.com\",\"email_is_enabled\":true}");
     }
 }

--- a/ui/src/App/App.tsx
+++ b/ui/src/App/App.tsx
@@ -18,6 +18,7 @@
 import React, { useEffect } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import Modal from 'Common/Modal/Modal';
+import useEnvironmentConfig from 'Hooks/useEnvironmentConfig';
 import { useRecoilValue } from 'recoil';
 import { getThemeClassFromUserSettings, ThemeState } from 'State/ThemeState';
 
@@ -47,6 +48,8 @@ import './App.scss';
 
 function App() {
 	const theme = useRecoilValue(ThemeState);
+
+	useEnvironmentConfig();
 
 	useEffect(() => {
 		document.body.className = getThemeClassFromUserSettings();

--- a/ui/src/App/App.tsx
+++ b/ui/src/App/App.tsx
@@ -49,7 +49,8 @@ import './App.scss';
 function App() {
 	const theme = useRecoilValue(ThemeState);
 
-	useEnvironmentConfig();
+	const environmentConfig = useEnvironmentConfig();
+	const { email_is_enabled = true } = environmentConfig || {};
 
 	useEffect(() => {
 		document.body.className = getThemeClassFromUserSettings();
@@ -62,29 +63,42 @@ function App() {
 				<Route path="/login" element={<LoginPage />} />
 				<Route path="/login/:teamId" element={<LoginPage />} />
 				<Route path="/create" element={<CreateTeamPage />} />
-				<Route path="/email/reset" element={<ChangeTeamDetailsPage />} />
-				<Route path="/password/reset" element={<ResetPasswordPage />} />
-				<Route
-					path={EXPIRED_PASSWORD_RESET_LINK_PATH}
-					element={<ExpiredResetPasswordLinkPage />}
-				/>
-				<Route
-					path={EXPIRED_EMAIL_RESET_LINK_PATH}
-					element={<ExpiredResetBoardOwnersLinkPage />}
-				/>
-				<Route
-					path={PASSWORD_RESET_REQUEST_PATH}
-					element={<PasswordResetRequestPage />}
-				/>
-				<Route
-					path={RECOVER_TEAM_NAME_PATH}
-					element={<RecoverTeamNamePage />}
-				/>
 				<Route path="/team/:teamId" element={<TeamPages />}>
 					<Route path="" element={<RetroPage />} />
 					<Route path="archives" element={<ArchivesPage />} />
 					<Route path="radiator" element={<RadiatorPage />} />
 				</Route>
+				{email_is_enabled && (
+					<Route path="/email/reset" element={<ChangeTeamDetailsPage />} />
+				)}
+				{email_is_enabled && (
+					<Route path="/password/reset" element={<ResetPasswordPage />} />
+				)}
+				{email_is_enabled && (
+					<Route
+						path={EXPIRED_PASSWORD_RESET_LINK_PATH}
+						element={<ExpiredResetPasswordLinkPage />}
+					/>
+				)}
+				{email_is_enabled && (
+					<Route
+						path={EXPIRED_EMAIL_RESET_LINK_PATH}
+						element={<ExpiredResetBoardOwnersLinkPage />}
+					/>
+				)}
+				{email_is_enabled && (
+					<Route
+						path={PASSWORD_RESET_REQUEST_PATH}
+						element={<PasswordResetRequestPage />}
+					/>
+				)}
+				{email_is_enabled && (
+					<Route
+						path={RECOVER_TEAM_NAME_PATH}
+						element={<RecoverTeamNamePage />}
+					/>
+				)}
+				<Route path="*" element={<div>404</div>} />
 			</Routes>
 			<Modal />
 		</div>

--- a/ui/src/App/Login/LoginPage.tsx
+++ b/ui/src/App/Login/LoginPage.tsx
@@ -24,11 +24,13 @@ import InputTeamName from 'Common/InputTeamName/InputTeamName';
 import LinkSecondary from 'Common/LinkSecondary/LinkSecondary';
 import LinkTertiary from 'Common/LinkTertiary/LinkTertiary';
 import useAuth from 'Hooks/useAuth';
+import { useRecoilValue } from 'recoil';
 import {
 	CREATE_TEAM_PAGE_PATH,
 	PASSWORD_RESET_REQUEST_PATH,
 } from 'RouteConstants';
 import TeamService from 'Services/Api/TeamService';
+import { EnvironmentConfigState } from 'State/EnvironmentConfigState';
 
 import './LoginPage.scss';
 
@@ -36,6 +38,8 @@ function LoginPage(): JSX.Element {
 	const { teamId = '' } = useParams();
 
 	const { login } = useAuth();
+
+	const environmentConfig = useRecoilValue(EnvironmentConfigState);
 
 	const [teamName, setTeamName] = useState<string>('');
 	const [password, setPassword] = useState<string>('');
@@ -89,9 +93,11 @@ function LoginPage(): JSX.Element {
 					validateInput={false}
 				/>
 			</Form>
-			<LinkTertiary to={PASSWORD_RESET_REQUEST_PATH}>
-				Forgot your login info?
-			</LinkTertiary>
+			{environmentConfig?.email_is_enabled && (
+				<LinkTertiary to={PASSWORD_RESET_REQUEST_PATH}>
+					Forgot your login info?
+				</LinkTertiary>
+			)}
 			<HorizontalRuleWithText text="or" />
 			<LinkSecondary
 				to={CREATE_TEAM_PAGE_PATH}

--- a/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
+++ b/ui/src/App/PasswordResetRequest/PasswordResetRequestPage.tsx
@@ -14,23 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import Form from 'Common/AuthTemplate/Form/Form';
 import CheckYourMailConfirmationPage from 'Common/CheckYourMailConfirmationPage/CheckYourMailConfirmationPage';
 import InputEmail from 'Common/InputEmail/InputEmail';
 import InputTeamName from 'Common/InputTeamName/InputTeamName';
 import LinkTertiary from 'Common/LinkTertiary/LinkTertiary';
-import ConfigurationService from 'Services/Api/ConfigurationService';
+import useEnvironmentConfig from 'Hooks/useEnvironmentConfig';
 import EmailService from 'Services/Api/EmailService';
 
 function PasswordResetRequestPage(): JSX.Element {
-	const [emailFromAddress, setEmailFromAddress] = useState<string>('');
 	const [emailSent, setEmailSent] = useState<boolean>(false);
 	const [errorMessages, setErrorMessages] = useState<string[]>([]);
 
 	const [teamName, setTeamName] = useState<string>('');
 	const [email, setEmail] = useState<string>('');
+
+	const environmentConfig = useEnvironmentConfig();
 
 	function submitRequest() {
 		if (!!teamName && !!email) {
@@ -47,14 +48,6 @@ function PasswordResetRequestPage(): JSX.Element {
 	function disableSubmitButton(): boolean {
 		return !teamName || !email;
 	}
-
-	useEffect(() => {
-		if (!emailFromAddress) {
-			ConfigurationService.get().then((config) =>
-				setEmailFromAddress(config.email_from_address)
-			);
-		}
-	});
 
 	return (
 		<>
@@ -102,7 +95,7 @@ function PasswordResetRequestPage(): JSX.Element {
 			{emailSent && (
 				<CheckYourMailConfirmationPage
 					paragraph1={`We’ve sent an email to ${email} with password reset instructions.`}
-					paragraph2={`If an email doesn't show up soon, check your spam folder. We sent it from ${emailFromAddress}.`}
+					paragraph2={`If an email doesn't show up soon, check your spam folder. We sent it from ${environmentConfig?.email_from_address}.`}
 				/>
 			)}
 		</>

--- a/ui/src/App/RecoverTeamName/RecoverTeamNamePage.tsx
+++ b/ui/src/App/RecoverTeamName/RecoverTeamNamePage.tsx
@@ -15,20 +15,20 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import AuthTemplate from 'Common/AuthTemplate/AuthTemplate';
 import Form from 'Common/AuthTemplate/Form/Form';
 import CheckYourMailConfirmationPage from 'Common/CheckYourMailConfirmationPage/CheckYourMailConfirmationPage';
 import InputEmail from 'Common/InputEmail/InputEmail';
-import ConfigurationService from 'Services/Api/ConfigurationService';
-
-import EmailService from '../../Services/Api/EmailService';
+import useEnvironmentConfig from 'Hooks/useEnvironmentConfig';
+import EmailService from 'Services/Api/EmailService';
 
 function RecoverTeamNamePage() {
-	const [emailFromAddress, setEmailFromAddress] = useState<string>('');
 	const [recoveryEmail, setRecoveryEmail] = useState<string>('');
 	const [errorMessages, setErrorMessages] = useState<string[]>([]);
 	const [emailSent, setEmailSent] = useState<boolean>(false);
+
+	const environmentConfig = useEnvironmentConfig();
 
 	function onSubmit() {
 		EmailService.sendTeamNameRecoveryEmail(recoveryEmail)
@@ -37,14 +37,6 @@ function RecoverTeamNamePage() {
 				setErrorMessages([error.response?.data?.message]);
 			});
 	}
-
-	useEffect(() => {
-		if (!emailFromAddress) {
-			ConfigurationService.get().then((config) =>
-				setEmailFromAddress(config.email_from_address)
-			);
-		}
-	});
 
 	return (
 		<>
@@ -71,7 +63,7 @@ function RecoverTeamNamePage() {
 			{emailSent && (
 				<CheckYourMailConfirmationPage
 					paragraph1={`If any RetroQuest teams are registered to ${recoveryEmail}, we’ve sent a list of all team names that are connected to the email address.`}
-					paragraph2={`If an email doesn’t show up soon, check your spam folder. We sent it from ${emailFromAddress}.`}
+					paragraph2={`If an email doesn’t show up soon, check your spam folder. We sent it from ${environmentConfig?.email_from_address}.`}
 				/>
 			)}
 		</>

--- a/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/AccountTab/BoardOwnersForm/EmailSentConfirmation/EmailSentConfirmation.tsx
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import ButtonPrimary from 'Common/ButtonPrimary/ButtonPrimary';
 import ThemedCheckboxIcon from 'Common/ThemedCheckboxIcon/ThemedCheckboxIcon';
 import { useSetRecoilState } from 'recoil';
-import ConfigurationService from 'Services/Api/ConfigurationService';
 import { ModalContentsState } from 'State/ModalContentsState';
+
+import useEnvironmentConfig from '../../../../../../../Hooks/useEnvironmentConfig';
 
 import './EmailSentConfirmation.scss';
 
@@ -33,17 +34,9 @@ function EmailSentConfirmation(props: Props) {
 
 	const setModalContents = useSetRecoilState(ModalContentsState);
 
-	const [emailFromAddress, setEmailFromAddress] = useState<string>('');
+	const environmentConfig = useEnvironmentConfig();
 
 	const closeModal = () => setModalContents(null);
-
-	useEffect(() => {
-		if (!emailFromAddress) {
-			ConfigurationService.get().then((config) =>
-				setEmailFromAddress(config.email_from_address)
-			);
-		}
-	});
 
 	return (
 		<div className="email-sent-confirmation">
@@ -54,7 +47,7 @@ function EmailSentConfirmation(props: Props) {
 			</div>
 			<p className="paragraph-2">
 				If an email doesn’t show up soon, check your spam folder. We sent it
-				from {emailFromAddress}.
+				from {environmentConfig?.email_from_address}.
 			</p>
 			<ButtonPrimary onClick={closeModal}>Close</ButtonPrimary>
 		</div>

--- a/ui/src/App/Team/TeamHeader/Settings/Settings.spec.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/Settings.spec.tsx
@@ -17,13 +17,15 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MutableSnapshot } from 'recoil';
+import { EnvironmentConfigState } from 'State/EnvironmentConfigState';
 import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
 
 import Settings, { SettingsTabs } from './Settings';
 
 describe('Settings', () => {
 	it('should be on the styles tab by default', () => {
-		renderWithRecoilRoot(<Settings />);
+		renderWithRecoilRoot(<Settings />, getRecoilState());
 		expect(hasSelectedTabClass(getStylesTab())).toBeTruthy();
 		expect(screen.getByText('Appearance')).toBeInTheDocument();
 		expect(screen.queryByTestId('accountTab')).not.toBeInTheDocument();
@@ -31,7 +33,10 @@ describe('Settings', () => {
 	});
 
 	it('should start on a different tab if specified via prop', () => {
-		renderWithRecoilRoot(<Settings activeTab={SettingsTabs.ACCOUNT} />);
+		renderWithRecoilRoot(
+			<Settings activeTab={SettingsTabs.ACCOUNT} />,
+			getRecoilState()
+		);
 		expect(hasSelectedTabClass(getAccountTab())).toBeTruthy();
 		expect(screen.getByText('Add Board Owners')).toBeInTheDocument();
 	});
@@ -44,7 +49,8 @@ describe('Settings', () => {
 					email1: 'email1@mail.com',
 					email2: 'email2@mail.com',
 				}}
-			/>
+			/>,
+			getRecoilState()
 		);
 		expect(hasSelectedTabClass(getAccountTab())).toBeTruthy();
 		expect(screen.getByText('Add Board Owners')).toBeInTheDocument();
@@ -58,14 +64,14 @@ describe('Settings', () => {
 	});
 
 	it('should go to the account settings when user clicks on the account tab', () => {
-		renderWithRecoilRoot(<Settings />);
+		renderWithRecoilRoot(<Settings />, getRecoilState());
 		userEvent.click(getAccountTab());
 		expect(hasSelectedTabClass(getAccountTab())).toBeTruthy();
 		expect(screen.getByTestId('accountTab')).toBeInTheDocument();
 	});
 
 	it('should go to the styles settings when user clicks on the styles tab', () => {
-		renderWithRecoilRoot(<Settings />);
+		renderWithRecoilRoot(<Settings />, getRecoilState());
 		userEvent.click(getAccountTab());
 		const stylesTab = getStylesTab();
 		expect(hasSelectedTabClass(stylesTab)).toBeFalsy();
@@ -75,7 +81,7 @@ describe('Settings', () => {
 	});
 
 	it('should go to the info settings when user clicks on the info tab', () => {
-		renderWithRecoilRoot(<Settings />);
+		renderWithRecoilRoot(<Settings />, getRecoilState());
 		const infoTab = getInfoTab();
 		expect(hasSelectedTabClass(infoTab)).toBeFalsy();
 
@@ -84,7 +90,24 @@ describe('Settings', () => {
 		expect(hasSelectedTabClass(infoTab)).toBeTruthy();
 		expect(screen.getByText('Version:')).toBeInTheDocument();
 	});
+
+	it('should hide account tab if email is not enabled', () => {
+		renderWithRecoilRoot(<Settings />, getRecoilState(false));
+
+		expect(screen.queryByText('Account')).toBeNull();
+		expect(getStylesTab()).toBeInTheDocument();
+		expect(getInfoTab()).toBeInTheDocument();
+	});
 });
+
+function getRecoilState(emailEnabled = true) {
+	return ({ set }: MutableSnapshot) => {
+		set(EnvironmentConfigState, {
+			email_is_enabled: emailEnabled,
+			email_from_address: '',
+		});
+	};
+}
 
 function getStylesTab() {
 	return screen.getByText('Styles');

--- a/ui/src/App/Team/TeamHeader/Settings/Settings.tsx
+++ b/ui/src/App/Team/TeamHeader/Settings/Settings.tsx
@@ -17,6 +17,8 @@
 
 import React, { useState } from 'react';
 import classnames from 'classnames';
+import { useRecoilValue } from 'recoil';
+import { EnvironmentConfigState } from 'State/EnvironmentConfigState';
 
 import AccountTab from './AccountTab/AccountTab';
 import { AddBoardOwnersFormProps } from './AccountTab/AddBoardOwnersForm/AddBoardOwnersForm';
@@ -39,6 +41,8 @@ interface Props {
 export function Settings(props: Props) {
 	const { activeTab = SettingsTabs.STYLES, accountTabData } = props;
 
+	const environmentConfig = useRecoilValue(EnvironmentConfigState);
+
 	const [tab, setTab] = useState<SettingsTabs>(activeTab);
 
 	const stylesTabIsActive = () => tab === SettingsTabs.STYLES;
@@ -57,12 +61,14 @@ export function Settings(props: Props) {
 					>
 						Styles
 					</button>
-					<button
-						className={classnames('tab', { selected: accountTabIsActive() })}
-						onClick={() => setTab(SettingsTabs.ACCOUNT)}
-					>
-						Account
-					</button>
+					{environmentConfig?.email_is_enabled && (
+						<button
+							className={classnames('tab', { selected: accountTabIsActive() })}
+							onClick={() => setTab(SettingsTabs.ACCOUNT)}
+						>
+							Account
+						</button>
+					)}
 					<button
 						className={classnames('tab', { selected: infoTabIsActive() })}
 						onClick={() => setTab(SettingsTabs.INFO)}

--- a/ui/src/Hooks/useEnvironmentConfig.spec.tsx
+++ b/ui/src/Hooks/useEnvironmentConfig.spec.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ReactNode } from 'react';
+import { waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { RecoilRoot } from 'recoil';
+import ConfigurationService from 'Services/Api/ConfigurationService';
+
+import { mockEnvironmentConfig } from '../Services/Api/__mocks__/ConfigurationService';
+import { EnvironmentConfigState } from '../State/EnvironmentConfigState';
+import EnvironmentConfig from '../Types/EnvironmentConfig';
+import { RecoilObserver } from '../Utils/RecoilObserver';
+
+import useEnvironmentConfig from './useEnvironmentConfig';
+
+jest.mock('Services/Api/ConfigurationService');
+
+describe('Use Environment Config', () => {
+	let environmentConfig: EnvironmentConfig;
+
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<RecoilRoot>
+			<RecoilObserver
+				recoilState={EnvironmentConfigState}
+				onChange={(value: EnvironmentConfig) => {
+					environmentConfig = value;
+				}}
+			/>
+			{children}
+		</RecoilRoot>
+	);
+
+	it('should get environment config from the api and set global state', async () => {
+		const { result } = renderHook(() => useEnvironmentConfig(), {
+			wrapper: wrapper,
+		});
+		await waitFor(() => expect(ConfigurationService.get).toHaveBeenCalled());
+		expect(environmentConfig).toEqual(mockEnvironmentConfig);
+		expect(result.current).toEqual(mockEnvironmentConfig);
+	});
+});

--- a/ui/src/Hooks/useEnvironmentConfig.tsx
+++ b/ui/src/Hooks/useEnvironmentConfig.tsx
@@ -15,15 +15,24 @@
  * limitations under the License.
  */
 
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import ConfigurationService from 'Services/Api/ConfigurationService';
 import EnvironmentConfig from 'Types/EnvironmentConfig';
 
-export const mockEnvironmentConfig: EnvironmentConfig = {
-	email_from_address: 'mock_email_from_address@email.com',
-	email_is_enabled: true,
-};
+import { EnvironmentConfigState } from '../State/EnvironmentConfigState';
 
-const configurationService = {
-	get: jest.fn().mockResolvedValue(mockEnvironmentConfig),
-};
+function useEnvironmentConfig(): EnvironmentConfig | null {
+	const [environmentConfig, setEnvironmentConfig] = useRecoilState(
+		EnvironmentConfigState
+	);
 
-export default configurationService;
+	useEffect(() => {
+		if (!environmentConfig)
+			ConfigurationService.get().then(setEnvironmentConfig);
+	}, [environmentConfig, setEnvironmentConfig]);
+
+	return environmentConfig;
+}
+
+export default useEnvironmentConfig;

--- a/ui/src/State/EnvironmentConfigState.ts
+++ b/ui/src/State/EnvironmentConfigState.ts
@@ -15,15 +15,10 @@
  * limitations under the License.
  */
 
+import { atom } from 'recoil';
 import EnvironmentConfig from 'Types/EnvironmentConfig';
 
-export const mockEnvironmentConfig: EnvironmentConfig = {
-	email_from_address: 'mock_email_from_address@email.com',
-	email_is_enabled: true,
-};
-
-const configurationService = {
-	get: jest.fn().mockResolvedValue(mockEnvironmentConfig),
-};
-
-export default configurationService;
+export const EnvironmentConfigState = atom<EnvironmentConfig | null>({
+	key: 'EnvironmentConfigState',
+	default: null,
+});

--- a/ui/src/Types/EnvironmentConfig.ts
+++ b/ui/src/Types/EnvironmentConfig.ts
@@ -16,6 +16,7 @@
  */
 
 interface EnvironmentConfig {
+	email_is_enabled: boolean;
 	email_from_address: string;
 }
 


### PR DESCRIPTION
## Overview
Given that this repository is open source and may be used by people who do not want to or cannot set up an email server to support the password reset, email reset, and team name recovery capabilities, this PR adds a flag so that users can configure their app to not support email related features.

If email is not enabled, the following will happen:
- [x] The "Account" tab on Settings page will be hidden
- [x] The "Forgot your login info?" link on login page will be hidden
- [x] Pages related to resetting the team password, resetting team emails, and recovering team names associated with an email will be unavailable.


## Testing Instructions
