### PR TITLE
Notification banner

### DIFF
--- a/ui/cypress/e2e/retro-facilitator-journey.cy.ts
+++ b/ui/cypress/e2e/retro-facilitator-journey.cy.ts
@@ -339,6 +339,28 @@ describe('Retro Facilitator Journey', () => {
 			);
 			cy.findByText('Add Email').should('be.enabled');
 		});
+
+		it('Show password reset banner if team has no emails', () => {
+			createTeamWithNoEmailsAndLogin();
+
+			cy.findByTestId('banner').should(
+				'contain',
+				'You can now change your team’s RetroQuest password!'
+			);
+
+			cy.log(
+				'**Clicking "Set It Up Here" should open Settings>Account modal**'
+			);
+			cy.findByText('Set It Up Here').click();
+
+			cy.findByText('Add Board Owners').should('exist');
+			cy.log('**Close settings modal**');
+			cy.findByTestId('closeModalButton').click();
+
+			cy.log('**Clicking banner x should close modal**');
+			cy.findByTestId('closeBannerButton').click();
+			cy.findByTestId('banner').should('not.exist');
+		});
 	});
 
 	const ensureModalIsOpen = () => {

--- a/ui/src/App/Team/TeamHeader/Banner/Banner.scss
+++ b/ui/src/App/Team/TeamHeader/Banner/Banner.scss
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../../../../Styles/main';
+
+.banner {
+	display: none;
+	min-height: 2.875rem;
+
+	color: main.$off-white;
+
+	background-color: main.$black-asphalt;
+
+	position: relative;
+
+	.go-to-settings-button {
+		margin-left: 0.5rem;
+		padding: 0.188rem 1.25rem;
+
+		font-weight: 600;
+		font-size: 1.125rem;
+
+		background: main.$dark-gray;
+		border-radius: 2rem;
+	}
+
+	.close-banner-button {
+		position: absolute;
+		right: 5%;
+		top: 0.75rem;
+	}
+
+	@include main.breakpoint-medium {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}
+
+@include main.dark-theme {
+	.banner {
+		color: main.$black-asphalt;
+		background-color: main.$off-white;
+
+		.go-to-settings-button {
+			color: main.$asphalt;
+			background: rgba(main.$light-gray, 0.8);
+		}
+	}
+}

--- a/ui/src/App/Team/TeamHeader/Banner/Banner.tsx
+++ b/ui/src/App/Team/TeamHeader/Banner/Banner.tsx
@@ -15,16 +15,40 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { ModalContentsState } from 'State/ModalContentsState';
+
+import Settings, { SettingsTabs } from '../Settings/Settings';
 
 import './Banner.scss';
 
 function Banner() {
-	return (
+	const setModalContents = useSetRecoilState(ModalContentsState);
+
+	const [hideBanner, setHideBanner] = useState<boolean>(false);
+
+	function openSettingsModal() {
+		setModalContents({
+			title: 'Settings',
+			component: <Settings activeTab={SettingsTabs.ACCOUNT} />,
+		});
+	}
+
+	return hideBanner ? (
+		<></>
+	) : (
 		<div data-testid="banner" className="banner">
 			<span>You can now change your team’s RetroQuest password!</span>
-			<button className="go-to-settings-button">Set It Up Here</button>
-			<button aria-label="Close Banner" className="close-banner-button">
+			<button className="go-to-settings-button" onClick={openSettingsModal}>
+				Set It Up Here
+			</button>
+			<button
+				aria-label="Close Banner"
+				className="close-banner-button"
+				data-testid="closeBannerButton"
+				onClick={() => setHideBanner(true)}
+			>
 				<i className="fas fa-close close-icon" aria-hidden />
 			</button>
 		</div>

--- a/ui/src/App/Team/TeamHeader/Banner/Banner.tsx
+++ b/ui/src/App/Team/TeamHeader/Banner/Banner.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import './Banner.scss';
+
+function Banner() {
+	return (
+		<div data-testid="banner" className="banner">
+			<span>You can now change your team’s RetroQuest password!</span>
+			<button className="go-to-settings-button">Set It Up Here</button>
+			<button aria-label="Close Banner" className="close-banner-button">
+				<i className="fas fa-close close-icon" aria-hidden />
+			</button>
+		</div>
+	);
+}
+
+export default Banner;

--- a/ui/src/App/Team/TeamHeader/TeamHeader.tsx
+++ b/ui/src/App/Team/TeamHeader/TeamHeader.tsx
@@ -18,9 +18,11 @@
 import React from 'react';
 import Header from 'Common/Header/Header';
 import useTeamFromRoute from 'Hooks/useTeamFromRoute';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { EnvironmentConfigState } from 'State/EnvironmentConfigState';
 import { ModalContentsState } from 'State/ModalContentsState';
 
+import Banner from './Banner/Banner';
 import Settings from './Settings/Settings';
 import TeamHeaderNavLink from './TeamHeaderNavLink/TeamHeaderNavLink';
 
@@ -39,35 +41,45 @@ const LINKS: RqLink[] = [
 
 function TeamHeader() {
 	const team = useTeamFromRoute();
+	const environmentConfig = useRecoilValue(EnvironmentConfigState);
 	const setModalContents = useSetRecoilState(ModalContentsState);
 
+	function showBanner(): boolean {
+		const teamHasNoEmails = !team.email && !team.secondaryEmail;
+		const emailIsEnabled = environmentConfig?.email_is_enabled === true;
+		return emailIsEnabled && teamHasNoEmails;
+	}
+
 	return (
-		<Header name={team.name}>
-			<>
-				<nav className="center-content">
-					{LINKS.map((link) => (
-						<React.Fragment key={link.path}>
-							<TeamHeaderNavLink to={`/team/${team.id}${link.path}`}>
-								{link.label}
-							</TeamHeaderNavLink>
-						</React.Fragment>
-					))}
-				</nav>
-				<div className="right-content">
-					<button
-						className="settings-button fas fa-cog"
-						onClick={() =>
-							setModalContents({
-								title: 'Settings',
-								component: <Settings />,
-							})
-						}
-						aria-label="Settings"
-						data-testid="settingsButton"
-					/>
-				</div>
-			</>
-		</Header>
+		<>
+			{showBanner() && <Banner />}
+			<Header name={team.name}>
+				<>
+					<nav className="center-content">
+						{LINKS.map((link) => (
+							<React.Fragment key={link.path}>
+								<TeamHeaderNavLink to={`/team/${team.id}${link.path}`}>
+									{link.label}
+								</TeamHeaderNavLink>
+							</React.Fragment>
+						))}
+					</nav>
+					<div className="right-content">
+						<button
+							className="settings-button fas fa-cog"
+							onClick={() =>
+								setModalContents({
+									title: 'Settings',
+									component: <Settings />,
+								})
+							}
+							aria-label="Settings"
+							data-testid="settingsButton"
+						/>
+					</div>
+				</>
+			</Header>
+		</>
 	);
 }
 

--- a/ui/src/Common/Modal/Modal.tsx
+++ b/ui/src/Common/Modal/Modal.tsx
@@ -18,11 +18,7 @@
 import React, { useCallback, useEffect } from 'react';
 import { useA11yDialog } from 'react-a11y-dialog';
 import { useRecoilState } from 'recoil';
-
-import {
-	ModalContents,
-	ModalContentsState,
-} from '../../State/ModalContentsState';
+import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
 
 import './Modal.scss';
 
@@ -79,6 +75,7 @@ function Modal() {
 					{...attr.closeButton}
 					className="modal-close-button"
 					aria-label="Close Modal"
+					data-testid="closeModalButton"
 					onClick={clearModalContents}
 				>
 					<i className="fas fa-close close-icon" aria-hidden />


### PR DESCRIPTION
## Overview
Created a notification banner that shows up when email is enabled, and team has no email. This banner should encourage users to add an email to their team's account.

### Demo
<img width="1725" alt="Screen Shot 2022-10-25 at 10 34 52 AM" src="https://user-images.githubusercontent.com/17144844/197803191-ead7679e-e4db-42ca-a5fc-0aaa485de3f9.png">
<img width="1725" alt="Screen Shot 2022-10-25 at 10 34 42 AM" src="https://user-images.githubusercontent.com/17144844/197803199-fe06cf1b-3247-44da-a6b3-094d03a5483b.png">

## Testing Instructions
1) Ensure the above banner shows up when email is enabled, and a team has no emails.
2) Clicking the "set it up here" button should open the Settings>Account modal
3) Clicking the x should close the banner until the user refreshes the page.