### PR TITLE
Move error messages from status 'reason' to response body as per HTTP…

### DIFF
--- a/api/src/main/java/com/ford/labs/retroquest/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/ford/labs/retroquest/exception/GlobalExceptionHandler.java
@@ -22,87 +22,100 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @ControllerAdvice
+@ResponseBody
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
-    @ResponseStatus(value = HttpStatus.CONFLICT, reason = "This team name is already in use. Please try another one.")
+    private static class ErrorDetails{
+        private final String reason;
+        public ErrorDetails(String reasonForError){
+            this.reason = reasonForError;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+    }
+
+    @ResponseStatus(value = HttpStatus.CONFLICT)
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public void duplicateUriConflict() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails duplicateUriConflict() {
+        return new ErrorDetails("This team name is already in use. Please try another one.");
     }
 
-    @ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Column Title with that ID not found")
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
     @ExceptionHandler(ColumnNotFoundException.class)
-    public void columnNotFound() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails columnNotFound() {
+        return new ErrorDetails("Column Title with that ID not found");
     }
 
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Please enter a team name without any special characters.")
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     @ExceptionHandler(SpecialCharacterTeamNameException.class)
-    public void badTeamNameWithSpecialCharactersRequest() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails badTeamNameWithSpecialCharactersRequest() {
+        return new ErrorDetails("Please enter a team name without any special characters.");
     }
 
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Please enter a team name.")
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     @ExceptionHandler(EmptyTeamNameException.class)
-    public void emptyTeamNameRequest() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails emptyTeamNameRequest() {
+        return new ErrorDetails("Please enter a team name.");
     }
 
-    @ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "Incorrect team name or password. Please try again.")
+    @ResponseStatus(value = HttpStatus.FORBIDDEN)
     @ExceptionHandler(TeamDoesNotExistException.class)
-    public void noTeamExceptionHandler() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails noTeamExceptionHandler() {
+        return new ErrorDetails("Incorrect team name or password. Please try again.");
     }
 
-    @ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "Incorrect team name or password. Please try again.")
+    @ResponseStatus(value = HttpStatus.FORBIDDEN)
     @ExceptionHandler(PasswordInvalidException.class)
