### PR TITLE
Add the ability to delete one archived action item at a time

### DIFF
--- a/ui/cypress/e2e/archivist-journey.cy.ts
+++ b/ui/cypress/e2e/archivist-journey.cy.ts
@@ -77,6 +77,21 @@ describe('Archivist Journey', () => {
 		cy.findByText('Action Items').click();
 		cy.findByText('Action Item Archives').should('exist');
 		cy.findAllByText('action to take').should('have.length', 3);
+
+		cy.get('[data-testid=deleteButton]').should('have.length', 3).eq(0).click();
+
+		cy.contains('Delete Action Item?').should('exist');
+
+		cy.intercept(
+			'GET',
+			`/api/team/${teamCredentials.teamId}/action-item?archived=true`
+		).as('getActionItems');
+
+		cy.findByText('Yes, Delete').click();
+
+		cy.wait('@getActionItems');
+
+		cy.get('[data-testid=deleteButton]').should('have.length', 2);
 	});
 
 	it('Download CSV Button', () => {

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.scss
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.scss
@@ -38,7 +38,9 @@
 		margin-top: 0.5rem;
 		margin-bottom: 2rem;
 
-		color: main.$gray-3;
+		color: main.$dark-gray;
+
+		font-weight: 600;
 		font-size: 1.1rem;
 	}
 
@@ -63,5 +65,9 @@
 @include main.dark-theme {
 	.action-item-archives-title {
 		color: main.$off-white;
+	}
+
+	.action-item-archives-description {
+		color: main.$light-gray;
 	}
 }

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
+import ArchivedActionItem from 'Common/ArchivedActionItem/ArchivedActionItem';
+import NotFoundSection from 'Common/NotFoundSection/NotFoundSection';
 import { useRecoilState, useRecoilValue } from 'recoil';
-
-import ActionItemDisplayOnly from '../../../../Common/ActionItemDisplayOnly/ActionItemDisplayOnly';
-import NotFoundSection from '../../../../Common/NotFoundSection/NotFoundSection';
-import ActionItemService from '../../../../Services/Api/ActionItemService';
-import { ActionItemState } from '../../../../State/ActionItemState';
-import { TeamState } from '../../../../State/TeamState';
+import ActionItemService from 'Services/Api/ActionItemService';
+import { ActionItemState } from 'State/ActionItemState';
+import { TeamState } from 'State/TeamState';
 
 import './ActionItemArchives.scss';
 
@@ -30,15 +29,15 @@ function ActionItemArchives() {
 	const team = useRecoilValue(TeamState);
 	const [actionItems, setActionItems] = useRecoilState(ActionItemState);
 
-	useEffect(() => {
-		if (team.id) {
-			ActionItemService.get(team.id, true)
-				.then((items) => {
-					setActionItems(items);
-				})
-				.catch(console.error);
-		}
+	const getActionItems = useCallback(() => {
+		ActionItemService.get(team.id, true)
+			.then(setActionItems)
+			.catch(console.error);
 	}, [setActionItems, team.id]);
+
+	useEffect(() => {
+		if (team.id) getActionItems();
+	}, [getActionItems, team.id]);
 
 	return (
 		<div className="action-item-archives">
@@ -52,7 +51,10 @@ function ActionItemArchives() {
 						{actionItems.map((actionItem, index) => {
 							return (
 								<li key={`archived-action-${index}`}>
-									<ActionItemDisplayOnly actionItem={actionItem} />
+									<ArchivedActionItem
+										actionItem={actionItem}
+										onActionItemDeletion={getActionItems}
+									/>
 								</li>
 							);
 						})}

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
@@ -45,7 +45,8 @@ function ActionItemArchives() {
 				<>
 					<h1 className="action-item-archives-title">Action Item Archives</h1>
 					<p className="action-item-archives-description">
-						Examine completed action items from times gone by
+						Examine completed action items from your team’s previous
+						retrospectives
 					</p>
 					<ul className="archived-action-items">
 						{actionItems.map((actionItem, index) => {

--- a/ui/src/App/Team/Archives/ActionItemArchives/DeleteActionItemConfirmation/DeleteActionItemConfirmation.spec.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/DeleteActionItemConfirmation/DeleteActionItemConfirmation.spec.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RecoilRoot } from 'recoil';
+import { mockTeam } from 'Services/Api/__mocks__/TeamService';
+import ActionItemService from 'Services/Api/ActionItemService';
+import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
+import { TeamState } from 'State/TeamState';
+import { RecoilObserver } from 'Utils/RecoilObserver';
+
+import DeleteActionItemConfirmation from './DeleteActionItemConfirmation';
+
+jest.mock('Services/Api/ActionItemService');
+
+describe('Delete Action Item Confirmation', () => {
+	let modalContent: ModalContents | null;
+	let onActionItemDeletion: jest.Mock<any, any>;
+	const actionItemId: number = 8432;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		modalContent = null;
+		onActionItemDeletion = jest.fn();
+
+		render(
+			<RecoilRoot
+				initializeState={({ set }) => {
+					set(TeamState, mockTeam);
+					set(ModalContentsState, {
+						title: 'Title',
+						component: <>component</>,
+					});
+				}}
+			>
+				<RecoilObserver
+					recoilState={ModalContentsState}
+					onChange={(value: ModalContents) => {
+						modalContent = value;
+					}}
+				/>
+				<DeleteActionItemConfirmation
+					actionItemId={actionItemId}
+					onActionItemDeletion={onActionItemDeletion}
+				/>
+			</RecoilRoot>
+		);
+	});
+
+	it('should ask user if they want to delete an archived action item', () => {
+		expect(screen.getByText('Delete Action Item?')).toBeInTheDocument();
+	});
+
+	it('should delete action item and close modal', async () => {
+		userEvent.click(screen.getByText('Yes, Delete'));
+
+		await waitFor(() =>
+			expect(ActionItemService.delete).toHaveBeenCalledWith(
+				mockTeam.id,
+				actionItemId
+			)
+		);
+		expect(onActionItemDeletion).toHaveBeenCalled();
+		expect(modalContent).toBe(null);
+	});
+
+	it('should cancel deleting of an action item', () => {
+		userEvent.click(screen.getByText('Cancel'));
+
+		expect(ActionItemService.delete).not.toHaveBeenCalled();
+		expect(onActionItemDeletion).not.toHaveBeenCalled();
+		expect(modalContent).toBe(null);
+	});
+});

--- a/ui/src/App/Team/Archives/ActionItemArchives/DeleteActionItemConfirmation/DeleteActionItemConfirmation.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/DeleteActionItemConfirmation/DeleteActionItemConfirmation.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import ConfirmationModal from 'Common/ConfirmationModal/ConfirmationModal';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import ActionItemService from 'Services/Api/ActionItemService';
+import { ModalContentsState } from 'State/ModalContentsState';
+import { TeamState } from 'State/TeamState';
+
+interface Props {
+	actionItemId: number;
+	onActionItemDeletion(): void;
+}
+
+function DeleteActionItemConfirmation(props: Props) {
+	const { actionItemId, onActionItemDeletion } = props;
+
+	const team = useRecoilValue(TeamState);
+	const setModalContents = useSetRecoilState(ModalContentsState);
+
+	const closeModal = () => setModalContents(null);
+
+	const onSubmit = () => {
+		ActionItemService.delete(team.id, actionItemId)
+			.then(() => {
+				onActionItemDeletion();
+				closeModal();
+			})
+			.catch(console.error);
+	};
+
+	return (
+		<ConfirmationModal
+			testId="deleteActionItemConfirmation"
+			title="Delete Action Item?"
+			subtitle="Are you sure you want to delete this archived action item? Doing so will permanently remove this data."
+			onSubmit={onSubmit}
+			onCancel={closeModal}
+			cancelButtonText="Cancel"
+			submitButtonText="Yes, Delete"
+		/>
+	);
+}
+
+export default DeleteActionItemConfirmation;

--- a/ui/src/App/Team/Radiator/RadiatorPage.spec.tsx
+++ b/ui/src/App/Team/Radiator/RadiatorPage.spec.tsx
@@ -91,7 +91,7 @@ describe('Radiator Page', () => {
 		);
 
 		const dateCreatedField = screen.getByTestId('dateCreated');
-		expect(dateCreatedField).toHaveClass('readOnly');
+		expect(dateCreatedField).toHaveClass('read-only');
 		expect(
 			screen.getAllByTestId('assigneeInput')[0].getAttribute('readOnly')
 		).not.toBeNull();

--- a/ui/src/Common/ArchivedActionItem/ArchivedActionItem.scss
+++ b/ui/src/Common/ArchivedActionItem/ArchivedActionItem.scss
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../../Styles/main';
+
+.archived-action-item {
+	width: 100%;
+
+	font-weight: bold;
+	font-size: 1rem;
+	text-align: left;
+
+	background-color: main.$white;
+	border-radius: 6px;
+	box-shadow: 0 1px 2px rgba(main.$black, 0.25);
+
+	.archived-action-item-task {
+		padding: 18px;
+	}
+
+	.archived-action-item-bottom {
+		display: flex;
+	}
+
+	.date-created {
+		flex: 50% 1;
+	}
+}
+
+@include main.dark-theme {
+	.archived-action-item {
+		color: main.$off-white;
+
+		background-color: main.$light-asphalt;
+		box-shadow: 0 1px 2px rgba(main.$black, 0.35);
+	}
+}

--- a/ui/src/Common/ArchivedActionItem/ArchivedActionItem.spec.tsx
+++ b/ui/src/Common/ArchivedActionItem/ArchivedActionItem.spec.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import DeleteActionItemConfirmation from 'App/Team/Archives/ActionItemArchives/DeleteActionItemConfirmation/DeleteActionItemConfirmation';
+import { getMockActionItem } from 'Services/Api/__mocks__/ActionItemService';
+import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
+import { TeamState } from 'State/TeamState';
+import Team from 'Types/Team';
+import { RecoilObserver } from 'Utils/RecoilObserver';
+import renderWithRecoilRoot from 'Utils/renderWithRecoilRoot';
+
+import ArchivedActionItem from './ArchivedActionItem';
+
+jest.mock('Services/Api/ActionItemService');
+
+describe('Archived Action Item', () => {
+	let modalContent: ModalContents | null;
+
+	const team: Team = {
+		id: 'team-name',
+		name: 'Team Name',
+		email: 'a@b.c',
+		secondaryEmail: '',
+	};
+	const actionItem = getMockActionItem();
+
+	it('should delete action item', async () => {
+		const onActionItemDeletion = jest.fn();
+		renderWithRecoilRoot(
+			<>
+				<RecoilObserver
+					recoilState={ModalContentsState}
+					onChange={(value: ModalContents) => {
+						modalContent = value;
+					}}
+				/>
+				<ArchivedActionItem
+					actionItem={actionItem}
+					onActionItemDeletion={onActionItemDeletion}
+				/>
+			</>,
+			({ set }) => {
+				set(TeamState, team);
+			}
+		);
+		screen.getByText('Delete').click();
+
+		await waitFor(() =>
+			expect(modalContent).toEqual({
+				title: 'Delete Action Item?',
+				component: (
+					<DeleteActionItemConfirmation
+						actionItemId={actionItem.id}
+						onActionItemDeletion={onActionItemDeletion}
+					/>
+				),
+			})
+		);
+	});
+});

--- a/ui/src/Common/ArchivedActionItem/ArchivedActionItem.tsx
+++ b/ui/src/Common/ArchivedActionItem/ArchivedActionItem.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import DeleteActionItemConfirmation from 'App/Team/Archives/ActionItemArchives/DeleteActionItemConfirmation/DeleteActionItemConfirmation';
+import { useSetRecoilState } from 'recoil';
+import { ModalContentsState } from 'State/ModalContentsState';
+import Action from 'Types/Action';
+
+import AssigneeInput from '../AssigneeInput/AssigneeInput';
+import { ColumnItemButtonGroup, DeleteButton } from '../ColumnItemButtons';
+import { DateCreated } from '../DateCreated/DateCreated';
+
+import './ArchivedActionItem.scss';
+
+interface Props {
+	actionItem: Action;
+	onActionItemDeletion(): void;
+}
+
+function ArchivedActionItem(props: Props) {
+	const { actionItem, onActionItemDeletion } = props;
+
+	const setModalContents = useSetRecoilState(ModalContentsState);
+
+	function deleteActionItem() {
+		setModalContents({
+			title: 'Delete Action Item?',
+			component: (
+				<DeleteActionItemConfirmation
+					actionItemId={actionItem.id}
+					onActionItemDeletion={onActionItemDeletion}
+				/>
+			),
+		});
+	}
+
+	return (
+		<div className="archived-action-item">
+			<div className="archived-action-item-task">{actionItem.task}</div>
+			<div className="archived-action-item-bottom">
+				<AssigneeInput assignee={actionItem.assignee} readOnly />
+			</div>
+			<ColumnItemButtonGroup>
+				<DateCreated date={actionItem.dateCreated} readOnly />
+				<DeleteButton aria-label="Delete" onClick={deleteActionItem} />
+				{/*<CheckboxButton*/}
+				{/*	aria-label="Mark as complete"*/}
+				{/*	checked={actionItem.completed}*/}
+				{/*	onClick={() => {}}*/}
+				{/*/>*/}
+			</ColumnItemButtonGroup>
+		</div>
+	);
+}
+
+export default ArchivedActionItem;

--- a/ui/src/Common/ColumnItemButtons/ColumnItemButtonGroup/ColumnItemButtonGroup.scss
+++ b/ui/src/Common/ColumnItemButtons/ColumnItemButtonGroup/ColumnItemButtonGroup.scss
@@ -72,6 +72,11 @@ $opacity: 0.25;
 			}
 		}
 
+		&.read-only {
+			cursor: initial;
+			pointer-events: unset;
+		}
+
 		&.confirm,
 		&.cancel {
 			font-size: 1rem;

--- a/ui/src/Common/DateCreated/DateCreated.spec.tsx
+++ b/ui/src/Common/DateCreated/DateCreated.spec.tsx
@@ -42,7 +42,7 @@ describe('Date Created', () => {
 	it('should be read only', () => {
 		rerender(<DateCreated date={date} readOnly={true} />);
 		const dateInput = getDateCreated();
-		expect(dateInput).toHaveClass('readOnly');
+		expect(dateInput).toHaveClass('read-only');
 	});
 });
 

--- a/ui/src/Common/DateCreated/DateCreated.tsx
+++ b/ui/src/Common/DateCreated/DateCreated.tsx
@@ -35,7 +35,7 @@ export function DateCreated(props: DateCreatedProps) {
 		<div
 			className={classnames('column-item-button date-created', className, {
 				disabled,
-				readOnly,
+				'read-only': readOnly,
 			})}
 			data-testid="dateCreated"
 		>


### PR DESCRIPTION
## What was done
- [x] Add the ability to delete one archived action item at a time by adding a delete button to each archived action item.

### Demo
<img width="771" alt="Screen Shot 2022-10-31 at 2 52 35 PM" src="https://user-images.githubusercontent.com/17144844/199086990-0bdc3142-7a12-4912-a4a8-d559327f5d42.png">

## Testing Instructions
1) Go to Archives>Action Item Archives (if no archived action items there, create some action items, mark them as completed, then archive the board)
2) Click on the delete button on one of the created action items. Ensure a confirmation modal pops up.
3) Click cancel and ensure nothing happens.
4) Click the delete button again and this time click "Yes, Delete". Ensure that the archived action item gets deleted by ensuring the action item is no longer on the page.