### PR TITLE
Only save cypress screenshots on test failure

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -98,5 +98,5 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: cypress
-          path: /home/runner/work/retroquest/retroquest/ui/cypress/
+          name: cypress-artifacts
+          path: /home/runner/work/retroquest/retroquest/ui/cypress/artifacts

--- a/ui/cypress.config.ts
+++ b/ui/cypress.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	downloadsFolder: 'cypress/downloads',
 	screenshotsFolder: 'cypress/artifacts/screenshots',
 	videosFolder: 'cypress/artifacts/videos',
+	videoUploadOnPasses: false,
 	chromeWebSecurity: false,
 	e2e: {
 		baseUrl: 'http://localhost:3000',

--- a/ui/cypress.config.ts
+++ b/ui/cypress.config.ts
@@ -3,8 +3,7 @@ import { defineConfig } from 'cypress';
 export default defineConfig({
 	downloadsFolder: 'cypress/downloads',
 	screenshotsFolder: 'cypress/artifacts/screenshots',
-	videosFolder: 'cypress/artifacts/videos',
-	videoUploadOnPasses: false,
+	video: false,
 	chromeWebSecurity: false,
 	e2e: {
 		baseUrl: 'http://localhost:3000',

--- a/ui/cypress.config.ts
+++ b/ui/cypress.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
 	downloadsFolder: 'cypress/downloads',
+	screenshotsFolder: 'cypress/artifacts/screenshots',
+	videosFolder: 'cypress/artifacts/videos',
 	chromeWebSecurity: false,
 	e2e: {
 		baseUrl: 'http://localhost:3000',

--- a/ui/cypress/.gitignore
+++ b/ui/cypress/.gitignore
@@ -1,5 +1,6 @@
 # You can ignore outputs of e2e test runs https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Folder-Structure
 screenshots/**
 videos/**
+artifacts/**
 fixtures/example.json
 downloads/**

--- a/ui/cypress/e2e/login.cy.ts
+++ b/ui/cypress/e2e/login.cy.ts
@@ -55,7 +55,7 @@ describe('Login', () => {
 
 	it('Pre-populates team name', () => {
 		cy.get('[data-testid=teamNameInput]').as('teamNameInput');
-		cy.get('@teamNameInput').should('have.value', '');
+		cy.get('@teamNameInput').should('have.value', 'sdf');
 
 		cy.visit(`${LOGIN_PAGE_PATH}/${teamCredentials.teamId}`);
 

--- a/ui/cypress/e2e/login.cy.ts
+++ b/ui/cypress/e2e/login.cy.ts
@@ -55,7 +55,7 @@ describe('Login', () => {
 
 	it('Pre-populates team name', () => {
 		cy.get('[data-testid=teamNameInput]').as('teamNameInput');
-		cy.get('@teamNameInput').should('have.value', 'sdf');
+		cy.get('@teamNameInput').should('have.value', '');
 
 		cy.visit(`${LOGIN_PAGE_PATH}/${teamCredentials.teamId}`);
 


### PR DESCRIPTION
## Overview
Right now, when a cypress test fails, the ENTIRE cypress folder is being saved as a github artifact so that anyone can see the failed video and screenshots for the failed test. This updates it so that only the snapshots are saved, not the entire cypress folder. Saving videos has also been turned off, as the videos stop recording before it shows anything helpful.

## Testing Instructions
Ensure only the failed snapshots get saved as artifacts when a cypress test fails.