-    public void badPasswordExceptionHandler() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails badPasswordExceptionHandler() {
+        return new ErrorDetails("Incorrect team name or password. Please try again.");
     }
 
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Reset token incorrect or expired.")
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     @ExceptionHandler(BadResetTokenException.class)
-    public void badPasswordResetTokenExceptionHandler() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails badPasswordResetTokenExceptionHandler() {
+        return new ErrorDetails("Reset token incorrect or expired.");
     }
 
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Password must be 8 characters or longer.")
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     @ExceptionHandler(PasswordTooShortException.class)
-    public void passwordTooShortExceptionHandler() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails passwordTooShortExceptionHandler() {
+        return new ErrorDetails("Password must be 8 characters or longer.");
     }
 
     @ExceptionHandler(EmailNotValidException.class)
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Team email is required.")
-    public void emailRequiredExceptionHandler() {
-        // Used by Spring for Controller Advice
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    public ErrorDetails emailRequiredExceptionHandler() {
+        return new ErrorDetails("Team email is required.");
     }
 
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Password must contain at least one numeric character.")
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     @ExceptionHandler(PasswordMissingNumberException.class)
-    public void passwordMissingNumberExceptionHandler() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails passwordMissingNumberExceptionHandler() {
+        return new ErrorDetails("Password must contain at least one numeric character.");
     }
 
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Password must contain at least one capital letter.")
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     @ExceptionHandler(PasswordMissingUpperCaseAlphaException.class)
-    public void passwordMissingUpperCaseAlphaExceptionHandler() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails passwordMissingUpperCaseAlphaExceptionHandler() {
+        return new ErrorDetails("Password must contain at least one capital letter.");
     }
 
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Password must contain at least one lower case letter.")
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     @ExceptionHandler(PasswordMissingLowerCaseAlphaException.class)
-    public void passwordMissingLowerCaseAlphaExceptionHandler() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails passwordMissingLowerCaseAlphaExceptionHandler() {
+        return new ErrorDetails("Password must contain at least one lower case letter.");
     }
 
     @ExceptionHandler(EmailNotAssociatedWithAnyTeamsException.class)
-    @ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "This email is not associated with any RetroQuest team.")
-    public void emailNotAssociatedWithAnyTeamsExceptionHandler() {
-        // Used by Spring for Controller Advice
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    public ErrorDetails emailNotAssociatedWithAnyTeamsExceptionHandler() {
+        return new ErrorDetails("This email is not associated with any RetroQuest team.");
     }
 
     @ExceptionHandler(ThoughtNotFoundException.class)
@@ -112,7 +125,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ResponseStatus(value = HttpStatus.NOT_FOUND)
     @ExceptionHandler(ActionItemDoesNotExistException.class)
-    public void actionItemDoesNotExistExceptionHandler() {
-        // Used by Spring for Controller Advice
+    public ErrorDetails actionItemDoesNotExistExceptionHandler() {
+        return new ErrorDetails("The requested action item cannot be found.");
     }
 }

--- a/api/src/test/java/com/ford/labs/retroquest/api/EmailApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/EmailApiTest.java
@@ -36,10 +36,12 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Tag("api")
@@ -104,7 +106,8 @@ public class EmailApiTest extends ApiTestBase {
                         .content(objectMapper.writeValueAsBytes(new RecoverTeamNamesRequest(recoveryEmail)))
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(status().reason("This email is not associated with any RetroQuest team."));
+                .andExpect(content().string(containsString("\"reason\":\"This email is not associated with any RetroQuest team.\"")));
+
 
         verify(emailService, never()).sendUnencryptedEmail("RetroQuest Teams Names Associated with your Account", "expectedMessage", recoveryEmail);
     }

--- a/api/src/test/java/com/ford/labs/retroquest/api/EmailResetTokenApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/EmailResetTokenApiTest.java
@@ -33,7 +33,9 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Tag("api")
@@ -135,13 +137,9 @@ class EmailResetTokenApiTest extends ApiTestBase {
 
     @Test
     void get_team_by_email_reset_token__should_throw_error_when_token_does_not_exist() throws Exception {
-        var resultOfGet = mockMvc.perform(get(getTeamByResetTokenPath("non-existant-reset-token")))
+        mockMvc.perform(get(getTeamByResetTokenPath("non-existant-reset-token")))
                 .andExpect(status().isBadRequest())
-                .andExpect(status().reason("Reset token incorrect or expired."))
-                .andReturn();
-
-        String content = resultOfGet.getResponse().getContentAsString();
-        assertThat(content).isEmpty();
+                .andExpect(content().string(containsString("\"reason\":\"Reset token incorrect or expired.\"")));
     }
 
     @Test
@@ -151,13 +149,9 @@ class EmailResetTokenApiTest extends ApiTestBase {
         expiredEmailResetToken.setTeam(team);
         emailResetTokenRepository.save(expiredEmailResetToken);
 
-        var resultOfGet = mockMvc.perform(get(getTeamByResetTokenPath(expiredEmailResetToken.getResetToken())))
+        mockMvc.perform(get(getTeamByResetTokenPath(expiredEmailResetToken.getResetToken())))
                 .andExpect(status().isBadRequest())
-                .andExpect(status().reason("Reset token incorrect or expired."))
-                .andReturn();
-
-        String content = resultOfGet.getResponse().getContentAsString();
-        assertThat(content).isEmpty();
+                .andExpect(content().string(containsString("\"reason\":\"Reset token incorrect or expired.\"")));
     }
 
     private String getIsResetTokenValidPath(EmailResetToken emailResetToken) {

--- a/api/src/test/java/com/ford/labs/retroquest/api/TeamApiTest.java
+++ b/api/src/test/java/com/ford/labs/retroquest/api/TeamApiTest.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Tag("api")
@@ -169,10 +170,11 @@ class TeamApiTest extends ApiTestBase {
 
     @Test
     void should_not_get_team_with_nonexistent_id() throws Exception {
-        mockMvc.perform(get("/api/team/nonExistentTeamId")
+        MvcResult mvcResult = mockMvc.perform(get("/api/team/nonExistentTeamId")
                         .header("Authorization", "Bearer " + jwtBuilder.buildJwt("nonExistentTeamId")))
                 .andExpect(status().isForbidden())
-                .andExpect(status().reason("Incorrect team name or password. Please try again."));
+                .andReturn();
+        mvcResult.getResponse().getContentAsString().contains("\"reason\":\"\"Incorrect team name or password. Please try again.\"\"");
     }
 
     @Test
@@ -257,7 +259,7 @@ class TeamApiTest extends ApiTestBase {
                         )
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(status().reason("Reset token incorrect or expired."));
+                .andExpect(content().string(containsString("\"reason\":\"Reset token incorrect or expired.\"")));
 
         Optional<Team> actualTeam = teamRepository.findTeamByUri("teamuri");
         assertThat(actualTeam.isPresent()).isTrue();
@@ -281,7 +283,7 @@ class TeamApiTest extends ApiTestBase {
                         )
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(status().reason("Reset token incorrect or expired."));
+                .andExpect(content().string(containsString("\"reason\":\"Reset token incorrect or expired.\"")));
 
         Optional<Team> actualTeam = teamRepository.findTeamByUri("teamuri");
         assertThat(actualTeam.isPresent()).isTrue();
@@ -352,7 +354,7 @@ class TeamApiTest extends ApiTestBase {
                         )
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(status().reason("Reset token incorrect or expired."));
+                .andExpect(content().string(containsString("\"reason\":\"Reset token incorrect or expired.\"")));
 
         Optional<Team> actualTeam = teamRepository.findTeamByUri("teamuri");
         assertThat(actualTeam.isPresent()).isTrue();
@@ -376,7 +378,7 @@ class TeamApiTest extends ApiTestBase {
                         )
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(status().reason("Reset token incorrect or expired."));
+                .andExpect(content().string(containsString("\"reason\":\"Reset token incorrect or expired.\"")));
 
         Optional<Team> actualTeam = teamRepository.findTeamByUri("teamuri");
         assertThat(actualTeam.isPresent()).isTrue();
@@ -391,7 +393,7 @@ class TeamApiTest extends ApiTestBase {
         mockMvc.perform(post("/api/team")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(sentCreateTeamRequest)))
-                .andExpect(status().reason(containsString("Team email is required.")))
+                .andExpect(content().string(containsString("\"reason\":\"Team email is required.\"")))
                 .andExpect(status().isBadRequest());
     }
 
@@ -403,7 +405,7 @@ class TeamApiTest extends ApiTestBase {
         mockMvc.perform(post("/api/team")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(sentCreateTeamRequest)))
-                .andExpect(status().reason(containsString("Password must be 8 characters or longer.")))
+                .andExpect(content().string(containsString("\"reason\":\"Password must be 8 characters or longer.\"")))
                 .andExpect(status().isBadRequest());
     }
 
@@ -415,8 +417,7 @@ class TeamApiTest extends ApiTestBase {
         mockMvc.perform(post("/api/team")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(sentCreateTeamRequest)))
-                .andExpect(status()
-                        .reason(containsString("Please enter a team name.")))
+                .andExpect(content().string(containsString("\"reason\":\"Please enter a team name.\"")))
                 .andExpect(status().isBadRequest());
     }
 
@@ -429,7 +430,7 @@ class TeamApiTest extends ApiTestBase {
         mockMvc.perform(post("/api/team")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(sentCreateTeamRequest)))
-                .andExpect(status().reason(containsString("Please enter a team name without any special characters.")))
+                .andExpect(content().string(containsString("\"reason\":\"Please enter a team name without any special characters.\"")))
                 .andExpect(status().isBadRequest());
     }
 
@@ -446,7 +447,7 @@ class TeamApiTest extends ApiTestBase {
         mockMvc.perform(post("/api/team")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(sentCreateTeamRequest)))
-                .andExpect(status().reason(containsString("This team name is already in use. Please try another one.")))
+                .andExpect(content().string(containsString("\"reason\":\"This team name is already in use. Please try another one.\"")))
                 .andExpect(status().isConflict());
     }
 
