### PR TITLE
Delete multiple archived action items

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemController.java
@@ -126,6 +126,15 @@ public class ActionItemController {
     @Operation(summary = "Deletes an action item given a team id and action item id", description = "deleteActionItem")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
     public void deleteActionItemByTeamIdAndId(@PathVariable("teamId") String teamId, @PathVariable("actionItemId") Long actionItemId) {
-        actionItemService.deleteActionItem(teamId, actionItemId);
+        actionItemService.deleteOneActionItem(teamId, actionItemId);
+    }
+
+    @Transactional
+    @DeleteMapping("/api/team/{teamId}/action-item")
+    @PreAuthorize("@teamAuthorization.requestIsAuthorized(authentication, #teamId)")
+    @Operation(description = "Deletes multiple action items given a team id and action item ids")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK")})
+    public void deleteActionItemsByTeamIdAndIds(@PathVariable("teamId") String teamId, @RequestBody() DeleteActionItemsRequest request) {
+        actionItemService.deleteMultipleActionItems(teamId, request.actionItemIds());
     }
 }

--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemRepository.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemRepository.java
@@ -20,6 +20,7 @@ package com.ford.labs.retroquest.actionitem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,5 +31,9 @@ public interface ActionItemRepository extends JpaRepository<ActionItem, Long>{
     List<ActionItem> findAllByTeamIdAndArchived(String teamId, boolean archived);
     List<ActionItem> findAllByTeamIdAndArchivedIsFalseAndCompletedIsTrue(String teamId);
 
+    @Transactional
     void deleteActionItemByTeamIdAndId(String teamId, Long id);
+
+    @Transactional
+    void deleteActionItemByTeamIdAndIdIn(String teamId, List<Long> ids);
 }

--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemService.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/ActionItemService.java
@@ -51,12 +51,11 @@ public class ActionItemService {
         else return actionItemRepository.findAllByTeamId(teamId);
     }
 
