### PR TITLE
Redirect to the expired password reset link page if form errors on submission

### DIFF
--- a/ui/src/App/ResetPassword/ResetPasswordPage.spec.tsx
+++ b/ui/src/App/ResetPassword/ResetPasswordPage.spec.tsx
@@ -153,6 +153,18 @@ describe('Reset Password Page', () => {
 		renderWithToken('ABC321');
 		expect(screen.queryByText(confirmationMessage)).not.toBeInTheDocument();
 	});
+
+	it('should redirect to Expired Reset Password Link Page if token is expired upon form submission', async () => {
+		TeamService.setPasswordWithResetToken = jest.fn().mockRejectedValue(null);
+
+		renderWithToken('expired-token');
+		submitValidForm();
+		await waitFor(() =>
+			expect(mockedUsedNavigate).toHaveBeenCalledWith(
+				'/password/reset/expired-link'
+			)
+		);
+	});
 });
 
 function submitValidForm(password: string = 'P@ssw0rd') {

--- a/ui/src/App/ResetPassword/ResetPasswordPage.tsx
+++ b/ui/src/App/ResetPassword/ResetPasswordPage.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Form from 'Common/AuthTemplate/Form/Form';
 import Header from 'Common/Header/Header';
@@ -42,22 +42,25 @@ function ResetPasswordPage(): JSX.Element {
 	const [isFormSubmitted, setIsFormSubmitted] = useState(false);
 	const [isValidForm, setIsValidForm] = useState<boolean>(false);
 
+	const goToExpiredLinkPage = useCallback(() => {
+		navigate(EXPIRED_PASSWORD_RESET_LINK_PATH);
+	}, [navigate]);
+
 	function submitNewPassword() {
 		if (newPassword) {
-			TeamService.setPasswordWithResetToken(
-				newPassword,
-				passwordResetToken
-			).then(() => setIsFormSubmitted(true));
+			TeamService.setPasswordWithResetToken(newPassword, passwordResetToken)
+				.then(() => setIsFormSubmitted(true))
+				.catch(goToExpiredLinkPage);
 		}
 	}
 
 	useEffect(() => {
 		PasswordResetTokenService.checkIfResetTokenIsValid(passwordResetToken).then(
 			(isValidToken) => {
-				if (!isValidToken) navigate(EXPIRED_PASSWORD_RESET_LINK_PATH);
+				if (!isValidToken) goToExpiredLinkPage();
 			}
 		);
-	}, [navigate, passwordResetToken]);
+	}, [goToExpiredLinkPage, passwordResetToken]);
 
 	return (
 		<div className="reset-password-page">


### PR DESCRIPTION
## Overview
If a user requests to change their password, gets the email, clicks on the link, then does not submit the form until after the reset token is expired, upon submission they will be redirected to the expired reset token link page

## Testing Instructions
1) Go to `/password/reset?token={{valid token}}`. Ensure its a valid token or you will be redirected right off the bat.
2) Wait 12 minutes until the token has expired. 
3) Type in a new password and submit. Ensure you get redirected to the expired token page.