@@ -466,8 +467,8 @@ class TeamApiTest extends ApiTestBase {
         mockMvc.perform(post("/api/team")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(lowerCaseCreateTeamRequest)))
-                .andExpect(status().reason(containsString("This team name is already in use. Please try another one.")))
-                .andExpect(status().isConflict());
+                .andExpect(status().isConflict())
+                .andExpect(content().string(containsString("\"reason\":\"This team name is already in use. Please try another one.\"")));
     }
 
     @Test
@@ -486,7 +487,7 @@ class TeamApiTest extends ApiTestBase {
         mockMvc.perform(post("/api/team")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(upperCaseCreateTeamRequest)))
-                .andExpect(status().reason(containsString("This team name is already in use. Please try another one.")))
+                .andExpect(content().string(containsString("\"reason\":\"This team name is already in use. Please try another one.\"")))
                 .andExpect(status().isConflict());
     }
 
@@ -506,7 +507,7 @@ class TeamApiTest extends ApiTestBase {
         mockMvc.perform(post("/api/team")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(leadingSpacesRequest)))
-                .andExpect(status().reason(containsString("This team name is already in use. Please try another one.")))
+                .andExpect(content().string(containsString("\"reason\":\"This team name is already in use. Please try another one.\"")))
                 .andExpect(status().isConflict());
     }
 
