### PR TITLE
Update github actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,18 +9,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: use node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
       - name: cache gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -39,7 +39,7 @@ jobs:
       - name: build application JAR
         run: ./gradlew assemble withPostgres
       - name: release artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: retroquest
           path: api/build/libs/retroquest.jar

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,11 +15,11 @@ jobs:
       run:
         working-directory: ui
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: use node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.x'
       - name: install dependencies
@@ -33,16 +33,16 @@ jobs:
   api-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
       - name: cache gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -64,18 +64,18 @@ jobs:
   e2e-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
       - name: cache gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -96,7 +96,7 @@ jobs:
         working-directory: ./ui
       - name: Upload Screenshots
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cypress-artifacts
           path: /home/runner/work/retroquest/retroquest/ui/cypress/artifacts


### PR DESCRIPTION
## Overview
I updated all the github actions to version 3 to clean up the warnings shown below:

<img width="1379" alt="Screen Shot 2022-11-23 at 2 14 10 PM" src="https://user-images.githubusercontent.com/17144844/203629093-e0ab6f45-7b34-4cdf-a4d3-07dd82f6a637.png">


## Testing Instructions
* Ensure all github checks pass correctly with no warnings.
<img width="1366" alt="Screen Shot 2022-11-23 at 2 14 02 PM" src="https://user-images.githubusercontent.com/17144844/203629104-f077f523-081b-45a1-aa0f-ba20351fa800.png">
