### PR TITLE
Manually set app theme and system theme in cypress tests

### DIFF
--- a/ui/cypress/e2e/retro-facilitator-journey.cy.ts
+++ b/ui/cypress/e2e/retro-facilitator-journey.cy.ts
@@ -29,6 +29,8 @@ describe('Retro Facilitator Journey', () => {
 	const editButtonSelector = '[data-testid=editButton]';
 
 	beforeEach(() => {
+		window.localStorage.setItem('theme', 'light-theme');
+
 		teamCredentials = getTeamCredentials();
 	});
 

--- a/ui/cypress/e2e/retro-member-journey.cy.ts
+++ b/ui/cypress/e2e/retro-member-journey.cy.ts
@@ -26,6 +26,8 @@ describe('Retro Member Journey', () => {
 	let teamCredentials;
 
 	beforeEach(() => {
+		window.localStorage.setItem('theme', 'light-theme');
+
 		teamCredentials = getTeamCredentials();
 		cy.createTeamAndLogin(teamCredentials, {
 			onBeforeLoad(win: Cypress.AUTWindow) {
@@ -275,6 +277,8 @@ describe('Retro Member Journey', () => {
 
 			cy.findByText('Styles').as('stylesTab');
 			cy.findByText('Account').as('accountTab');
+
+			setSystemPreferencesToLightMode();
 		});
 
 		it('Styles Tab: Change theme between light, dark, and system settings mode', () => {
@@ -359,4 +363,21 @@ function shouldAddHappyThoughts(happyThoughts: string[]) {
 		cy.findByText(happyThought).should('exist');
 		cy.confirmNumberOfThoughtsInColumn(Topic.HAPPY, index + 1);
 	});
+}
+
+function setSystemPreferencesToLightMode() {
+	cy.wrap(
+		Cypress.automation('remote:debugger:protocol', {
+			command: 'Emulation.setEmulatedMedia',
+			params: {
+				media: 'page',
+				features: [
+					{
+						name: 'prefers-color-scheme',
+						value: 'light',
+					},
+				],
+			},
+		})
+	);
 }


### PR DESCRIPTION
## Overview
Set app theme and system theme in cypress tests so that the cypress tests are not reliant on the developers system preferences being in light mode

## Testing Instructions
Ensure the cypress tests all pass whether your computer's system preferences are in dark mode or light mode.