@@ -526,7 +527,7 @@ class TeamApiTest extends ApiTestBase {
         mockMvc.perform(post("/api/team")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsBytes(trailingSpacesRequest)))
-                .andExpect(status().reason(containsString("This team name is already in use. Please try another one.")))
+                .andExpect(content().string(containsString("\"reason\":\"This team name is already in use. Please try another one.\"")))
                 .andExpect(status().isConflict());
     }
 
@@ -592,7 +593,7 @@ class TeamApiTest extends ApiTestBase {
     void should_not_get_team_name_with_nonexistant_name() throws Exception {
         mockMvc.perform(get("/api/team/nonExistentTeamName/name"))
                 .andExpect(status().isForbidden())
-                .andExpect(status().reason("Incorrect team name or password. Please try again."));
+                .andExpect(content().string(containsString("\"reason\":\"Incorrect team name or password. Please try again.\"")));
     }
 
     @ParameterizedTest
@@ -639,7 +640,7 @@ class TeamApiTest extends ApiTestBase {
                         .content(objectMapper.writeValueAsBytes(loginRequest))
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isForbidden())
-                .andExpect(status().reason("Incorrect team name or password. Please try again."));
+                .andExpect(content().string(containsString("\"reason\":\"Incorrect team name or password. Please try again.\"")));
     }
 
     @Test
@@ -660,7 +661,8 @@ class TeamApiTest extends ApiTestBase {
                         .content(objectMapper.writeValueAsBytes(loginRequest))
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isForbidden())
-                .andExpect(status().reason("Incorrect team name or password. Please try again."));
+                .andExpect(content().string(containsString("\"reason\":\"Incorrect team name or password. Please try again.\"")));
+
     }
 
     @Test
@@ -681,7 +683,7 @@ class TeamApiTest extends ApiTestBase {
                         .content(objectMapper.writeValueAsBytes(loginRequest))
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isForbidden())
-                .andExpect(status().reason("Incorrect team name or password. Please try again."));
+                .andExpect(content().string(containsString("\"reason\":\"Incorrect team name or password. Please try again.\"")));
     }
 
     @Test