-    public ActionItem updateCompletedStatus(String teamId, Long actionItemId, UpdateActionItemCompletedRequest request) {
+    public void updateCompletedStatus(String teamId, Long actionItemId, UpdateActionItemCompletedRequest request) {
         var savedActionItem = fetchActionItem(teamId, actionItemId);
         savedActionItem.setCompleted(request.completed());
         var updatedActionItem = actionItemRepository.save(savedActionItem);
         websocketService.publishEvent(new WebsocketActionItemEvent(teamId, UPDATE, updatedActionItem));
-        return updatedActionItem;
     }
 
     public ActionItem updateTask(String teamId, Long actionItemId, UpdateActionItemTaskRequest request) {
@@ -75,17 +74,20 @@ public class ActionItemService {
         return updatedActionItem;
     }
 
-    public ActionItem updateArchivedStatus(String teamId, Long actionItemId, UpdateActionItemArchivedRequest request) {
+    public void updateArchivedStatus(String teamId, Long actionItemId, UpdateActionItemArchivedRequest request) {
         var savedActionItem = fetchActionItem(teamId, actionItemId);
         savedActionItem.setArchived(request.archived());
         var updatedActionItem = actionItemRepository.save(savedActionItem);
         websocketService.publishEvent(new WebsocketActionItemEvent(teamId, UPDATE, updatedActionItem));
-        return updatedActionItem;
     }
 
-    public void deleteActionItem(String teamId, Long actionItemId) {
+    public void deleteOneActionItem(String teamId, Long actionItemId) {
         actionItemRepository.deleteActionItemByTeamIdAndId(teamId, actionItemId);
         websocketService.publishEvent(new WebsocketActionItemEvent(teamId, DELETE, ActionItem.builder().id(actionItemId).build()));
+    }
+
+    public void deleteMultipleActionItems(String teamId, List<Long> actionItemIds) {
+        actionItemRepository.deleteActionItemByTeamIdAndIdIn(teamId, actionItemIds);
     }
 
     public void archiveCompletedActionItems(String teamId) {

--- a/api/src/main/java/com/ford/labs/retroquest/actionitem/DeleteActionItemsRequest.java
+++ b/api/src/main/java/com/ford/labs/retroquest/actionitem/DeleteActionItemsRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ford.labs.retroquest.actionitem;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DeleteActionItemsRequest(List<Long> actionItemIds) { }

--- a/ui/cypress/e2e/archivist-journey.cy.ts
+++ b/ui/cypress/e2e/archivist-journey.cy.ts
@@ -76,9 +76,11 @@ describe('Archivist Journey', () => {
 
 		cy.findByText('Action Items').click();
 		cy.findByText('Action Item Archives').should('exist');
-		cy.findAllByText('action to take').should('have.length', 3);
+		cy.findAllByText('action to take').should('have.length', 6);
 
-		cy.get('[data-testid=deleteButton]').should('have.length', 3).eq(0).click();
+		cy.log('**Delete a single action item at a time**');
+
+		cy.get('[data-testid=deleteButton]').eq(0).click();
 
 		cy.contains('Delete Action Item?').should('exist');
 
@@ -90,6 +92,37 @@ describe('Archivist Journey', () => {
 		cy.findByText('Yes, Delete').click();
 
 		cy.wait('@getActionItems');
+
+		cy.get('[data-testid=deleteButton]').should('have.length', 5);
+
+		cy.log('**Delete multiple action items at a time**');
+
+		cy.findAllByTestId('checkboxButton').as('checkboxes');
+
+		cy.get('@checkboxes').each(($el, index) => {
+			cy.get('@checkboxes')
+				.eq(index)
+				.should('have.attr', 'data-checked', 'false');
+		});
+
+		cy.get('@checkboxes')
+			.eq(0)
+			.click()
+			.should('have.attr', 'data-checked', 'true');
+		cy.get('@checkboxes')
+			.eq(1)
+			.click()
+			.should('have.attr', 'data-checked', 'true');
+		cy.get('@checkboxes')
+			.eq(3)
+			.click()
+			.should('have.attr', 'data-checked', 'true');
+
+		cy.findByText('Delete Selected').click();
+
+		cy.contains('Delete Selected Items?').should('exist');
+
+		cy.findByText('Yes, Delete').click();
 
 		cy.get('[data-testid=deleteButton]').should('have.length', 2);
 	});
@@ -236,6 +269,7 @@ function createAndArchiveBoard(
 				columns[2].id
 			);
 	});
+	addCompletedActionItemToTeam(teamCredentials.teamId, 'action to take', 'me');
 	addCompletedActionItemToTeam(teamCredentials.teamId, 'action to take', 'me');
 	archiveBoard(teamCredentials.teamId);
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,7 +13,7 @@
         "@fontsource/quicksand": "^4.4.5",
         "@fortawesome/fontawesome-free": "^6.0.0",
         "@stomp/stompjs": "^6.1.2",
-        "axios": "^0.26.0",
+        "axios": "^1.1.3",
         "classnames": "^2.3.1",
         "file-saver": "^2.0.5",
         "hammerjs": "^2.0.8",
@@ -5021,8 +5021,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -5103,12 +5102,32 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/axobject-query": {
       "version": "2.2.0",
@@ -6173,7 +6192,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -7137,7 +7155,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -12592,7 +12609,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12601,7 +12617,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -23319,8 +23334,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -23367,11 +23381,30 @@
       "dev": true
     },
     "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
       "requires": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "proxy-from-env": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        }
       }
     },
     "axobject-query": {
@@ -24175,7 +24208,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -24897,8 +24929,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -28988,14 +29019,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -47,7 +47,7 @@
     "@fontsource/quicksand": "^4.4.5",
     "@fortawesome/fontawesome-free": "^6.0.0",
     "@stomp/stompjs": "^6.1.2",
-    "axios": "^0.26.0",
+    "axios": "^1.1.3",
     "classnames": "^2.3.1",
     "file-saver": "^2.0.5",
     "hammerjs": "^2.0.8",

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.scss
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.scss
@@ -35,7 +35,7 @@
 	.actions-container {
 		display: flex;
 		gap: 1rem;
-		align-items: start;
+		align-items: flex-start;
 		margin: 1.5rem 0;
 	}
 

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.scss
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.scss
@@ -26,65 +26,79 @@
 	@include main.breakpoint-large {
 		text-align: left;
 	}
+}
 
-	.action-item-archives-header {
+.action-item-archives-header {
+	display: flex;
+	justify-content: space-between;
+
+	.actions-container {
 		display: flex;
+		gap: 1rem;
+		align-items: start;
+		margin: 1.5rem 0;
+	}
+
+	.delete-selected-button {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
 		justify-content: space-between;
+		box-sizing: border-box;
+		width: 4.5rem;
+		margin-top: 0.5rem;
 
-		.actions-container {
-			display: flex;
-			gap: 1rem;
-			align-items: start;
-			margin: 1.5rem 0;
+		color: main.$red;
+
+		&:focus,
+		&:hover {
+			color: main.$dark-red;
 		}
 
-		.delete-selected-button {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			justify-content: space-between;
-			box-sizing: border-box;
-			width: 4.5rem;
-			height: 4rem;
-			margin-top: 0.5rem;
-
-			color: main.$red;
+		.delete-selected-text {
 			font-weight: 600;
+			font-size: 0.625rem;
+			line-height: 0.75rem;
 		}
 
-		.action-item-archives-title {
-			margin-bottom: 0;
-
-			font-weight: 600;
-			font-size: 1.5rem;
-		}
-
-		.action-item-archives-description {
-			margin-top: 0.5rem;
-			margin-bottom: 2rem;
-
-			color: main.$dark-gray;
-
-			font-weight: 600;
-			font-size: 1.1rem;
+		.trashcan-icon {
+			width: 1.25rem;
+			height: 1.25rem;
 		}
 	}
 
-	.archived-action-items {
-		display: grid;
-		grid-gap: 2rem;
-		grid-template-columns: repeat(auto-fill, 80%);
-		justify-content: center;
+	.action-item-archives-title {
+		margin-bottom: 0;
 
-		@include main.breakpoint-medium {
-			grid-template-columns: repeat(auto-fill, 350px);
-		}
+		font-weight: 600;
+		font-size: 1.5rem;
+	}
 
-		@include main.breakpoint-large {
-			grid-gap: 3rem;
-			grid-template-columns: repeat(auto-fill, 350px);
-			justify-content: left;
-		}
+	.action-item-archives-description {
+		margin-top: 0.5rem;
+		margin-bottom: 2rem;
+
+		color: main.$dark-gray;
+
+		font-weight: 600;
+		font-size: 1.1rem;
+	}
+}
+
+.archived-action-items {
+	display: grid;
+	grid-gap: 2rem;
+	grid-template-columns: repeat(auto-fill, 80%);
+	justify-content: center;
+
+	@include main.breakpoint-medium {
+		grid-template-columns: repeat(auto-fill, 350px);
+	}
+
+	@include main.breakpoint-large {
+		grid-gap: 3rem;
+		grid-template-columns: repeat(auto-fill, 350px);
+		justify-content: left;
 	}
 }
 

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.scss
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.scss
@@ -18,7 +18,7 @@
 @use '../../../../Styles/main';
 
 .action-item-archives {
-	max-width: 1162px;
+	max-width: 1146px;
 	margin: 0 auto;
 
 	text-align: center;
@@ -27,21 +27,39 @@
 		text-align: left;
 	}
 
-	.action-item-archives-title {
-		margin-bottom: 0;
+	.action-item-archives-header {
+		display: flex;
+		justify-content: space-between;
 
-		font-weight: 600;
-		font-size: 1.5rem;
-	}
+		.delete-selected-button {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: space-between;
+			width: 4.5rem;
+			height: 4rem;
+			margin: 1.5rem 0;
 
-	.action-item-archives-description {
-		margin-top: 0.5rem;
-		margin-bottom: 2rem;
+			color: main.$red;
+			font-weight: 600;
+		}
 
-		color: main.$dark-gray;
+		.action-item-archives-title {
+			margin-bottom: 0;
 
-		font-weight: 600;
-		font-size: 1.1rem;
+			font-weight: 600;
+			font-size: 1.5rem;
+		}
+
+		.action-item-archives-description {
+			margin-top: 0.5rem;
+			margin-bottom: 2rem;
+
+			color: main.$dark-gray;
+
+			font-weight: 600;
+			font-size: 1.1rem;
+		}
 	}
 
 	.archived-action-items {
@@ -63,11 +81,17 @@
 }
 
 @include main.dark-theme {
-	.action-item-archives-title {
-		color: main.$off-white;
-	}
+	.action-item-archives-header {
+		.delete-selected-button {
+			color: main.$light-red;
+		}
 
-	.action-item-archives-description {
-		color: main.$light-gray;
+		.action-item-archives-title {
+			color: main.$off-white;
+		}
+
+		.action-item-archives-description {
+			color: main.$light-gray;
+		}
 	}
 }

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.scss
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.scss
@@ -31,14 +31,22 @@
 		display: flex;
 		justify-content: space-between;
 
+		.actions-container {
+			display: flex;
+			gap: 1rem;
+			align-items: start;
+			margin: 1.5rem 0;
+		}
+
 		.delete-selected-button {
 			display: flex;
 			flex-direction: column;
 			align-items: center;
 			justify-content: space-between;
+			box-sizing: border-box;
 			width: 4.5rem;
 			height: 4rem;
-			margin: 1.5rem 0;
+			margin-top: 0.5rem;
 
 			color: main.$red;
 			font-weight: 600;

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.spec.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.spec.tsx
@@ -103,8 +103,11 @@ describe('Action Item Archives', () => {
 		);
 	});
 
-	xit('should only show "Delete Selected" button once an action item has been clicked', () => {
-		expect(false).toBeTruthy();
+	it('should only show "Delete Selected" button once an action item has been clicked', async () => {
+		await renderActionItemArchives();
+		expect(screen.queryByText('Delete Selected')).toBeNull();
+		screen.getAllByTestId('checkboxButton')[0].click();
+		expect(screen.getByText('Delete Selected')).toBeDefined();
 	});
 
 	it('should select and open confirmation modal to delete multiple action items at a time', async () => {
@@ -128,7 +131,7 @@ describe('Action Item Archives', () => {
 		);
 	});
 
-	xit('should select and unselect action items and only ask for confirmation to delete selected items', async () => {
+	it('should select and unselect action items and only ask for confirmation to delete selected items', async () => {
 		await renderActionItemArchives();
 
 		const checkboxes = screen.getAllByTestId('checkboxButton');

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.spec.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.spec.tsx
@@ -149,6 +149,27 @@ describe('Action Item Archives', () => {
 			)
 		);
 	});
+
+	it('should select all action items when clicking "Select All"', async () => {
+		await renderActionItemArchives();
+
+		const selectAllCheckbox = screen.getByLabelText('Select All', {
+			selector: 'input',
+		});
+		expect(selectAllCheckbox).toHaveAttribute('data-checked', 'false');
+
+		const checkboxButtons = screen.getAllByTestId('checkboxButton');
+
+		checkboxButtons.forEach((button) => {
+			expect(button).toHaveAttribute('data-checked', 'false');
+		});
+
+		selectAllCheckbox.click();
+		expect(selectAllCheckbox).toHaveAttribute('data-checked', 'true');
+		checkboxButtons.forEach((button) => {
+			expect(button).toHaveAttribute('data-checked', 'true');
+		});
+	});
 });
 
 function getExpectedModalContents(actionItemIds: number[]) {

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
@@ -84,19 +84,21 @@ function ActionItemArchives() {
 							</p>
 						</div>
 						<div>
-							<button
-								className="delete-selected-button"
-								onClick={onDeleteSelectedBtnClick}
-							>
-								<i className="fa fa-trash" aria-hidden="true" />
-								Delete Selected
-							</button>
+							{selectedActionItemIds.length > 0 && (
+								<button
+									className="delete-selected-button"
+									onClick={onDeleteSelectedBtnClick}
+								>
+									<i className="fa fa-trash" aria-hidden="true" />
+									Delete Selected
+								</button>
+							)}
 						</div>
 					</div>
 					<ul className="archived-action-items">
-						{actionItems.map((actionItem, index) => {
+						{actionItems.map((actionItem) => {
 							return (
-								<li key={`archived-action-${index}`}>
+								<li key={`archived-action-${actionItem.id}`}>
 									<ArchivedActionItem
 										actionItem={actionItem}
 										onActionItemDeletion={getActionItems}

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
@@ -90,8 +90,11 @@ function ActionItemArchives() {
 									className="delete-selected-button"
 									onClick={onDeleteSelectedBtnClick}
 								>
-									<i className="fa fa-trash fa-lg" aria-hidden="true" />
-									Delete Selected
+									<i
+										className="fa fa-trash fa-lg trashcan-icon"
+										aria-hidden="true"
+									/>
+									<span className="delete-selected-text">Delete Selected</span>
 								</button>
 							)}
 							<Checkbox

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
@@ -70,6 +70,11 @@ function ActionItemArchives() {
 		});
 	}
 
+	function selectAllActionItems(selectAll: boolean) {
+		const selectedItemIds = selectAll ? actionItems.map((item) => item.id) : [];
+		setSelectedActionItemIds(selectedItemIds);
+	}
+
 	return (
 		<div className="action-item-archives">
 			{actionItems.length ? (
@@ -102,16 +107,18 @@ function ActionItemArchives() {
 								id="select-action-items"
 								value="Select All"
 								label="Select All"
-								onChange={(checked) => console.log('checked', checked)}
+								onChange={selectAllActionItems}
 							/>
 						</div>
 					</div>
 					<ul className="archived-action-items">
 						{actionItems.map((actionItem) => {
+							const isSelected = selectedActionItemIds.includes(actionItem.id);
 							return (
 								<li key={`archived-action-${actionItem.id}`}>
 									<ArchivedActionItem
 										actionItem={actionItem}
+										isSelected={isSelected}
 										onActionItemDeletion={getActionItems}
 										onActionItemCheckboxClick={onActionItemCheckboxClick}
 									/>

--- a/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/ActionItemArchives.tsx
@@ -17,6 +17,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import ArchivedActionItem from 'Common/ArchivedActionItem/ArchivedActionItem';
+import Checkbox from 'Common/Checkbox/Checkbox';
 import NotFoundSection from 'Common/NotFoundSection/NotFoundSection';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import ActionItemService from 'Services/Api/ActionItemService';
@@ -83,16 +84,23 @@ function ActionItemArchives() {
 								retrospectives
 							</p>
 						</div>
-						<div>
+						<div className="actions-container">
 							{selectedActionItemIds.length > 0 && (
 								<button
 									className="delete-selected-button"
 									onClick={onDeleteSelectedBtnClick}
 								>
-									<i className="fa fa-trash" aria-hidden="true" />
+									<i className="fa fa-trash fa-lg" aria-hidden="true" />
 									Delete Selected
 								</button>
 							)}
+							<Checkbox
+								className="select-action-items-checkbox"
+								id="select-action-items"
+								value="Select All"
+								label="Select All"
+								onChange={(checked) => console.log('checked', checked)}
+							/>
 						</div>
 					</div>
 					<ul className="archived-action-items">

--- a/ui/src/App/Team/Archives/ActionItemArchives/DeleteMultipleActionItemsConfirmation/DeleteMultipleActionItemsConfirmation.spec.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/DeleteMultipleActionItemsConfirmation/DeleteMultipleActionItemsConfirmation.spec.tsx
@@ -25,14 +25,14 @@ import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
 import { TeamState } from 'State/TeamState';
 import { RecoilObserver } from 'Utils/RecoilObserver';
 
-import DeleteActionItemConfirmation from './DeleteActionItemConfirmation';
+import DeleteMultipleActionItemsConfirmation from './DeleteMultipleActionItemsConfirmation';
 
 jest.mock('Services/Api/ActionItemService');
 
-describe('Delete Action Item Confirmation', () => {
+describe('Delete Multiple Action Items Confirmation', () => {
 	let modalContent: ModalContents | null;
 	let onActionItemDeletion: jest.Mock<any, any>;
-	const actionItemId: number = 8432;
+	const actionItemIdsToDelete: number[] = [8432, 2343, 2577, 2333];
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -56,25 +56,25 @@ describe('Delete Action Item Confirmation', () => {
 						modalContent = value;
 					}}
 				/>
-				<DeleteActionItemConfirmation
-					actionItemId={actionItemId}
+				<DeleteMultipleActionItemsConfirmation
+					actionItemIds={actionItemIdsToDelete}
 					onActionItemDeletion={onActionItemDeletion}
 				/>
 			</RecoilRoot>
 		);
 	});
 
-	it('should ask user if they want to delete an archived action item', () => {
-		expect(screen.getByText('Delete Action Item?')).toBeInTheDocument();
+	it('should ask user if they want to delete multiple archived action items', () => {
+		expect(screen.getByText('Delete Selected Items?')).toBeInTheDocument();
 	});
 
-	it('should delete action item and close modal', async () => {
+	it('should delete action items and close modal', async () => {
 		userEvent.click(screen.getByText('Yes, Delete'));
 
 		await waitFor(() =>
-			expect(ActionItemService.delete).toHaveBeenCalledWith(
+			expect(ActionItemService.deleteMultiple).toHaveBeenCalledWith(
 				mockTeam.id,
-				actionItemId
+				actionItemIdsToDelete
 			)
 		);
 		expect(onActionItemDeletion).toHaveBeenCalled();
@@ -84,7 +84,7 @@ describe('Delete Action Item Confirmation', () => {
 	it('should cancel deleting of an action item', () => {
 		userEvent.click(screen.getByText('Cancel'));
 
-		expect(ActionItemService.delete).not.toHaveBeenCalled();
+		expect(ActionItemService.deleteMultiple).not.toHaveBeenCalled();
 		expect(onActionItemDeletion).not.toHaveBeenCalled();
 		expect(modalContent).toBe(null);
 	});

--- a/ui/src/App/Team/Archives/ActionItemArchives/DeleteMultipleActionItemsConfirmation/DeleteMultipleActionItemsConfirmation.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/DeleteMultipleActionItemsConfirmation/DeleteMultipleActionItemsConfirmation.tsx
@@ -22,12 +22,12 @@ import { ModalContentsState } from 'State/ModalContentsState';
 import { TeamState } from 'State/TeamState';
 
 interface Props {
-	actionItemId: number;
+	actionItemIds: number[];
 	onActionItemDeletion(): void;
 }
 
-function DeleteActionItemConfirmation(props: Props) {
-	const { actionItemId, onActionItemDeletion } = props;
+function DeleteMultipleActionItemsConfirmation(props: Props) {
+	const { actionItemIds, onActionItemDeletion } = props;
 
 	const team = useRecoilValue(TeamState);
 	const setModalContents = useSetRecoilState(ModalContentsState);
@@ -35,7 +35,7 @@ function DeleteActionItemConfirmation(props: Props) {
 	const closeModal = () => setModalContents(null);
 
 	const onSubmit = () => {
-		ActionItemService.delete(team.id, actionItemId)
+		ActionItemService.deleteMultiple(team.id, actionItemIds)
 			.then(() => {
 				onActionItemDeletion();
 				closeModal();
@@ -45,9 +45,8 @@ function DeleteActionItemConfirmation(props: Props) {
 
 	return (
 		<ConfirmationModal
-			testId="deleteActionItemConfirmation"
-			title="Delete Action Item?"
-			subtitle="Are you sure you want to delete this archived action item? Doing so will permanently remove this data."
+			title="Delete Selected Items?"
+			subtitle="Are you sure you want to delete these selected action items? This will permanently erase this data."
 			onSubmit={onSubmit}
 			onCancel={closeModal}
 			cancelButtonText="Cancel"
@@ -56,4 +55,4 @@ function DeleteActionItemConfirmation(props: Props) {
 	);
 }
 
-export default DeleteActionItemConfirmation;
+export default DeleteMultipleActionItemsConfirmation;

--- a/ui/src/App/Team/Archives/ActionItemArchives/DeleteSingleActionItemConfirmation/DeleteSingleActionItemConfirmation.spec.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/DeleteSingleActionItemConfirmation/DeleteSingleActionItemConfirmation.spec.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RecoilRoot } from 'recoil';
+import { mockTeam } from 'Services/Api/__mocks__/TeamService';
+import ActionItemService from 'Services/Api/ActionItemService';
+import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
+import { TeamState } from 'State/TeamState';
+import { RecoilObserver } from 'Utils/RecoilObserver';
+
+import DeleteSingleActionItemConfirmation from './DeleteSingleActionItemConfirmation';
+
+jest.mock('Services/Api/ActionItemService');
+
+describe('Delete Single Action Item Confirmation', () => {
+	let modalContent: ModalContents | null;
+	let onActionItemDeletion: jest.Mock<any, any>;
+	const actionItemId: number = 8432;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		modalContent = null;
+		onActionItemDeletion = jest.fn();
+
+		render(
+			<RecoilRoot
+				initializeState={({ set }) => {
+					set(TeamState, mockTeam);
+					set(ModalContentsState, {
+						title: 'Title',
+						component: <>component</>,
+					});
+				}}
+			>
+				<RecoilObserver
+					recoilState={ModalContentsState}
+					onChange={(value: ModalContents) => {
+						modalContent = value;
+					}}
+				/>
+				<DeleteSingleActionItemConfirmation
+					actionItemId={actionItemId}
+					onActionItemDeletion={onActionItemDeletion}
+				/>
+			</RecoilRoot>
+		);
+	});
+
+	it('should ask user if they want to delete an archived action item', () => {
+		expect(screen.getByText('Delete Action Item?')).toBeInTheDocument();
+	});
+
+	it('should delete action item and close modal', async () => {
+		userEvent.click(screen.getByText('Yes, Delete'));
+
+		await waitFor(() =>
+			expect(ActionItemService.deleteOne).toHaveBeenCalledWith(
+				mockTeam.id,
+				actionItemId
+			)
+		);
+		expect(onActionItemDeletion).toHaveBeenCalled();
+		expect(modalContent).toBe(null);
+	});
+
+	it('should cancel deleting of an action item', () => {
+		userEvent.click(screen.getByText('Cancel'));
+
+		expect(ActionItemService.deleteOne).not.toHaveBeenCalled();
+		expect(onActionItemDeletion).not.toHaveBeenCalled();
+		expect(modalContent).toBe(null);
+	});
+});

--- a/ui/src/App/Team/Archives/ActionItemArchives/DeleteSingleActionItemConfirmation/DeleteSingleActionItemConfirmation.tsx
+++ b/ui/src/App/Team/Archives/ActionItemArchives/DeleteSingleActionItemConfirmation/DeleteSingleActionItemConfirmation.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import ConfirmationModal from 'Common/ConfirmationModal/ConfirmationModal';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import ActionItemService from 'Services/Api/ActionItemService';
+import { ModalContentsState } from 'State/ModalContentsState';
+import { TeamState } from 'State/TeamState';
+
+interface Props {
+	actionItemId: number;
+	onActionItemDeletion(): void;
+}
+
+function DeleteSingleActionItemConfirmation(props: Props) {
+	const { actionItemId, onActionItemDeletion } = props;
+
+	const team = useRecoilValue(TeamState);
+	const setModalContents = useSetRecoilState(ModalContentsState);
+
+	const closeModal = () => setModalContents(null);
+
+	const onSubmit = () => {
+		ActionItemService.deleteOne(team.id, actionItemId)
+			.then(() => {
+				onActionItemDeletion();
+				closeModal();
+			})
+			.catch(console.error);
+	};
+
+	return (
+		<ConfirmationModal
+			title="Delete Action Item?"
+			subtitle="Are you sure you want to delete this archived action item? Doing so will permanently remove this data."
+			onSubmit={onSubmit}
+			onCancel={closeModal}
+			cancelButtonText="Cancel"
+			submitButtonText="Yes, Delete"
+		/>
+	);
+}
+
+export default DeleteSingleActionItemConfirmation;

--- a/ui/src/App/Team/Retro/ActionItemsColumn/ActionItem/DeleteActionItemView/DeleteActionItemView.spec.tsx
+++ b/ui/src/App/Team/Retro/ActionItemsColumn/ActionItem/DeleteActionItemView/DeleteActionItemView.spec.tsx
@@ -62,21 +62,21 @@ describe('Delete Action Item View', () => {
 		userEvent.type(document.body, '{Escape}');
 
 		expect(mockSetViewState).toHaveBeenCalledWith(ActionItemViewState.DEFAULT);
-		expect(ActionItemService.delete).not.toHaveBeenCalled();
+		expect(ActionItemService.deleteOne).not.toHaveBeenCalled();
 	});
 
 	it('should not delete thought when user cancels deletion', () => {
 		userEvent.click(screen.getByText('Cancel'));
 
 		expect(mockSetViewState).toHaveBeenCalledWith(ActionItemViewState.DEFAULT);
-		expect(ActionItemService.delete).not.toHaveBeenCalled();
+		expect(ActionItemService.deleteOne).not.toHaveBeenCalled();
 	});
 
 	it('should delete thought when user confirms deletion', async () => {
 		userEvent.click(screen.getByText('Yes, Delete'));
 
 		await waitFor(() =>
-			expect(ActionItemService.delete).toHaveBeenCalledWith(
+			expect(ActionItemService.deleteOne).toHaveBeenCalledWith(
 				mockTeam.id,
 				fakeActionItem.id
 			)

--- a/ui/src/App/Team/Retro/ActionItemsColumn/ActionItem/DeleteActionItemView/DeleteActionItemView.tsx
+++ b/ui/src/App/Team/Retro/ActionItemsColumn/ActionItem/DeleteActionItemView/DeleteActionItemView.tsx
@@ -16,12 +16,12 @@
  */
 
 import React from 'react';
+import DeleteColumnItem from 'Common/ColumnItem/DeleteColumnItem/DeleteColumnItem';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
+import ActionItemService from 'Services/Api/ActionItemService';
+import { ModalContentsState } from 'State/ModalContentsState';
+import { TeamState } from 'State/TeamState';
 
-import DeleteColumnItem from '../../../../../../Common/ColumnItem/DeleteColumnItem/DeleteColumnItem';
-import ActionItemService from '../../../../../../Services/Api/ActionItemService';
-import { ModalContentsState } from '../../../../../../State/ModalContentsState';
-import { TeamState } from '../../../../../../State/TeamState';
 import { ActionItemViewState } from '../ActionItem';
 
 interface Props {
@@ -39,7 +39,7 @@ function DeleteActionItemView(props: Props) {
 	const closeModal = () => setModalContents(null);
 
 	const deleteActionItem = () => {
-		ActionItemService.delete(team.id, actionItemId)
+		ActionItemService.deleteOne(team.id, actionItemId)
 			.then(closeModal)
 			.catch(console.error);
 	};

--- a/ui/src/Common/ArchivedActionItem/ArchivedActionItem.spec.tsx
+++ b/ui/src/Common/ArchivedActionItem/ArchivedActionItem.spec.tsx
@@ -74,4 +74,24 @@ describe('Archived Action Item', () => {
 			})
 		);
 	});
+
+	it('should show "Select" and "Unselect" as checkbox tooltip text', () => {
+		renderWithRecoilRoot(
+			<ArchivedActionItem
+				actionItem={actionItem}
+				isSelected={false}
+				onActionItemDeletion={jest.fn()}
+			/>
+		);
+		screen.getByText('Select');
+
+		renderWithRecoilRoot(
+			<ArchivedActionItem
+				actionItem={actionItem}
+				isSelected={true}
+				onActionItemDeletion={jest.fn()}
+			/>
+		);
+		screen.getByText('Unselect');
+	});
 });

--- a/ui/src/Common/ArchivedActionItem/ArchivedActionItem.spec.tsx
+++ b/ui/src/Common/ArchivedActionItem/ArchivedActionItem.spec.tsx
@@ -52,6 +52,7 @@ describe('Archived Action Item', () => {
 				/>
 				<ArchivedActionItem
 					actionItem={actionItem}
+					isSelected={false}
 					onActionItemDeletion={onActionItemDeletion}
 				/>
 			</>,

--- a/ui/src/Common/ArchivedActionItem/ArchivedActionItem.spec.tsx
+++ b/ui/src/Common/ArchivedActionItem/ArchivedActionItem.spec.tsx
@@ -17,7 +17,7 @@
 
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
-import DeleteActionItemConfirmation from 'App/Team/Archives/ActionItemArchives/DeleteActionItemConfirmation/DeleteActionItemConfirmation';
+import DeleteSingleActionItemConfirmation from 'App/Team/Archives/ActionItemArchives/DeleteSingleActionItemConfirmation/DeleteSingleActionItemConfirmation';
 import { getMockActionItem } from 'Services/Api/__mocks__/ActionItemService';
 import { ModalContents, ModalContentsState } from 'State/ModalContentsState';
 import { TeamState } from 'State/TeamState';
@@ -65,7 +65,7 @@ describe('Archived Action Item', () => {
 			expect(modalContent).toEqual({
 				title: 'Delete Action Item?',
 				component: (
-					<DeleteActionItemConfirmation
+					<DeleteSingleActionItemConfirmation
 						actionItemId={actionItem.id}
 						onActionItemDeletion={onActionItemDeletion}
 					/>

--- a/ui/src/Common/ArchivedActionItem/ArchivedActionItem.tsx
+++ b/ui/src/Common/ArchivedActionItem/ArchivedActionItem.tsx
@@ -77,6 +77,7 @@ function ArchivedActionItem(props: Props) {
 				<DeleteButton aria-label="Delete" onClick={deleteActionItem} />
 				<CheckboxButton
 					aria-label="Mark as complete"
+					tooltipText={{ checked: 'Unselect', unchecked: 'Select' }}
 					checked={isChecked}
 					onClick={(checked) => {
 						setIsChecked(checked);

--- a/ui/src/Common/ArchivedActionItem/ArchivedActionItem.tsx
+++ b/ui/src/Common/ArchivedActionItem/ArchivedActionItem.tsx
@@ -15,14 +15,18 @@
  * limitations under the License.
  */
 
-import React from 'react';
-import DeleteActionItemConfirmation from 'App/Team/Archives/ActionItemArchives/DeleteActionItemConfirmation/DeleteActionItemConfirmation';
+import React, { useState } from 'react';
+import DeleteSingleActionItemConfirmation from 'App/Team/Archives/ActionItemArchives/DeleteSingleActionItemConfirmation/DeleteSingleActionItemConfirmation';
 import { useSetRecoilState } from 'recoil';
 import { ModalContentsState } from 'State/ModalContentsState';
 import Action from 'Types/Action';
 
 import AssigneeInput from '../AssigneeInput/AssigneeInput';
-import { ColumnItemButtonGroup, DeleteButton } from '../ColumnItemButtons';
+import {
+	CheckboxButton,
+	ColumnItemButtonGroup,
+	DeleteButton,
+} from '../ColumnItemButtons';
 import { DateCreated } from '../DateCreated/DateCreated';
 
 import './ArchivedActionItem.scss';
@@ -30,18 +34,21 @@ import './ArchivedActionItem.scss';
 interface Props {
 	actionItem: Action;
 	onActionItemDeletion(): void;
+	onActionItemCheckboxClick?(actionItemId: number, isChecked: boolean): void;
 }
 
 function ArchivedActionItem(props: Props) {
-	const { actionItem, onActionItemDeletion } = props;
+	const { actionItem, onActionItemDeletion, onActionItemCheckboxClick } = props;
 
 	const setModalContents = useSetRecoilState(ModalContentsState);
+
+	const [isChecked, setIsChecked] = useState<boolean>(false);
 
 	function deleteActionItem() {
 		setModalContents({
 			title: 'Delete Action Item?',
 			component: (
-				<DeleteActionItemConfirmation
+				<DeleteSingleActionItemConfirmation
 					actionItemId={actionItem.id}
 					onActionItemDeletion={onActionItemDeletion}
 				/>
@@ -58,11 +65,16 @@ function ArchivedActionItem(props: Props) {
 			<ColumnItemButtonGroup>
 				<DateCreated date={actionItem.dateCreated} readOnly />
 				<DeleteButton aria-label="Delete" onClick={deleteActionItem} />
-				{/*<CheckboxButton*/}
-				{/*	aria-label="Mark as complete"*/}
-				{/*	checked={actionItem.completed}*/}
-				{/*	onClick={() => {}}*/}
-				{/*/>*/}
+				<CheckboxButton
+					aria-label="Mark as complete"
+					checked={isChecked}
+					onClick={(checked) => {
+						setIsChecked(checked);
+						if (onActionItemCheckboxClick) {
+							onActionItemCheckboxClick(actionItem.id, checked);
+						}
+					}}
+				/>
 			</ColumnItemButtonGroup>
 		</div>
 	);

--- a/ui/src/Common/ArchivedActionItem/ArchivedActionItem.tsx
+++ b/ui/src/Common/ArchivedActionItem/ArchivedActionItem.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import DeleteSingleActionItemConfirmation from 'App/Team/Archives/ActionItemArchives/DeleteSingleActionItemConfirmation/DeleteSingleActionItemConfirmation';
 import { useSetRecoilState } from 'recoil';
 import { ModalContentsState } from 'State/ModalContentsState';
@@ -33,16 +33,22 @@ import './ArchivedActionItem.scss';
 
 interface Props {
 	actionItem: Action;
+	isSelected: boolean;
 	onActionItemDeletion(): void;
 	onActionItemCheckboxClick?(actionItemId: number, isChecked: boolean): void;
 }
 
 function ArchivedActionItem(props: Props) {
-	const { actionItem, onActionItemDeletion, onActionItemCheckboxClick } = props;
+	const {
+		actionItem,
+		isSelected = false,
+		onActionItemDeletion,
+		onActionItemCheckboxClick,
+	} = props;
 
 	const setModalContents = useSetRecoilState(ModalContentsState);
 
-	const [isChecked, setIsChecked] = useState<boolean>(false);
+	const [isChecked, setIsChecked] = useState<boolean>(isSelected);
 
 	function deleteActionItem() {
 		setModalContents({
@@ -55,6 +61,10 @@ function ArchivedActionItem(props: Props) {
 			),
 		});
 	}
+
+	useEffect(() => {
+		setIsChecked(isSelected);
+	}, [isSelected]);
 
 	return (
 		<div className="archived-action-item">

--- a/ui/src/Common/Checkbox/Checkbox.scss
+++ b/ui/src/Common/Checkbox/Checkbox.scss
@@ -23,11 +23,20 @@
 	align-items: center;
 	justify-content: space-between;
 
-	font-weight: 600;
-
 	cursor: pointer;
 
 	position: relative;
+
+	&:focus,
+	&:hover {
+		color: main.$teal;
+	}
+
+	.label-text {
+		font-weight: 600;
+		font-size: 0.625rem;
+		line-height: 0.75rem;
+	}
 
 	.checkbox-icon {
 		width: 1.25rem;
@@ -49,5 +58,16 @@
 		position: absolute;
 		top: 0;
 		left: 30%;
+	}
+}
+
+@include main.dark-theme {
+	.checkbox-container {
+		color: main.$off-white;
+
+		&:focus,
+		&:hover {
+			color: main.$sea-foam;
+		}
 	}
 }

--- a/ui/src/Common/Checkbox/Checkbox.scss
+++ b/ui/src/Common/Checkbox/Checkbox.scss
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use '../../Styles/main';
+
+.checkbox-container {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: space-between;
+
+	font-weight: 600;
+
+	cursor: pointer;
+
+	position: relative;
+
+	.checkbox-icon {
+		width: 1.25rem;
+		height: 1.25rem;
+	}
+
+	> * {
+		cursor: pointer;
+	}
+
+	.checkbox-input {
+		width: 1.25rem;
+		height: 1.25rem;
+		overflow: hidden;
+
+		clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+		clip: rect(1px, 1px, 1px, 1px);
+
+		position: absolute;
+		top: 0;
+		left: 30%;
+	}
+}

--- a/ui/src/Common/Checkbox/Checkbox.spec.tsx
+++ b/ui/src/Common/Checkbox/Checkbox.spec.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import Checkbox from './Checkbox';
+
+describe('Checkbox', () => {
+	it('should render without axe errors', async () => {
+		const { container } = render(
+			<Checkbox id="1" label="Label" value="1" onChange={jest.fn()} />
+		);
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
+
+	it('should mark checkbox as checked and change icon', async () => {
+		render(<Checkbox id="1" label="Label" value="1" onChange={jest.fn()} />);
+
+		const checkbox = getCheckbox();
+		expect(checkbox).toHaveAttribute('data-checked', 'false');
+
+		const checkboxIcon = screen.getByTestId('checkboxIcon');
+		expect(checkboxIcon).toHaveClass('fa-square');
+		expect(checkboxIcon).not.toHaveClass('fa-square-check');
+
+		checkbox.click();
+
+		expect(checkbox).toHaveAttribute('data-checked', 'true');
+		expect(checkboxIcon).toHaveClass('fa-square-check');
+		expect(checkboxIcon).not.toHaveClass('fa-square');
+	});
+
+	it('should call onChange callback when checkbox is clicked', () => {
+		const onChange = jest.fn();
+		render(<Checkbox id="1" label="Label" value="1" onChange={onChange} />);
+		const checkbox = getCheckbox();
+
+		checkbox.click();
+		expect(onChange).toHaveBeenCalledWith(true);
+		checkbox.click();
+		expect(onChange).toHaveBeenCalledWith(false);
+		checkbox.click();
+		expect(onChange).toHaveBeenCalledWith(true);
+	});
+});
+
+function getCheckbox() {
+	return screen.getByLabelText('Label', { selector: 'input' });
+}

--- a/ui/src/Common/Checkbox/Checkbox.tsx
+++ b/ui/src/Common/Checkbox/Checkbox.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import classNames from 'classnames';
 
 import './Checkbox.scss';
@@ -32,9 +32,15 @@ function Checkbox(props: Props) {
 	const { id, label, value, className, onChange } = props;
 	const [isChecked, setIsChecked] = useState<boolean>(false);
 
+	function onCheckboxClick(event: ChangeEvent<HTMLInputElement>) {
+		const { checked } = event.target;
+		setIsChecked(checked);
+		onChange(checked);
+	}
+
 	return (
 		<label htmlFor={id} className={classNames('checkbox-container', className)}>
-			<div>
+			<span>
 				{isChecked ? (
 					<i
 						className="fa-solid fa-lg fa-square-check checkbox-icon"
@@ -54,14 +60,10 @@ function Checkbox(props: Props) {
 					data-checked={isChecked}
 					type="checkbox"
 					value={value}
-					onChange={(event) => {
-						const { checked } = event.target;
-						setIsChecked(checked);
-						onChange(checked);
-					}}
+					onChange={onCheckboxClick}
 				/>
-			</div>
-			{label}
+			</span>
+			<span className="label-text">{label}</span>
 		</label>
 	);
 }

--- a/ui/src/Common/Checkbox/Checkbox.tsx
+++ b/ui/src/Common/Checkbox/Checkbox.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+import classNames from 'classnames';
+
+import './Checkbox.scss';
+
+interface Props {
+	id: string;
+	label: string;
+	value: string;
+	className?: string;
+	onChange(checked: boolean): void;
+}
+
+function Checkbox(props: Props) {
+	const { id, label, value, className, onChange } = props;
+	const [isChecked, setIsChecked] = useState<boolean>(false);
+
+	return (
+		<label htmlFor={id} className={classNames('checkbox-container', className)}>
+			<div>
+				{isChecked ? (
+					<i
+						className="fa-solid fa-lg fa-square-check checkbox-icon"
+						aria-hidden="true"
+						data-testid="checkboxIcon"
+					/>
+				) : (
+					<i
+						className="fa-regular fa-lg fa-square checkbox-icon"
+						aria-hidden="true"
+						data-testid="checkboxIcon"
+					/>
+				)}
+				<input
+					id={id}
+					className="checkbox-input"
+					data-checked={isChecked}
+					type="checkbox"
+					value={value}
+					onChange={(event) => {
+						const { checked } = event.target;
+						setIsChecked(checked);
+						onChange(checked);
+					}}
+				/>
+			</div>
+			{label}
+		</label>
+	);
+}
+
+export default Checkbox;

--- a/ui/src/Common/ColumnItemButtons/CheckboxButton/CheckboxButton.spec.tsx
+++ b/ui/src/Common/ColumnItemButtons/CheckboxButton/CheckboxButton.spec.tsx
@@ -37,12 +37,33 @@ describe('Checkbox Button', () => {
 		screen.getByTestId('checkmark');
 	});
 
-	it('should have tooltips', () => {
+	it('should show "Close" tooltip when checkbox is not checked', () => {
 		render(<CheckboxButton checked={false} onClick={jest.fn()} />);
 		screen.getByText('Close');
+	});
 
+	it('should show "Close" tooltip when checkbox is checked', () => {
 		render(<CheckboxButton checked={true} onClick={jest.fn()} />);
 		screen.getByText('Open');
+	});
+
+	it('should show custom tooltip text if prop is provided', () => {
+		render(
+			<CheckboxButton
+				tooltipText={{ checked: 'Unselect', unchecked: 'Select' }}
+				checked={true}
+				onClick={jest.fn()}
+			/>
+		);
+		screen.getByText('Unselect');
+		render(
+			<CheckboxButton
+				tooltipText={{ checked: 'Unselect', unchecked: 'Select' }}
+				checked={false}
+				onClick={jest.fn()}
+			/>
+		);
+		screen.getByText('Select');
 	});
 
 	it('should not have tooltips', () => {

--- a/ui/src/Common/ColumnItemButtons/CheckboxButton/CheckboxButton.spec.tsx
+++ b/ui/src/Common/ColumnItemButtons/CheckboxButton/CheckboxButton.spec.tsx
@@ -24,32 +24,36 @@ describe('Checkbox Button', () => {
 	const mockCheck = jest.fn();
 
 	it('should display not display checkmark when not checked', () => {
-		render(<CheckboxButton checked={false} />);
+		render(<CheckboxButton checked={false} onClick={jest.fn()} />);
 
 		screen.getByTestId('checkbox');
 		expect(screen.queryByTestId('checkmark')).toBeFalsy();
 	});
 
 	it('should display display checkmark when checked', () => {
-		render(<CheckboxButton checked={true} />);
+		render(<CheckboxButton checked={true} onClick={jest.fn()} />);
 
 		screen.getByTestId('checkbox');
 		screen.getByTestId('checkmark');
 	});
 
 	it('should have tooltips', () => {
-		render(<CheckboxButton checked={false} />);
+		render(<CheckboxButton checked={false} onClick={jest.fn()} />);
 		screen.getByText('Close');
 
-		render(<CheckboxButton checked={true} />);
+		render(<CheckboxButton checked={true} onClick={jest.fn()} />);
 		screen.getByText('Open');
 	});
 
 	it('should not have tooltips', () => {
-		render(<CheckboxButton checked={false} disableTooltips />);
+		render(
+			<CheckboxButton checked={false} onClick={jest.fn()} disableTooltips />
+		);
 		expect(screen.queryByText('Close')).toBeNull();
 
-		render(<CheckboxButton checked={true} disableTooltips />);
+		render(
+			<CheckboxButton checked={true} onClick={jest.fn()} disableTooltips />
+		);
 		expect(screen.queryByText('Open')).toBeNull();
 	});
 
@@ -66,10 +70,17 @@ describe('Checkbox Button', () => {
 			<CheckboxButton checked={false} onClick={mockCheck} disabled={true} />
 		);
 		const checkboxButton = screen.getByTestId('checkboxButton');
-
 		userEvent.click(checkboxButton);
 
 		expect(mockCheck).toHaveBeenCalledTimes(0);
 		expect(checkboxButton.getAttribute('disabled')).not.toBeNull();
+	});
+
+	it('should return new state of checkbox on click', () => {
+		render(<CheckboxButton checked={false} onClick={mockCheck} />);
+
+		const checkboxButton = screen.getByTestId('checkboxButton');
+		userEvent.click(checkboxButton);
+		expect(mockCheck).toHaveBeenCalledWith(true);
 	});
 });

--- a/ui/src/Common/ColumnItemButtons/CheckboxButton/CheckboxButton.tsx
+++ b/ui/src/Common/ColumnItemButtons/CheckboxButton/CheckboxButton.tsx
@@ -15,27 +15,32 @@
  * limitations under the License.
  */
 
-import React, { ComponentPropsWithoutRef, forwardRef, LegacyRef } from 'react';
+import React, { forwardRef, LegacyRef } from 'react';
 import classnames from 'classnames';
 import Tooltip from 'Common/Tooltip/Tooltip';
 
 import './CheckboxButton.scss';
 
-interface CheckmarkButtonProps extends ComponentPropsWithoutRef<'button'> {
+interface CheckmarkButtonProps {
 	checked: boolean;
 	disableTooltips?: boolean;
+	className?: string;
+	disabled?: boolean;
+	onClick(checked: boolean): void;
 }
 
 const CheckboxButton = forwardRef(
 	(props: CheckmarkButtonProps, ref: LegacyRef<HTMLButtonElement>) => {
-		const { checked, className, disableTooltips, ...buttonProps } = props;
+		const { checked, className, disableTooltips, onClick, disabled } = props;
 
 		return (
 			<button
 				className={classnames('column-item-button', className)}
-				{...buttonProps}
 				ref={ref}
 				data-testid="checkboxButton"
+				data-checked={checked}
+				disabled={disabled}
+				onClick={() => onClick(!checked)}
 			>
 				<div className={classnames('checkbox', { checked })}>
 					<div className="checkbox-border" data-testid="checkbox" />

--- a/ui/src/Common/ColumnItemButtons/CheckboxButton/CheckboxButton.tsx
+++ b/ui/src/Common/ColumnItemButtons/CheckboxButton/CheckboxButton.tsx
@@ -27,11 +27,22 @@ interface CheckmarkButtonProps {
 	className?: string;
 	disabled?: boolean;
 	onClick(checked: boolean): void;
+	tooltipText?: {
+		checked: string;
+		unchecked: string;
+	};
 }
 
 const CheckboxButton = forwardRef(
 	(props: CheckmarkButtonProps, ref: LegacyRef<HTMLButtonElement>) => {
-		const { checked, className, disableTooltips, onClick, disabled } = props;
+		const {
+			checked,
+			className,
+			disableTooltips,
+			onClick,
+			disabled,
+			tooltipText = { checked: 'Open', unchecked: 'Close' },
+		} = props;
 
 		return (
 			<button
@@ -52,7 +63,11 @@ const CheckboxButton = forwardRef(
 						/>
 					)}
 				</div>
-				{!disableTooltips && <Tooltip>{checked ? 'Open' : 'Close'}</Tooltip>}
+				{!disableTooltips && (
+					<Tooltip>
+						{checked ? tooltipText.checked : tooltipText.unchecked}
+					</Tooltip>
+				)}
 			</button>
 		);
 	}

--- a/ui/src/Services/Api/ActionItemService.spec.ts
+++ b/ui/src/Services/Api/ActionItemService.spec.ts
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 
+import { mockGetCookie } from '__mocks__/universal-cookie';
 import axios from 'axios';
 import moment from 'moment';
-
-import { mockGetCookie } from '../../__mocks__/universal-cookie';
-import Action from '../../Types/Action';
-import CreateActionItemRequest from '../../Types/CreateActionItemRequest';
+import Action from 'Types/Action';
+import CreateActionItemRequest from 'Types/CreateActionItemRequest';
 
 import { getMockActionItem } from './__mocks__/ActionItemService';
 import ActionItemService from './ActionItemService';
@@ -96,10 +95,22 @@ describe('Action Item Service', () => {
 		});
 	});
 
-	describe('delete', () => {
+	describe('deleteOne', () => {
 		it('should delete an action item', async () => {
-			await ActionItemService.delete(teamId, actionItemId);
+			await ActionItemService.deleteOne(teamId, actionItemId);
 			expect(axios.delete).toHaveBeenCalledWith(actionItemByIdUrl, mockConfig);
+		});
+	});
+
+	describe('deleteMultiple', () => {
+		it('should delete an action item', async () => {
+			const actionItemIds = [7, 4, 5];
+			await ActionItemService.deleteMultiple(teamId, actionItemIds);
+			const configWithData = { ...mockConfig, data: { actionItemIds } };
+			expect(axios.delete).toHaveBeenCalledWith(
+				allActionItemsUrl,
+				configWithData
+			);
 		});
 	});
 

--- a/ui/src/Services/Api/ActionItemService.ts
+++ b/ui/src/Services/Api/ActionItemService.ts
@@ -17,15 +17,16 @@
 
 import axios from 'axios';
 import moment from 'moment';
+import Action from 'Types/Action';
+import CreateActionItemRequest from 'Types/CreateActionItemRequest';
 
-import Action from '../../Types/Action';
-import CreateActionItemRequest from '../../Types/CreateActionItemRequest';
-
-import { getActionItemApiPath } from './ApiConstants';
 import getAuthConfig from './getAuthConfig';
 
 const ASSIGNEE_PARSE_SYMBOL = '@';
 export const ASSIGNEE_PARSE_REGEX = /(@[a-zA-Z0-9]+\b)/g;
+
+const getActionItemApiPath = (teamId: string) =>
+	`/api/team/${teamId}/action-item`;
 
 const ActionItemService = {
 	get(teamId: string, archived: boolean): Promise<Action[]> {
@@ -54,9 +55,15 @@ const ActionItemService = {
 			.then((response) => response.data);
 	},
 
-	delete(teamId: string, actionItemId: number): Promise<void> {
+	deleteOne(teamId: string, actionItemId: number): Promise<void> {
 		const url = `${getActionItemApiPath(teamId)}/${actionItemId}`;
 		return axios.delete(url, getAuthConfig());
+	},
+
+	deleteMultiple(teamId: string, actionItemIds: number[]) {
+		const url = getActionItemApiPath(teamId);
+		const configWithData = { ...getAuthConfig(), data: { actionItemIds } };
+		return axios.delete(url, configWithData);
 	},
 
 	updateTask(

--- a/ui/src/Services/Api/ApiConstants.ts
+++ b/ui/src/Services/Api/ApiConstants.ts
@@ -27,9 +27,5 @@ export const getCSVApiPath = (teamId: string) => `/api/team/${teamId}/csv`;
 
 export const getThoughtApiPath = (teamId: string) =>
 	`/api/team/${teamId}/thought`;
-
-export const getActionItemApiPath = (teamId: string) =>
-	`/api/team/${teamId}/action-item`;
-
 export const getArchiveRetroApiPath = (teamId: string) =>
 	`/api/team/${teamId}/end-retro`;

--- a/ui/src/Services/Api/BoardService.ts
+++ b/ui/src/Services/Api/BoardService.ts
@@ -65,7 +65,9 @@ const BoardService = {
 		return axios.get(url, getAuthConfig()).then((response) => {
 			return {
 				boards: response.data,
-				paginationData: getPaginatedDataFromHeaders(response.headers),
+				paginationData: getPaginatedDataFromHeaders(
+					response.headers as AxiosResponseHeaders
+				),
 			};
 		});
 	},
@@ -89,10 +91,10 @@ function getPaginatedDataFromHeaders(
 	return {
 		sortBy: headers['sort-by'] as SortByType,
 		sortOrder: headers['sort-order'] as SortOrder,
-		pageIndex: parseInt(headers['page-index'], 10),
-		pageSize: parseInt(headers['page-size'], 10),
-		pageRange: headers['page-range'],
-		totalBoardCount: parseInt(headers['total-board-count'], 10),
-		totalPages: parseInt(headers['total-pages'], 10),
+		pageIndex: parseInt(headers['page-index']!, 10),
+		pageSize: parseInt(headers['page-size']!, 10),
+		pageRange: headers['page-range']!,
+		totalBoardCount: parseInt(headers['total-board-count']!, 10),
+		totalPages: parseInt(headers['total-pages']!, 10),
 	};
 }

--- a/ui/src/Services/Api/TeamService.ts
+++ b/ui/src/Services/Api/TeamService.ts
@@ -44,7 +44,7 @@ const FORBIDDEN_STATUS = 403;
 
 const returnTokenAndTeamId = (response: AxiosResponse): AuthResponse => ({
 	token: response.data,
-	teamId: response.headers.location,
+	teamId: response.headers.location || '',
 });
 
 const TeamService = {

--- a/ui/src/Services/Api/__mocks__/ActionItemService.ts
+++ b/ui/src/Services/Api/__mocks__/ActionItemService.ts
@@ -32,7 +32,8 @@ export const getMockActionItem = (
 const ActionItemService = {
 	get: jest.fn().mockResolvedValue([]),
 	create: jest.fn().mockResolvedValue((action: Action) => action),
-	delete: jest.fn().mockResolvedValue(null),
+	deleteOne: jest.fn().mockResolvedValue(null),
+	deleteMultiple: jest.fn().mockResolvedValue(null),
 	updateTask: jest.fn().mockResolvedValue(null),
 	updateAssignee: jest.fn().mockResolvedValue(null),
 	updateCompletionStatus: jest.fn().mockResolvedValue(null),


### PR DESCRIPTION
## Overview
This PR adds the ability to delete more than one archived action item at a time. You can manually select the ones you wish to delete, or you can select all and delete.

### Demo
<img width="1687" alt="Screen Shot 2022-11-03 at 11 42 57 AM" src="https://user-images.githubusercontent.com/17144844/199767265-9a2ab669-250b-4979-822d-787c79ebae3c.png">

## Testing Instructions
1) Create and close a bunch of action items. Archive that board.
2) Go to the action items archive page.
3) Ensure there is no "Delete selected" button yet, but that you can now see checkboxes on each card, and a "Select All" checkbox at the top.
3) Click the checkbox on a couple different action items. Ensure a "Delete Selected" button pops up at the top.
4) Click the "Delete Selected" button. A modal should pop up. Ensure clicking cancel closes the modal. Ensure clicking, "Yes, Delete" deletes the selected action items.
5) Click the "Select All" checkbox. Ensure all get selected. 
6) Click the "Delete Selected" button again and confirm. Ensure all items got deleted.