--- a/ui/src/App/CreateTeam/CreateTeamPage.tsx
+++ b/ui/src/App/CreateTeam/CreateTeamPage.tsx
@@ -74,7 +74,7 @@ function CreateTeamPage(): JSX.Element {
 				if (response.status === 409) {
 					errorMsg =
 						typeof response !== 'undefined'
-							? response.data.message
+							? response.data.reason
 							: error.message;
 				}
 				setErrorMessages([errorMsg]);

--- a/ui/src/App/CreateTeam/CreateTeamPage.tsx
+++ b/ui/src/App/CreateTeam/CreateTeamPage.tsx
@@ -86,6 +86,26 @@ function CreateTeamPage(): JSX.Element {
 		createTeam();
 	}
 
+	function onTeamNameChange(updatedTeamName: string, validity: boolean) {
+		setTeamName({ value: updatedTeamName, validity: validity });
+		setErrorMessages([]);
+	}
+
+	function onPasswordChange(updatedPassword: string, isValid: boolean) {
+		setPassword({ value: updatedPassword, validity: isValid });
+		setErrorMessages([]);
+	}
+
+	function onPrimaryEmailChange(value: string, validity: boolean) {
+		setEmail({ value: value, validity: validity });
+		setErrorMessages([]);
+	}
+
+	function onSecondaryEmailChange(value: string, validity: boolean) {
+		setSecondEmail({ value: value, validity: validity });
+		setErrorMessages([]);
+	}
+
 	return (
 		<AuthTemplate header="Create a New Team!" className="create-team-page">
 			<Form
@@ -94,41 +114,23 @@ function CreateTeamPage(): JSX.Element {
 				submitButtonText="Create Team"
 				disableSubmitBtn={disableSubmitButton()}
 			>
-				<InputTeamName
-					value={teamName.value}
-					onChange={(updatedTeamName: string, validity: boolean) => {
-						setTeamName({ value: updatedTeamName, validity: validity });
-						setErrorMessages([]);
-					}}
-				/>
+				<InputTeamName value={teamName.value} onChange={onTeamNameChange} />
 				<InputPassword
 					password={password.value}
-					onPasswordInputChange={(
-						updatedPassword: string,
-						isValid: boolean
-					) => {
-						setPassword({ value: updatedPassword, validity: isValid });
-						setErrorMessages([]);
-					}}
+					onPasswordInputChange={onPasswordChange}
 				/>
 				<InputEmail
 					id="emailInput"
 					label="Email"
 					value={email.value}
-					onChange={(value, validity) => {
-						setEmail({ value: value, validity: validity });
-						setErrorMessages([]);
-					}}
+					onChange={onPrimaryEmailChange}
 				/>
 				<InputEmail
 					id="secondEmailInput"
 					label="Second Teammate's Email (optional)"
 					value={secondEmail.value}
 					required={false}
-					onChange={(value, validity) => {
-						setSecondEmail({ value: value, validity: validity });
-						setErrorMessages([]);
-					}}
+					onChange={onSecondaryEmailChange}
 				/>
 			</Form>
 			<HorizontalRuleWithText text="or" />

--- a/ui/src/App/RecoverTeamName/RecoverTeamNamePage.spec.tsx
+++ b/ui/src/App/RecoverTeamName/RecoverTeamNamePage.spec.tsx
@@ -64,7 +64,7 @@ describe('Recover Team Name', () => {
 	it('should show error message if error is returned from the api call', async () => {
 		const expectedErrorMessage = 'errorMessage';
 		EmailService.sendTeamNameRecoveryEmail = jest.fn().mockRejectedValue({
-			response: { data: { message: expectedErrorMessage } },
+			response: { data: { reason: expectedErrorMessage } },
 		});
 
 		await renderRecoverTeamNamesPage();

--- a/ui/src/App/RecoverTeamName/RecoverTeamNamePage.tsx
+++ b/ui/src/App/RecoverTeamName/RecoverTeamNamePage.tsx
@@ -34,7 +34,7 @@ function RecoverTeamNamePage() {
 		EmailService.sendTeamNameRecoveryEmail(recoveryEmail)
 			.then(() => setEmailSent(true))
 			.catch((error) => {
-				setErrorMessages([error.response?.data?.message]);
+				setErrorMessages([error.response?.data?.reason]);
 			});
 	}
 


### PR DESCRIPTION
## Overview
This PR changes the way RetroQuest's API reports errors.

*Previously*, RetroQuest API placed error details in the `reason` field of the HTTP status object transmitted as part of the response to the failed request.  This is off-spec behavior, but more importantly: many browsers and other tools *discard status reasons*, as they are redundant - they should always correspond to the status code.  404 is always "Not Found", 409 is always "Conflict", etc.  These are not meant to change per application!

*After this PR is applied*, RetroQuest will put error messages in the body of the response, under the `reason` field.

## Testing Instructions

* Run the app
* Open your browser's inspector
* Behave badly, i.e. create the same team twice, try to login incorrectly, try to reset password for a nonexistent team, etc.
* Note that the same error messages that used to appear in the UI still do, this should be unchanged
* Note that each failed request in the Inspector now comes with a response body including error message